### PR TITLE
fix: deduplicate intra-day snapshots in computeCategoryChanges

### DIFF
--- a/Sources/Portu/Features/Performance/PerformanceFeature.swift
+++ b/Sources/Portu/Features/Performance/PerformanceFeature.swift
@@ -184,10 +184,27 @@ struct PerformanceFeature {
         let firstDay = cal.startOfDay(for: sorted.first!.timestamp)
         let lastDay = cal.startOfDay(for: sorted.last!.timestamp)
 
+        // Dedup: for each (day, accountId, assetId), keep only the latest timestamp.
+        struct DedupKey: Hashable {
+            let day: Date
+            let accountId: UUID
+            let assetId: UUID
+        }
+        var latest: [DedupKey: CategorySnapshotEntry] = [:]
+        for entry in sorted {
+            let key = DedupKey(
+                day: cal.startOfDay(for: entry.timestamp),
+                accountId: entry.accountId, assetId: entry.assetId)
+            if let existing = latest[key], existing.timestamp >= entry.timestamp {
+                continue
+            }
+            latest[key] = entry
+        }
+
         var startValues: [AssetCategory: Decimal] = [:]
         var endValues: [AssetCategory: Decimal] = [:]
 
-        for entry in sorted {
+        for entry in latest.values {
             let day = cal.startOfDay(for: entry.timestamp)
             if day == firstDay { startValues[entry.category, default: 0] += entry.usdValue }
             if day == lastDay { endValues[entry.category, default: 0] += entry.usdValue }

--- a/Sources/Portu/Features/Performance/PerformanceFeature.swift
+++ b/Sources/Portu/Features/Performance/PerformanceFeature.swift
@@ -99,6 +99,29 @@ struct PerformanceFeature {
 
     // MARK: - Pure Functions
 
+    /// Deduplicate snapshot entries: for each (day, accountId, assetId), keep only the latest timestamp.
+    /// Category is excluded from the key so a mid-day category change doesn't cause double-counting.
+    private static func deduplicateByDayAndAsset(
+        _ entries: [CategorySnapshotEntry]) -> [CategorySnapshotEntry] {
+        let cal = Calendar.current
+        struct DedupKey: Hashable {
+            let day: Date
+            let accountId: UUID
+            let assetId: UUID
+        }
+        var latest: [DedupKey: CategorySnapshotEntry] = [:]
+        for entry in entries {
+            let key = DedupKey(
+                day: cal.startOfDay(for: entry.timestamp),
+                accountId: entry.accountId, assetId: entry.assetId)
+            if let existing = latest[key], existing.timestamp >= entry.timestamp {
+                continue
+            }
+            latest[key] = entry
+        }
+        return Array(latest.values)
+    }
+
     /// Keep only the last value per calendar day, sorted ascending.
     static func lastPerDay(_ values: [(Date, Decimal)]) -> [(Date, Decimal)] {
         let cal = Calendar.current
@@ -137,28 +160,10 @@ struct PerformanceFeature {
     static func aggregateCategorySnapshots(
         entries: [CategorySnapshotEntry]) -> [CategoryChartPoint] {
         let cal = Calendar.current
+        let deduped = deduplicateByDayAndAsset(entries)
 
-        // Step 1: Dedup — for each (day, accountId, assetId), keep the latest timestamp.
-        // Category is excluded from the key so a mid-day category change doesn't cause double-counting.
-        struct DedupKey: Hashable {
-            let day: Date
-            let accountId: UUID
-            let assetId: UUID
-        }
-        var latest: [DedupKey: CategorySnapshotEntry] = [:]
-        for entry in entries {
-            let key = DedupKey(
-                day: cal.startOfDay(for: entry.timestamp),
-                accountId: entry.accountId, assetId: entry.assetId)
-            if let existing = latest[key], existing.timestamp >= entry.timestamp {
-                continue
-            }
-            latest[key] = entry
-        }
-
-        // Step 2: Sum deduped entries by (day, category from latest snapshot).
         var grouped: [Date: [AssetCategory: Decimal]] = [:]
-        for entry in latest.values {
+        for entry in deduped {
             let day = cal.startOfDay(for: entry.timestamp)
             grouped[day, default: [:]][entry.category, default: 0] += entry.usdValue
         }
@@ -183,28 +188,12 @@ struct PerformanceFeature {
         let sorted = entries.sorted { $0.timestamp < $1.timestamp }
         let firstDay = cal.startOfDay(for: sorted.first!.timestamp)
         let lastDay = cal.startOfDay(for: sorted.last!.timestamp)
-
-        // Dedup: for each (day, accountId, assetId), keep only the latest timestamp.
-        struct DedupKey: Hashable {
-            let day: Date
-            let accountId: UUID
-            let assetId: UUID
-        }
-        var latest: [DedupKey: CategorySnapshotEntry] = [:]
-        for entry in sorted {
-            let key = DedupKey(
-                day: cal.startOfDay(for: entry.timestamp),
-                accountId: entry.accountId, assetId: entry.assetId)
-            if let existing = latest[key], existing.timestamp >= entry.timestamp {
-                continue
-            }
-            latest[key] = entry
-        }
+        let deduped = deduplicateByDayAndAsset(sorted)
 
         var startValues: [AssetCategory: Decimal] = [:]
         var endValues: [AssetCategory: Decimal] = [:]
 
-        for entry in latest.values {
+        for entry in deduped {
             let day = cal.startOfDay(for: entry.timestamp)
             if day == firstDay { startValues[entry.category, default: 0] += entry.usdValue }
             if day == lastDay { endValues[entry.category, default: 0] += entry.usdValue }

--- a/Tests/PortuTests/PerformanceFeatureTests.swift
+++ b/Tests/PortuTests/PerformanceFeatureTests.swift
@@ -214,4 +214,30 @@ struct PerformanceCategoryChangeTests {
         let changes = PerformanceFeature.computeCategoryChanges(entries: [])
         #expect(changes.isEmpty)
     }
+
+    @Test func `uses only latest snapshot per asset per day not sum of all syncs`() throws {
+        let cal = Calendar.current
+        let acct = UUID()
+        let btc = UUID()
+
+        let day1Morning = try #require(cal.date(from: DateComponents(year: 2024, month: 1, day: 1, hour: 8)))
+        let day1Evening = try #require(cal.date(from: DateComponents(year: 2024, month: 1, day: 1, hour: 20)))
+        let day2Morning = try #require(cal.date(from: DateComponents(year: 2024, month: 1, day: 2, hour: 8)))
+        let day2Evening = try #require(cal.date(from: DateComponents(year: 2024, month: 1, day: 2, hour: 20)))
+
+        // Two syncs on each day for the same (accountId, assetId)
+        let entries: [CategorySnapshotEntry] = [
+            CategorySnapshotEntry(accountId: acct, assetId: btc, timestamp: day1Morning, category: .major, usdValue: 900),
+            CategorySnapshotEntry(accountId: acct, assetId: btc, timestamp: day1Evening, category: .major, usdValue: 1000),
+            CategorySnapshotEntry(accountId: acct, assetId: btc, timestamp: day2Morning, category: .major, usdValue: 1100),
+            CategorySnapshotEntry(accountId: acct, assetId: btc, timestamp: day2Evening, category: .major, usdValue: 1200)
+        ]
+
+        let changes = PerformanceFeature.computeCategoryChanges(entries: entries)
+
+        let major = changes.first { $0.name == "Major" }
+        // Must use the latest snapshot per (day, accountId, assetId), not sum all syncs
+        #expect(major?.startValue == 1000) // day1Evening only, not 900 + 1000 = 1900
+        #expect(major?.endValue == 1200) // day2Evening only, not 1100 + 1200 = 2300
+    }
 }

--- a/Tests/PortuTests/PerformanceFeatureTests.swift
+++ b/Tests/PortuTests/PerformanceFeatureTests.swift
@@ -239,5 +239,6 @@ struct PerformanceCategoryChangeTests {
         // Must use the latest snapshot per (day, accountId, assetId), not sum all syncs
         #expect(major?.startValue == 1000) // day1Evening only, not 900 + 1000 = 1900
         #expect(major?.endValue == 1200) // day2Evening only, not 1100 + 1200 = 2300
+        #expect(major?.percentChange == Decimal(string: "0.2")!)
     }
 }


### PR DESCRIPTION
## Summary

- `computeCategoryChanges()` had the same intra-day summing bug fixed in #8 for `aggregateCategorySnapshots()` — when multiple syncs happen on the first/last day, all entries were summed rather than deduped, inflating start/end values and distorting percentage changes
- Applied dedup pattern: for each `(day, accountId, assetId)`, keep only the latest timestamp entry before computing start/end category values
- Extracted duplicated dedup logic from both `aggregateCategorySnapshots()` and `computeCategoryChanges()` into a shared `deduplicateByDayAndAsset()` private helper to prevent this bug class from recurring

Closes #22

## Test plan

- [x] Regression test added: "uses only latest snapshot per asset per day not sum of all syncs"
- [x] Full test suite passes (141/141)
- [x] Code review approved — correctness, blast radius, root cause all verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Snapshot processing now uses a single latest entry per calendar day and asset when computing category change aggregates, simplifying and speeding up daily calculations.

* **Tests**
  * Added unit tests confirming category change results derive from the most recent daily snapshot values and yield expected start/end/percent-change outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->