### PR TITLE
fix: centralize TCA-AppState bridge and disable multi-window

### DIFF
--- a/Sources/Portu/App/AppState.swift
+++ b/Sources/Portu/App/AppState.swift
@@ -38,13 +38,21 @@ final class AppState {
     var onSyncRequested: (@MainActor () -> Void)?
 
     /// Syncs all TCA state fields from the store; does not touch `onSyncRequested`.
+    /// Guards each assignment to avoid redundant Observation notifications.
     func bridge(from store: StoreOf<AppFeature>) {
-        prices = store.prices
-        priceChanges24h = store.priceChanges24h
-        syncStatus = store.syncStatus
-        connectionStatus = store.connectionStatus
-        lastPriceUpdate = store.lastPriceUpdate
-        storeIsEphemeral = store.storeIsEphemeral
+        updateIfChanged(\.prices, to: store.prices)
+        updateIfChanged(\.priceChanges24h, to: store.priceChanges24h)
+        updateIfChanged(\.syncStatus, to: store.syncStatus)
+        updateIfChanged(\.connectionStatus, to: store.connectionStatus)
+        updateIfChanged(\.lastPriceUpdate, to: store.lastPriceUpdate)
+        updateIfChanged(\.storeIsEphemeral, to: store.storeIsEphemeral)
+    }
+
+    private func updateIfChanged<Value: Equatable>(
+        _ keyPath: ReferenceWritableKeyPath<AppState, Value>,
+        to newValue: Value) {
+        guard self[keyPath: keyPath] != newValue else { return }
+        self[keyPath: keyPath] = newValue
     }
 
     /// Continuously observes TCA store and syncs changes to AppState.

--- a/Sources/Portu/App/AppState.swift
+++ b/Sources/Portu/App/AppState.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import Foundation
 import PortuCore
 
@@ -35,4 +36,27 @@ final class AppState {
 
     /// Bridge: called by features to trigger sync until they're migrated to TCA (Phase 4)
     var onSyncRequested: (@MainActor () -> Void)?
+
+    /// Syncs all TCA state fields from the store; does not touch `onSyncRequested`.
+    func bridge(from store: StoreOf<AppFeature>) {
+        prices = store.prices
+        priceChanges24h = store.priceChanges24h
+        syncStatus = store.syncStatus
+        connectionStatus = store.connectionStatus
+        lastPriceUpdate = store.lastPriceUpdate
+        storeIsEphemeral = store.storeIsEphemeral
+    }
+
+    /// Continuously observes TCA store and syncs changes to AppState.
+    /// Uses recursive `withObservationTracking` so this is centralized at app level,
+    /// not duplicated per-window.
+    func observe(_ store: StoreOf<AppFeature>) {
+        withObservationTracking {
+            bridge(from: store)
+        } onChange: {
+            Task { @MainActor [weak self] in
+                self?.observe(store)
+            }
+        }
+    }
 }

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -44,32 +44,19 @@ struct PortuApp: App {
         }
 
         // Bridge: features can trigger sync via AppState until migrated to TCA
-        appState.storeIsEphemeral = isEphemeral
         appState.onSyncRequested = { [store] in
             store.send(.syncTapped)
         }
+        appState.observe(store)
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView(store: store)
                 .environment(appState)
-                .onAppear {
-                    appState.prices = store.prices
-                    appState.priceChanges24h = store.priceChanges24h
-                    appState.syncStatus = store.syncStatus
-                    appState.connectionStatus = store.connectionStatus
-                    appState.lastPriceUpdate = store.lastPriceUpdate
-                    appState.storeIsEphemeral = store.storeIsEphemeral
-                }
-                .onChange(of: store.prices) { _, new in appState.prices = new }
-                .onChange(of: store.priceChanges24h) { _, new in appState.priceChanges24h = new }
-                .onChange(of: store.syncStatus) { _, new in appState.syncStatus = new }
-                .onChange(of: store.connectionStatus) { _, new in appState.connectionStatus = new }
-                .onChange(of: store.lastPriceUpdate) { _, new in appState.lastPriceUpdate = new }
-                .onChange(of: store.storeIsEphemeral) { _, new in appState.storeIsEphemeral = new }
         }
         .modelContainer(container)
