### PR TITLE
fix: persist SyncEngine error states and propagate fetch errors

### DIFF
--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -16,8 +16,8 @@ final class SyncEngine: @unchecked Sendable {
     // MARK: - Public API
 
     func sync() async throws -> SyncResult {
-        let activeSyncable = fetchActiveSyncableAccounts()
-        let activeManual = fetchActiveManualAccounts()
+        let activeSyncable = try fetchActiveSyncableAccounts()
+        let activeManual = try fetchActiveManualAccounts()
 
         guard !activeSyncable.isEmpty || !activeManual.isEmpty else {
             throw SyncError.noActiveAccounts
@@ -38,6 +38,7 @@ final class SyncEngine: @unchecked Sendable {
         // ── Phase B: Snapshot all tiers ──
         let allSyncAttemptedFailed = failedAccounts.count == activeSyncable.count
         if allSyncAttemptedFailed, activeManual.isEmpty, !activeSyncable.isEmpty {
+            try modelContext.save()
             throw SyncError.allAccountsFailed
         }
 
@@ -80,7 +81,7 @@ final class SyncEngine: @unchecked Sendable {
 
             var net: Decimal = 0
             for tokenDTO in dto.tokens {
-                let asset = upsertAsset(from: tokenDTO)
+                let asset = try upsertAsset(from: tokenDTO)
                 let token = PositionToken(
                     role: tokenDTO.role,
                     amount: tokenDTO.amount,
@@ -108,10 +109,10 @@ final class SyncEngine: @unchecked Sendable {
 
     // MARK: - Asset Upsert (3-tier hierarchy)
 
-    func upsertAsset(from dto: TokenDTO) -> Asset {
+    func upsertAsset(from dto: TokenDTO) throws -> Asset {
         // Tier 1: coinGeckoId
         if let cgId = dto.coinGeckoId, !cgId.isEmpty {
-            if let existing = fetchAsset(coinGeckoId: cgId) {
+            if let existing = try fetchAsset(coinGeckoId: cgId) {
                 updateAssetMetadata(existing, from: dto)
                 return existing
             }
@@ -119,7 +120,7 @@ final class SyncEngine: @unchecked Sendable {
 
         // Tier 2: upsertChain + upsertContract
         if let chain = dto.chain, let contract = dto.contractAddress, !contract.isEmpty {
-            if let existing = fetchAsset(chain: chain, contract: contract) {
+            if let existing = try fetchAsset(chain: chain, contract: contract) {
                 updateAssetMetadata(existing, from: dto)
                 return existing
             }
@@ -127,7 +128,7 @@ final class SyncEngine: @unchecked Sendable {
 
         // Tier 3: sourceKey
         if let key = dto.sourceKey, !key.isEmpty {
-            if let existing = fetchAsset(sourceKey: key) {
+            if let existing = try fetchAsset(sourceKey: key) {
                 updateAssetMetadata(existing, from: dto)
                 return existing
             }
@@ -186,7 +187,7 @@ final class SyncEngine: @unchecked Sendable {
             .filter { $0.account?.isActive == true }
 
         createPortfolioSnapshot(batchId: batchId, timestamp: batchTimestamp, positions: allPositions, isPartial: isPartial)
-        createAccountSnapshots(batchId: batchId, timestamp: batchTimestamp)
+        try createAccountSnapshots(batchId: batchId, timestamp: batchTimestamp)
         createAssetSnapshots(batchId: batchId, timestamp: batchTimestamp, positions: allPositions)
 
         pruneSnapshots()
@@ -231,8 +232,8 @@ final class SyncEngine: @unchecked Sendable {
         modelContext.insert(snap)
     }
 
-    private func createAccountSnapshots(batchId: UUID, timestamp: Date) {
-        for account in fetchAllActiveAccounts() {
+    private func createAccountSnapshots(batchId: UUID, timestamp: Date) throws {
+        for account in try fetchAllActiveAccounts() {
             let accountTotal = account.positions.reduce(Decimal.zero) { $0 + $1.netUSDValue }
             let isFresh = account.dataSource == .manual || account.lastSyncError == nil
 
@@ -333,40 +334,34 @@ final class SyncEngine: @unchecked Sendable {
     // SwiftData predicates have limitations with enum comparisons.
     // Use FetchDescriptor without predicate and filter in memory for safety.
 
-    private func fetchActiveSyncableAccounts() -> [Account] {
+    private func fetchActiveSyncableAccounts() throws -> [Account] {
         let descriptor = FetchDescriptor<Account>()
-        let all = (try? modelContext.fetch(descriptor)) ?? []
-        return all.filter { $0.isActive && $0.dataSource != .manual }
+        return try modelContext.fetch(descriptor).filter { $0.isActive && $0.dataSource != .manual }
     }
 
-    private func fetchActiveManualAccounts() -> [Account] {
+    private func fetchActiveManualAccounts() throws -> [Account] {
         let descriptor = FetchDescriptor<Account>()
-        let all = (try? modelContext.fetch(descriptor)) ?? []
-        return all.filter { $0.isActive && $0.dataSource == .manual }
+        return try modelContext.fetch(descriptor).filter { $0.isActive && $0.dataSource == .manual }
     }
 
-    private func fetchAllActiveAccounts() -> [Account] {
+    private func fetchAllActiveAccounts() throws -> [Account] {
         let descriptor = FetchDescriptor<Account>()
-        let all = (try? modelContext.fetch(descriptor)) ?? []
-        return all.filter(\.isActive)
+        return try modelContext.fetch(descriptor).filter(\.isActive)
     }
 
-    private func fetchAsset(coinGeckoId: String) -> Asset? {
+    private func fetchAsset(coinGeckoId: String) throws -> Asset? {
         let descriptor = FetchDescriptor<Asset>()
-        let all = (try? modelContext.fetch(descriptor)) ?? []
-        return all.first { $0.coinGeckoId == coinGeckoId }
+        return try modelContext.fetch(descriptor).first { $0.coinGeckoId == coinGeckoId }
     }
 
-    private func fetchAsset(chain: Chain, contract: String) -> Asset? {
+    private func fetchAsset(chain: Chain, contract: String) throws -> Asset? {
         let descriptor = FetchDescriptor<Asset>()
-        let all = (try? modelContext.fetch(descriptor)) ?? []
-        return all.first { $0.upsertChain == chain && $0.upsertContract == contract }
+        return try modelContext.fetch(descriptor).first { $0.upsertChain == chain && $0.upsertContract == contract }
     }
 
-    private func fetchAsset(sourceKey: String) -> Asset? {
+    private func fetchAsset(sourceKey: String) throws -> Asset? {
         let descriptor = FetchDescriptor<Asset>()
-        let all = (try? modelContext.fetch(descriptor)) ?? []
-        return all.first { $0.sourceKey == sourceKey }
+        return try modelContext.fetch(descriptor).first { $0.sourceKey == sourceKey }
     }
 }
 

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -331,8 +331,9 @@ final class SyncEngine: @unchecked Sendable {
         }
     }
 
-    // SwiftData predicates have limitations with enum comparisons.
-    // Use FetchDescriptor without predicate and filter in memory for safety.
+    // SwiftData predicates have limitations with enum comparisons and optional
+    // properties. Plain Bool predicates (isActive) are safe; enum and Optional<String>
+    // filters use in-memory filtering to avoid runtime crashes.
 
     private func fetchActiveSyncableAccounts() throws -> [Account] {
         let descriptor = FetchDescriptor<Account>()

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -345,8 +345,8 @@ final class SyncEngine: @unchecked Sendable {
     }
 
     private func fetchAllActiveAccounts() throws -> [Account] {
-        let descriptor = FetchDescriptor<Account>()
-        return try modelContext.fetch(descriptor).filter(\.isActive)
+        let descriptor = FetchDescriptor<Account>(predicate: #Predicate { $0.isActive })
+        return try modelContext.fetch(descriptor)
     }
 
     private func fetchAsset(coinGeckoId: String) throws -> Asset? {

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -180,14 +180,15 @@ final class SyncEngine: @unchecked Sendable {
         let batchId = UUID()
         let batchTimestamp = Date.now
 
-        // Query all positions from active accounts — filter in memory to avoid
-        // SwiftData predicate issues with optional chaining
+        // Prefetch all throwing queries before any inserts to avoid staged
+        // orphan snapshots if a fetch fails mid-way.
         let allPositionsDescriptor = FetchDescriptor<Position>()
         let allPositions = try modelContext.fetch(allPositionsDescriptor)
             .filter { $0.account?.isActive == true }
+        let activeAccounts = try fetchAllActiveAccounts()
 
         createPortfolioSnapshot(batchId: batchId, timestamp: batchTimestamp, positions: allPositions, isPartial: isPartial)
-        try createAccountSnapshots(batchId: batchId, timestamp: batchTimestamp)
+        createAccountSnapshots(batchId: batchId, timestamp: batchTimestamp, accounts: activeAccounts)
         createAssetSnapshots(batchId: batchId, timestamp: batchTimestamp, positions: allPositions)
 
         pruneSnapshots()
@@ -232,8 +233,8 @@ final class SyncEngine: @unchecked Sendable {
         modelContext.insert(snap)
     }
 
-    private func createAccountSnapshots(batchId: UUID, timestamp: Date) throws {
-        for account in try fetchAllActiveAccounts() {
+    private func createAccountSnapshots(batchId: UUID, timestamp: Date, accounts: [Account]) {
+        for account in accounts {
             let accountTotal = account.positions.reduce(Decimal.zero) { $0 + $1.netUSDValue }
             let isFresh = account.dataSource == .manual || account.lastSyncError == nil
 

--- a/Tests/PortuTests/SyncEngineTests.swift
+++ b/Tests/PortuTests/SyncEngineTests.swift
@@ -71,8 +71,8 @@ struct SyncEngineTests {
         }
 
         // Verify via fresh context — confirms error state was written to the store.
-        // Bug: save() is never called before the allAccountsFailed throw, so
-        // lastSyncError is nil in the persistent store even though it was set in memory.
+        // Previously, save() was not called before throwing allAccountsFailed, so
+        // lastSyncError remained nil in the persistent store despite being set in memory.
         let freshContext = ModelContext(context.container)
         let accounts = try freshContext.fetch(FetchDescriptor<Account>())
         let fetched = try #require(accounts.first)

--- a/Tests/PortuTests/SyncEngineTests.swift
+++ b/Tests/PortuTests/SyncEngineTests.swift
@@ -51,6 +51,34 @@ struct SyncEngineTests {
         #expect(result.failedAccounts.isEmpty)
     }
 
+    // MARK: - Error Persistence
+
+    /// Regression test for: lastSyncError is set in memory but never saved before
+    /// allAccountsFailed is thrown. A fresh context sees nil instead of the error.
+    @Test func `lastSyncError persisted when all syncable accounts fail`() async throws {
+        let (context, engine) = try makeTestContext()
+
+        // Zapper account with no API key in MockSecretStore → resolveProvider throws missingAPIKey
+        let account = Account(name: "My Wallet", kind: .wallet, dataSource: .zapper)
+        context.insert(account)
+        try context.save()
+
+        do {
+            _ = try await engine.sync()
+            Issue.record("Expected SyncError.allAccountsFailed")
+        } catch let error as SyncError {
+            #expect(error == .allAccountsFailed)
+        }
+
+        // Verify via fresh context — confirms error state was written to the store.
+        // Bug: save() is never called before the allAccountsFailed throw, so
+        // lastSyncError is nil in the persistent store even though it was set in memory.
+        let freshContext = ModelContext(context.container)
+        let accounts = try freshContext.fetch(FetchDescriptor<Account>())
+        let fetched = try #require(accounts.first)
+        #expect(fetched.lastSyncError != nil)
+    }
+
     // MARK: - Upsert Backfill & Dedup
 
     @Test func `backfill sets chain and contract when nil`() throws {

--- a/Tests/PortuTests/SyncEngineTests.swift
+++ b/Tests/PortuTests/SyncEngineTests.swift
@@ -97,7 +97,7 @@ struct SyncEngineTests {
             symbol: "UNI", name: "Uniswap",
             chain: .ethereum, contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
             coinGeckoId: "uniswap")
-        let result = engine.upsertAsset(from: dto)
+        let result = try engine.upsertAsset(from: dto)
 
         // Should reuse existing asset (not create a new one)
         #expect(result.id == asset.id)
@@ -121,7 +121,7 @@ struct SyncEngineTests {
             symbol: "WETH", name: "Wrapped Ether",
             chain: .polygon, contractAddress: "0xdifferent",
             coinGeckoId: "weth")
-        let result = engine.upsertAsset(from: dto)
+        let result = try engine.upsertAsset(from: dto)
 
         #expect(result.id == asset.id)
         // Original values must be preserved (append-only)
@@ -137,13 +137,13 @@ struct SyncEngineTests {
             symbol: "ETH", name: "Ethereum",
             chain: .ethereum, contractAddress: "0xabc",
             coinGeckoId: "ethereum")
-        _ = engine.upsertAsset(from: dtoA)
+        _ = try engine.upsertAsset(from: dtoA)
 
         // DTO-B: same chain/contract, no coinGeckoId
         let dtoB = makeTokenDTO(
             symbol: "ETH", name: "Ethereum",
             chain: .ethereum, contractAddress: "0xabc")
-        _ = engine.upsertAsset(from: dtoB)
+        _ = try engine.upsertAsset(from: dtoB)
 
         let allAssets = try context.fetch(FetchDescriptor<Asset>())
         #expect(allAssets.count == 1)
@@ -156,14 +156,14 @@ struct SyncEngineTests {
         let dtoA = makeTokenDTO(
             symbol: "ETH", name: "Ethereum",
             chain: .ethereum, contractAddress: "0xabc")
-        _ = engine.upsertAsset(from: dtoA)
+        _ = try engine.upsertAsset(from: dtoA)
 
         // DTO-B: same chain/contract + coinGeckoId
         let dtoB = makeTokenDTO(
             symbol: "ETH", name: "Ethereum",
             chain: .ethereum, contractAddress: "0xabc",
             coinGeckoId: "ethereum")
-        _ = engine.upsertAsset(from: dtoB)
+        _ = try engine.upsertAsset(from: dtoB)
 
         let allAssets = try context.fetch(FetchDescriptor<Asset>())
         #expect(allAssets.count == 1)


### PR DESCRIPTION
## Summary

- Save `modelContext` before throwing `allAccountsFailed` so `lastSyncError` survives in the persistent store instead of being discarded with unsaved in-memory state
- Replace `try? modelContext.fetch(...) ?? []` in all 6 fetch helpers with proper error propagation — a corrupted or locked SwiftData store now surfaces errors instead of silently returning empty arrays
- Add regression test verifying error persistence via a fresh `ModelContext` from the same container

## Root Cause

1. `sync()` threw `SyncError.allAccountsFailed` without calling `modelContext.save()` first, discarding `lastSyncError` mutations set during the per-account loop
2. All fetch helpers used `try?` + `?? []`, converting SwiftData persistence errors into "no data found" — making store corruption invisible to users

## Test Plan

- [x] Regression test: "lastSyncError persisted when all syncable accounts fail" — creates Zapper account with no API key, verifies `lastSyncError != nil` via fresh ModelContext after `allAccountsFailed`
- [x] Full test suite: 141/141 tests pass across 33 suites
- [x] Existing `upsertAsset` tests updated for `throws` signature — all pass

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync failures are now reliably recorded and persisted so last-sync errors remain available for diagnosis.
  * Account and asset operations now surface fetch/upsert errors instead of being silently ignored, improving reliability and observability.

* **Tests**
  * Added a regression test verifying sync errors persist when all syncable accounts fail.
  * Updated tests to align with stricter error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->