+        .commands { CommandGroup(replacing: .newItem) {} }
 
         Settings {
             SettingsView()

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -51,12 +51,11 @@ struct PortuApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        Window("Portu", id: "main") {
             ContentView(store: store)
                 .environment(appState)
         }
         .modelContainer(container)
-        .commands { CommandGroup(replacing: .newItem) {} }
 
         Settings {
             SettingsView()

--- a/Tests/PortuTests/AppStateBridgeTests.swift
+++ b/Tests/PortuTests/AppStateBridgeTests.swift
@@ -6,16 +6,17 @@ import Testing
 
 // MARK: - AppState Bridge Tests
 
-// Tests for centralized TCA → AppState bridge.
+// Tests for the centralized TCA → AppState bridge/observation flow.
 //
-// Bug #16: The bridge is currently scattered across per-window .onAppear/.onChange
-// view modifiers in WindowGroup body. Each Cmd+N window duplicates the bridge,
-// and the Settings scene has no bridge at all.
+// Bug #16 was that the bridge used to be scattered across per-window
+// .onAppear/.onChange view modifiers in the WindowGroup body, which duplicated
+// bridging for each Cmd+N window and left the Settings scene without coverage.
 //
-// These tests verify that AppState exposes a `bridge(from:)` method that:
+// These tests verify the centralized AppState bridge behavior by checking that it:
 // - Syncs all 6 TCA state fields to AppState in one call
 // - Preserves existing callbacks (onSyncRequested)
 // - Is idempotent (safe to call multiple times)
+// - Continuously propagates store changes via observe(_:)
 
 @MainActor
 struct AppStateBridgeTests {

--- a/Tests/PortuTests/PortuAppTests.swift
+++ b/Tests/PortuTests/PortuAppTests.swift
@@ -148,7 +148,13 @@ struct AppStateBridgeTests {
         // Continuous observation should propagate this
         #expect(appState.syncStatus == .syncing(progress: 0))
 
-        // Clean up: complete the sync
+        // Clean up: complete the sync and wait for the in-flight effect
         syncCompleted.continuation.finish()
+
+        for _ in 0 ..< 100 where appState.syncStatus != .idle {
+            await Task.yield()
+        }
+
+        #expect(appState.syncStatus == .idle)
     }
 }

--- a/Tests/PortuTests/PortuAppTests.swift
+++ b/Tests/PortuTests/PortuAppTests.swift
@@ -1,8 +1,154 @@
+import ComposableArchitecture
+import Foundation
+@testable import Portu
+import PortuCore
 import Testing
 
-struct PortuAppTests {
-    @Test func `app launches without crash`() {
-        // Placeholder — verifies the test target links correctly
-        #expect(true)
+// MARK: - AppState Bridge Tests
+
+// Tests for centralized TCA → AppState bridge.
+//
+// Bug #16: The bridge is currently scattered across per-window .onAppear/.onChange
+// view modifiers in WindowGroup body. Each Cmd+N window duplicates the bridge,
+// and the Settings scene has no bridge at all.
+//
+// These tests verify that AppState exposes a `bridge(from:)` method that:
+// - Syncs all 6 TCA state fields to AppState in one call
+// - Preserves existing callbacks (onSyncRequested)
+// - Is idempotent (safe to call multiple times)
+
+@MainActor
+struct AppStateBridgeTests {
+    @Test func `bridge syncs all fields from store to AppState`() {
+        let store = Store(initialState: AppFeature.State(
+            syncStatus: .syncing(progress: 0.5),
+            connectionStatus: .fetching,
+            prices: ["bitcoin": 50000],
+            priceChanges24h: ["bitcoin": 2.5],
+            lastPriceUpdate: Date(timeIntervalSince1970: 1_000_000),
+            storeIsEphemeral: true)) {
+                AppFeature()
+            } withDependencies: {
+                $0.syncEngine = .testValue
+                $0.priceService = .testValue
+            }
+
+        let appState = AppState()
+        appState.bridge(from: store)
+
+        #expect(appState.prices == ["bitcoin": 50000])
+        #expect(appState.priceChanges24h == ["bitcoin": 2.5])
+        #expect(appState.syncStatus == .syncing(progress: 0.5))
+        #expect(appState.connectionStatus == .fetching)
+        #expect(appState.lastPriceUpdate == Date(timeIntervalSince1970: 1_000_000))
+        #expect(appState.storeIsEphemeral == true)
+    }
+
+    @Test func `bridge preserves onSyncRequested callback`() {
+        let store = Store(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine = .testValue
+            $0.priceService = .testValue
+        }
+
+        var callbackInvoked = false
+        let appState = AppState()
+        appState.onSyncRequested = { callbackInvoked = true }
+
+        appState.bridge(from: store)
+
+        appState.onSyncRequested?()
+        #expect(callbackInvoked)
+    }
+
+    @Test func `bridge is idempotent`() {
+        let store = Store(initialState: AppFeature.State(
+            prices: ["ethereum": 3000])) {
+                AppFeature()
+            } withDependencies: {
+                $0.syncEngine = .testValue
+                $0.priceService = .testValue
+            }
+
+        let appState = AppState()
+        appState.bridge(from: store)
+        appState.bridge(from: store)
+
+        #expect(appState.prices == ["ethereum": 3000])
+    }
+
+    @Test func `bridge syncs default idle state`() {
+        let store = Store(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine = .testValue
+            $0.priceService = .testValue
+        }
+
+        let appState = AppState()
+        appState.bridge(from: store)
+
+        #expect(appState.prices.isEmpty)
+        #expect(appState.priceChanges24h.isEmpty)
+        #expect(appState.syncStatus == .idle)
+        #expect(appState.connectionStatus == .idle)
+        #expect(appState.lastPriceUpdate == nil)
+        #expect(appState.storeIsEphemeral == false)
+    }
+
+    @Test func `bridge propagates store changes after initial sync`() async {
+        let store = Store(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine = .testValue
+            $0.priceService = .testValue
+            $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+        }
+
+        let appState = AppState()
+        appState.observe(store)
+
+        #expect(appState.prices.isEmpty)
+
+        // Mutate store state via action after observe was called
+        store.send(.pricesReceived(PriceUpdate(prices: ["bitcoin": 50000], changes24h: ["bitcoin": 2.5])))
+
+        // Yield to allow observation callbacks to fire
+        await Task.yield()
+
+        // Continuous observation should propagate this
+        #expect(appState.prices == ["bitcoin": 50000])
+        #expect(appState.priceChanges24h == ["bitcoin": 2.5])
+    }
+
+    @Test func `bridge propagates sync status changes`() async {
+        let syncCompleted = AsyncStream<Void>.makeStream()
+        let store = Store(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine.sync = {
+                for await _ in syncCompleted.stream {
+                    break
+                }
+                return SyncResult(failedAccounts: [])
+            }
+            $0.priceService = .testValue
+        }
+
+        let appState = AppState()
+        appState.observe(store)
+
+        #expect(appState.syncStatus == .idle)
+
+        // Start sync — store status changes to .syncing
+        store.send(.syncTapped)
+        await Task.yield()
+
+        // Continuous observation should propagate this
+        #expect(appState.syncStatus == .syncing(progress: 0))
+
+        // Clean up: complete the sync
+        syncCompleted.continuation.finish()
     }
 }


### PR DESCRIPTION
Closes #16

## Summary

- Replace per-window `.onAppear`/`.onChange` view modifiers with a centralized `observe(_:)` method on `AppState` using recursive `withObservationTracking`
- Add `bridge(from:)` one-shot sync method (used internally by `observe`)
- Disable Cmd+N multi-window via `.commands { CommandGroup(replacing: .newItem) {} }` — single-window app by design
- Call `appState.observe(store)` once in `PortuApp.init()` instead of bridging per-window

## Test plan

- [x] 6 new tests in `AppStateBridgeTests`:
  - `bridge syncs all fields from store to AppState`
  - `bridge preserves onSyncRequested callback`
  - `bridge is idempotent`
  - `bridge syncs default idle state`
  - `bridge propagates store changes after initial sync` (continuous observation)
  - `bridge propagates sync status changes` (continuous observation)
- [x] All 145 tests pass (33 suites)
- [x] SwiftFormat clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced redundant UI updates by improving state synchronization for smoother, more efficient runtime behavior.

* **Refactor**
  * Centralized app state observation to simplify lifecycle handling and improve reliability of reflected data (prices, sync/connection status, timestamps).

* **Chores**
  * Removed the default "New Item" application command to streamline menu behavior.

* **Tests**
  * Added comprehensive tests verifying state mirroring, idempotence, and continued propagation from the source store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->