### PR TITLE
feat: debug server skeleton with NWListener and HTTP parser

### DIFF
--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -10,6 +10,7 @@
     final class DebugServer {
         private let port: UInt16
         private var listener: NWListener?
+        private var startingListener: NWListener?
         private var routes: [String: [String: @Sendable (HTTPRequest) -> HTTPResponse]] = [:]
         private let startTime = ContinuousClock.now
         private let logger = Logger(subsystem: "com.portu.app", category: "DebugServer")
@@ -41,6 +42,8 @@
             params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: nwPort)
 
             let newListener = try NWListener(using: params)
+            startingListener = newListener
+            defer { startingListener = nil }
 
             do {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
@@ -89,6 +92,8 @@
         }
 
         func stop() {
+            startingListener?.cancel()
+            startingListener = nil
             listener?.cancel()
             listener = nil
             logger.info("Debug server stopped")

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -1,0 +1,178 @@
+#if DEBUG
+
+    import Foundation
+    import Network
+    import os
+
+    @MainActor
+    final class DebugServer {
+        private let port: UInt16
+        private var listener: NWListener?
+        private var routes: [String: [String: @Sendable (HTTPRequest) -> HTTPResponse]] = [:]
+        private let startTime = ContinuousClock.now
+        private let logger = Logger(subsystem: "com.portu.app", category: "DebugServer")
+
+        init(port: UInt16 = 9999) {
+            self.port = port
+            registerBuiltInRoutes()
+        }
+
+        // MARK: - Lifecycle
+
+        func start() async throws {
+            let params = NWParameters.tcp
+
+            guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+                throw DebugServerError.invalidPort(port)
+            }
+            params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: nwPort)
+
+            let newListener = try NWListener(using: params)
+            listener = newListener
+
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                nonisolated(unsafe) var resumed = false
+
+                newListener.stateUpdateHandler = { [weak self] state in
+                    guard self != nil else { return }
+                    switch state {
+                    case .ready:
+                        if !resumed {
+                            resumed = true
+                            continuation.resume()
+                        }
+                    case let .failed(error):
+                        if !resumed {
+                            resumed = true
+                            continuation.resume(throwing: error)
+                        }
+                    case .cancelled:
+                        break
+                    default:
+                        break
+                    }
+                }
+
+                newListener.newConnectionHandler = { [weak self] connection in
+                    Task { @MainActor in
+                        self?.handleConnection(connection)
+                    }
+                }
+
+                newListener.start(queue: .main)
+            }
+
+            let boundPort = port
+            logger.info("Debug server listening on 127.0.0.1:\(boundPort)")
+        }
+
+        func stop() {
+            listener?.cancel()
+            listener = nil
+            logger.info("Debug server stopped")
+        }
+
+        // MARK: - Routing
+
+        func addRoute(_ method: String, _ path: String, handler: @Sendable @escaping (HTTPRequest) -> HTTPResponse) {
+            routes[path, default: [:]][method] = handler
+        }
+
+        // MARK: - Built-in Routes
+
+        private func registerBuiltInRoutes() {
+            let capturedStartTime = startTime
+            addRoute("GET", "/health") { _ in
+                let uptime = ContinuousClock.now - capturedStartTime
+                let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+                return Self.jsonResponse(statusCode: 200, body: [
+                    "status": "ok",
+                    "version": version,
+                    "uptime": uptime.seconds
+                ])
+            }
+        }
+
+        // MARK: - Connection Handling
+
+        private func handleConnection(_ connection: NWConnection) {
+            connection.start(queue: .main)
+
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, _, error in
+                Task { @MainActor in
+                    guard let self else {
+                        connection.cancel()
+                        return
+                    }
+
+                    if error != nil {
+                        connection.cancel()
+                        return
+                    }
+
+                    guard let data = content, let request = HTTPParser.parse(data) else {
+                        self.sendResponse(
+                            Self.jsonResponse(statusCode: 400, body: ["error": "Bad request"]),
+                            on: connection)
+                        return
+                    }
+
+                    let response: HTTPResponse = if
+                        let pathRoutes = self.routes[request.path],
+                        let handler = pathRoutes[request.method] {
+                        handler(request)
+                    } else {
+                        Self.jsonResponse(statusCode: 404, body: ["error": "Not found"])
+                    }
+
+                    self.sendResponse(response, on: connection)
+                }
+            }
+        }
+
+        private func sendResponse(_ response: HTTPResponse, on connection: NWConnection) {
+            var header = "HTTP/1.1 \(response.statusCode) \(response.statusText)\r\n"
+            header += "Content-Type: application/json\r\n"
+            header += "Content-Length: \(response.body.count)\r\n"
+            header += "Connection: close\r\n"
+            header += "\r\n"
+
+            var payload = Data(header.utf8)
+            payload.append(response.body)
+
+            connection.send(content: payload, completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+        }
+
+        // MARK: - Helpers
+
+        nonisolated private static func jsonResponse(statusCode: Int, body: [String: any Sendable]) -> HTTPResponse {
+            let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data("{}".utf8)
+            return HTTPResponse(statusCode: statusCode, body: data)
+        }
+    }
+
+    // MARK: - Errors
+
+    enum DebugServerError: LocalizedError {
+        case invalidPort(UInt16)
+
+        var errorDescription: String? {
+            switch self {
+            case let .invalidPort(port):
+                "Invalid port: \(port)"
+            }
+        }
+    }
+
+    // MARK: - Duration Extension
+
+    private extension Duration {
+        var seconds: Double {
+            let (secs, attosecs) = components
+            return Double(secs) + Double(attosecs) * 1e-18
+        }
+    }
+
+#endif

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -11,7 +11,7 @@
         private let port: UInt16
         private var listener: NWListener?
         private var startingListener: NWListener?
-        private var routes: [String: [String: @Sendable (HTTPRequest) -> HTTPResponse]] = [:]
+        private var routes: [String: [String: @MainActor (HTTPRequest) -> HTTPResponse]] = [:]
         private var activeConnections: [ObjectIdentifier: NWConnection] = [:]
         private let startTime = ContinuousClock.now
         private let logger = Logger(subsystem: "com.portu.app", category: "DebugServer")
@@ -115,7 +115,7 @@
 
         // MARK: - Routing
 
-        func addRoute(_ method: String, _ path: String, handler: @Sendable @escaping (HTTPRequest) -> HTTPResponse) {
+        func addRoute(_ method: String, _ path: String, handler: @MainActor @escaping (HTTPRequest) -> HTTPResponse) {
             routes[path, default: [:]][method] = handler
         }
 

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -76,7 +76,7 @@
 
                     newListener.newConnectionHandler = { [weak self] connection in
                         Task { @MainActor in
-                            guard let self, self.listener != nil else {
+                            guard let self, self.listener != nil || self.startingListener != nil else {
                                 connection.cancel()
                                 return
                             }
@@ -142,6 +142,17 @@
         }
 
         private func handleConnection(_ connection: NWConnection) {
+            connection.stateUpdateHandler = { [weak self] state in
+                Task { @MainActor in
+                    guard case .failed = state else { return }
+                    if let self {
+                        self.finishConnection(connection)
+                    } else {
+                        connection.cancel()
+                    }
+                }
+            }
+
             connection.start(queue: .main)
 
             connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, _, error in

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -76,7 +76,7 @@
 
                     newListener.newConnectionHandler = { [weak self] connection in
                         Task { @MainActor in
-                            guard let self else {
+                            guard let self, self.listener != nil else {
                                 connection.cancel()
                                 return
                             }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -1,8 +1,10 @@
 #if DEBUG
 
+    import ComposableArchitecture
     import Foundation
     import Network
     import os
+    import SwiftData
 
     @MainActor
     final class DebugServer {
@@ -12,14 +14,25 @@
         private let startTime = ContinuousClock.now
         private let logger = Logger(subsystem: "com.portu.app", category: "DebugServer")
 
-        init(port: UInt16 = 9999) {
+        // Stored for future endpoints (sub-issues #3, #4)
+        private let modelContainer: ModelContainer?
+        private let store: StoreOf<AppFeature>?
+
+        init(
+            port: UInt16 = 9999,
+            modelContainer: ModelContainer? = nil,
+            store: StoreOf<AppFeature>? = nil) {
             self.port = port
+            self.modelContainer = modelContainer
+            self.store = store
             registerBuiltInRoutes()
         }
 
         // MARK: - Lifecycle
 
         func start() async throws {
+            guard listener == nil else { return }
+
             let params = NWParameters.tcp
 
             guard let nwPort = NWEndpoint.Port(rawValue: port) else {
@@ -31,6 +44,8 @@
             listener = newListener
 
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                // Safety: `resumed` is only mutated from the .main queue (see newListener.start below),
+                // so concurrent access cannot occur. nonisolated(unsafe) suppresses the Swift 6 diagnostic.
                 nonisolated(unsafe) var resumed = false
 
                 newListener.stateUpdateHandler = { [weak self] state in
@@ -148,7 +163,10 @@
         // MARK: - Helpers
 
         nonisolated private static func jsonResponse(statusCode: Int, body: [String: any Sendable]) -> HTTPResponse {
-            let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data("{}".utf8)
+            guard let data = try? JSONSerialization.data(withJSONObject: body) else {
+                assertionFailure("DebugServer: failed to serialize JSON response")
+                return HTTPResponse(statusCode: 500, body: Data("{\"error\":\"serialization failed\"}".utf8))
+            }
             return HTTPResponse(statusCode: statusCode, body: data)
         }
     }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -203,7 +203,11 @@
                     logger.debug("Connection send error: \(error)")
                 }
                 Task { @MainActor in
-                    self?.finishConnection(connection) ?? connection.cancel()
+                    if let self {
+                        self.finishConnection(connection)
+                    } else {
+                        connection.cancel()
+                    }
                 }
             })
         }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -41,42 +41,49 @@
             params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: nwPort)
 
             let newListener = try NWListener(using: params)
-            listener = newListener
 
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                // Safety: `resumed` is only mutated from the .main queue (see newListener.start below),
-                // so concurrent access cannot occur. nonisolated(unsafe) suppresses the Swift 6 diagnostic.
-                nonisolated(unsafe) var resumed = false
+            do {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    // Safety: `resumed` is only mutated from the .main queue (see newListener.start below),
+                    // so concurrent access cannot occur. nonisolated(unsafe) suppresses the Swift 6 diagnostic.
+                    nonisolated(unsafe) var resumed = false
 
-                newListener.stateUpdateHandler = { [weak self] state in
-                    guard self != nil else { return }
-                    switch state {
-                    case .ready:
-                        if !resumed {
-                            resumed = true
-                            continuation.resume()
+                    newListener.stateUpdateHandler = { state in
+                        switch state {
+                        case .ready:
+                            if !resumed {
+                                resumed = true
+                                continuation.resume()
+                            }
+                        case let .failed(error):
+                            if !resumed {
+                                resumed = true
+                                continuation.resume(throwing: error)
+                            }
+                        case .cancelled:
+                            if !resumed {
+                                resumed = true
+                                continuation.resume(throwing: DebugServerError.cancelled)
+                            }
+                        default:
+                            break
                         }
-                    case let .failed(error):
-                        if !resumed {
-                            resumed = true
-                            continuation.resume(throwing: error)
+                    }
+
+                    newListener.newConnectionHandler = { [weak self] connection in
+                        Task { @MainActor in
+                            self?.handleConnection(connection)
                         }
-                    case .cancelled:
-                        break
-                    default:
-                        break
                     }
-                }
 
-                newListener.newConnectionHandler = { [weak self] connection in
-                    Task { @MainActor in
-                        self?.handleConnection(connection)
-                    }
+                    newListener.start(queue: .main)
                 }
-
-                newListener.start(queue: .main)
+            } catch {
+                newListener.cancel()
+                throw error
             }
 
+            listener = newListener
             let boundPort = port
             logger.info("Debug server listening on 127.0.0.1:\(boundPort)")
         }
@@ -175,11 +182,14 @@
 
     enum DebugServerError: LocalizedError {
         case invalidPort(UInt16)
+        case cancelled
 
         var errorDescription: String? {
             switch self {
             case let .invalidPort(port):
                 "Invalid port: \(port)"
+            case .cancelled:
+                "Server start cancelled"
             }
         }
     }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -12,6 +12,7 @@
         private var listener: NWListener?
         private var startingListener: NWListener?
         private var routes: [String: [String: @Sendable (HTTPRequest) -> HTTPResponse]] = [:]
+        private var activeConnections: [ObjectIdentifier: NWConnection] = [:]
         private let startTime = ContinuousClock.now
         private let logger = Logger(subsystem: "com.portu.app", category: "DebugServer")
 
@@ -79,6 +80,7 @@
                                 connection.cancel()
                                 return
                             }
+                            self.activeConnections[ObjectIdentifier(connection)] = connection
                             self.handleConnection(connection)
                         }
                     }
@@ -100,6 +102,10 @@
         }
 
         func stop() {
+            for connection in activeConnections.values {
+                connection.cancel()
+            }
+            activeConnections.removeAll()
             startingListener?.cancel()
             startingListener = nil
             listener?.cancel()
@@ -130,6 +136,11 @@
 
         // MARK: - Connection Handling
 
+        private func finishConnection(_ connection: NWConnection) {
+            activeConnections.removeValue(forKey: ObjectIdentifier(connection))
+            connection.cancel()
+        }
+
         private func handleConnection(_ connection: NWConnection) {
             connection.start(queue: .main)
 
@@ -142,7 +153,7 @@
 
                     if let error {
                         self.logger.debug("Connection receive error: \(error)")
-                        connection.cancel()
+                        self.finishConnection(connection)
                         return
                     }
 
@@ -176,11 +187,13 @@
             var payload = Data(header.utf8)
             payload.append(response.body)
 
-            connection.send(content: payload, completion: .contentProcessed { [logger] error in
+            connection.send(content: payload, completion: .contentProcessed { [weak self, logger] error in
                 if let error {
                     logger.debug("Connection send error: \(error)")
                 }
-                connection.cancel()
+                Task { @MainActor in
+                    self?.finishConnection(connection) ?? connection.cancel()
+                }
             })
         }
 

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -86,6 +86,10 @@
                 throw error
             }
 
+            guard startingListener === newListener else {
+                newListener.cancel()
+                throw DebugServerError.cancelled
+            }
             listener = newListener
             let boundPort = port
             logger.info("Debug server listening on 127.0.0.1:\(boundPort)")
@@ -133,7 +137,7 @@
                     }
 
                     if let error {
-                        logger.debug("Connection receive error: \(error)")
+                        self.logger.debug("Connection receive error: \(error)")
                         connection.cancel()
                         return
                     }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -144,6 +144,7 @@
         private func handleConnection(_ connection: NWConnection) {
             connection.stateUpdateHandler = { [weak self] state in
                 Task { @MainActor in
+                    // Only .failed needs cleanup here — .cancelled is covered by stop() via activeConnections.removeAll()
                     guard case .failed = state else { return }
                     if let self {
                         self.finishConnection(connection)

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -32,7 +32,7 @@
         // MARK: - Lifecycle
 
         func start() async throws {
-            guard listener == nil else { return }
+            guard listener == nil, startingListener == nil else { return }
 
             let params = NWParameters.tcp
 

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -168,7 +168,10 @@
             var payload = Data(header.utf8)
             payload.append(response.body)
 
-            connection.send(content: payload, completion: .contentProcessed { _ in
+            connection.send(content: payload, completion: .contentProcessed { [logger] error in
+                if let error {
+                    logger.debug("Connection send error: \(error)")
+                }
                 connection.cancel()
             })
         }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -132,7 +132,8 @@
                         return
                     }
 
-                    if error != nil {
+                    if let error {
+                        logger.debug("Connection receive error: \(error)")
                         connection.cancel()
                         return
                     }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -75,7 +75,11 @@
 
                     newListener.newConnectionHandler = { [weak self] connection in
                         Task { @MainActor in
-                            self?.handleConnection(connection)
+                            guard let self else {
+                                connection.cancel()
+                                return
+                            }
+                            self.handleConnection(connection)
                         }
                     }
 

--- a/Sources/Portu/Debug/HTTPParser.swift
+++ b/Sources/Portu/Debug/HTTPParser.swift
@@ -43,7 +43,7 @@
 
             // "GET /path HTTP/1.1"
             let parts = requestLine.split(separator: " ", maxSplits: 2)
-            guard parts.count == 3 else { return nil }
+            guard parts.count == 3, parts[2].hasPrefix("HTTP/") else { return nil }
 
             let method = String(parts[0])
             let rawURI = String(parts[1])

--- a/Sources/Portu/Debug/HTTPParser.swift
+++ b/Sources/Portu/Debug/HTTPParser.swift
@@ -1,0 +1,78 @@
+#if DEBUG
+
+    import Foundation
+
+    struct HTTPRequest {
+        let method: String
+        let path: String
+        let queryParams: [String: String]
+    }
+
+    struct HTTPResponse {
+        let statusCode: Int
+        let body: Data
+
+        var statusText: String {
+            switch statusCode {
+            case 200: "OK"
+            case 400: "Bad Request"
+            case 404: "Not Found"
+            case 500: "Internal Server Error"
+            default: "Unknown"
+            }
+        }
+    }
+
+    enum HTTPParser {
+        private static let maxRequestLineLength = 8192
+        private static let headerTerminator = Data("\r\n\r\n".utf8)
+
+        static func parse(_ data: Data) -> HTTPRequest? {
+            guard
+                !data.isEmpty,
+                data.range(of: headerTerminator) != nil
+            else { return nil }
+
+            guard let firstLineEnd = data.range(of: Data("\r\n".utf8)) else { return nil }
+            let requestLineData = data[data.startIndex ..< firstLineEnd.lowerBound]
+
+            guard
+                requestLineData.count <= maxRequestLineLength,
+                let requestLine = String(data: requestLineData, encoding: .utf8)
+            else { return nil }
+
+            // "GET /path HTTP/1.1"
+            let parts = requestLine.split(separator: " ", maxSplits: 2)
+            guard parts.count == 3 else { return nil }
+
+            let method = String(parts[0])
+            let rawURI = String(parts[1])
+
+            let (path, queryParams) = parseURI(rawURI)
+            return HTTPRequest(method: method, path: path, queryParams: queryParams)
+        }
+
+        private static func parseURI(_ uri: String) -> (path: String, queryParams: [String: String]) {
+            guard let questionMark = uri.firstIndex(of: "?") else {
+                return (uri, [:])
+            }
+
+            let path = String(uri[uri.startIndex ..< questionMark])
+            let queryString = String(uri[uri.index(after: questionMark)...])
+
+            var params: [String: String] = [:]
+            for pair in queryString.split(separator: "&", omittingEmptySubsequences: true) {
+                if let eqIndex = pair.firstIndex(of: "=") {
+                    let key = String(pair[pair.startIndex ..< eqIndex])
+                    let value = String(pair[pair.index(after: eqIndex)...])
+                    params[key] = value
+                } else {
+                    params[String(pair)] = ""
+                }
+            }
+
+            return (path, params)
+        }
+    }
+
+#endif

--- a/Sources/Portu/Debug/HTTPParser.swift
+++ b/Sources/Portu/Debug/HTTPParser.swift
@@ -18,7 +18,7 @@
             case 400: "Bad Request"
             case 404: "Not Found"
             case 500: "Internal Server Error"
-            default: "Unknown"
+            default: "Status \(statusCode)"
             }
         }
     }

--- a/Sources/Portu/Resources/Portu.entitlements
+++ b/Sources/Portu/Resources/Portu.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/Tests/PortuTests/DebugServerTests.swift
+++ b/Tests/PortuTests/DebugServerTests.swift
@@ -77,7 +77,7 @@
 
         // MARK: - Localhost Binding
 
-        @Test func `server binds to localhost only`() async throws {
+        @Test func `server responds on loopback`() async throws {
             let server = DebugServer(port: 19005)
             try await server.start()
             defer { server.stop() }

--- a/Tests/PortuTests/DebugServerTests.swift
+++ b/Tests/PortuTests/DebugServerTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Network
 @testable import Portu
 import Testing
 

--- a/Tests/PortuTests/DebugServerTests.swift
+++ b/Tests/PortuTests/DebugServerTests.swift
@@ -5,14 +5,12 @@ import Testing
 
 @MainActor
 struct DebugServerTests {
-    // MARK: - HTTPParser Integration (already unit-tested, quick smoke check)
+    // MARK: - Health Endpoint
 
     @Test func `health endpoint returns valid JSON`() async throws {
         let server = DebugServer(port: 19001)
         try await server.start()
-
-        // Give listener a moment to be ready
-        try await Task.sleep(for: .milliseconds(100))
+        defer { server.stop() }
 
         let (data, response) = try await URLSession.shared.data(
             from: #require(URL(string: "http://127.0.0.1:19001/health")))
@@ -25,14 +23,14 @@ struct DebugServerTests {
         #expect(json["status"] as? String == "ok")
         #expect(json["version"] != nil)
         #expect(json["uptime"] != nil)
-
-        server.stop()
     }
+
+    // MARK: - 404 Fallback
 
     @Test func `unknown path returns 404`() async throws {
         let server = DebugServer(port: 19002)
         try await server.start()
-        try await Task.sleep(for: .milliseconds(100))
+        defer { server.stop() }
 
         let (data, response) = try await URLSession.shared.data(
             from: #require(URL(string: "http://127.0.0.1:19002/nonexistent")))
@@ -42,19 +40,17 @@ struct DebugServerTests {
 
         let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(json["error"] as? String == "Not found")
-
-        server.stop()
     }
+
+    // MARK: - Server Lifecycle
 
     @Test func `server stop cancels listener`() async throws {
         let server = DebugServer(port: 19003)
         try await server.start()
-        try await Task.sleep(for: .milliseconds(100))
 
         server.stop()
         try await Task.sleep(for: .milliseconds(100))
 
-        // After stop, connections should be refused
         do {
             _ = try await URLSession.shared.data(
                 from: #require(URL(string: "http://127.0.0.1:19003/health")))
@@ -67,7 +63,7 @@ struct DebugServerTests {
     @Test func `port in use does not crash`() async throws {
         let server1 = DebugServer(port: 19004)
         try await server1.start()
-        try await Task.sleep(for: .milliseconds(100))
+        defer { server1.stop() }
 
         let server2 = DebugServer(port: 19004)
         do {
@@ -76,27 +72,28 @@ struct DebugServerTests {
         } catch {
             // Expected — port already bound
         }
-
-        server1.stop()
     }
+
+    // MARK: - Localhost Binding
 
     @Test func `server binds to localhost only`() async throws {
         let server = DebugServer(port: 19005)
         try await server.start()
-        try await Task.sleep(for: .milliseconds(100))
+        defer { server.stop() }
 
-        // Verify we can reach it on 127.0.0.1
         let (_, response) = try await URLSession.shared.data(
             from: #require(URL(string: "http://127.0.0.1:19005/health")))
         let httpResponse = try #require(response as? HTTPURLResponse)
         #expect(httpResponse.statusCode == 200)
-
-        server.stop()
     }
+
+    // MARK: - Uptime
 
     @Test func `uptime increases over time`() async throws {
         let server = DebugServer(port: 19006)
         try await server.start()
+        defer { server.stop() }
+
         try await Task.sleep(for: .milliseconds(200))
 
         let (data, _) = try await URLSession.shared.data(
@@ -105,7 +102,5 @@ struct DebugServerTests {
         let uptime = try #require(json["uptime"] as? Double)
 
         #expect(uptime >= 0.1)
-
-        server.stop()
     }
 }

--- a/Tests/PortuTests/DebugServerTests.swift
+++ b/Tests/PortuTests/DebugServerTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Network
+@testable import Portu
+import Testing
+
+@MainActor
+struct DebugServerTests {
+    // MARK: - HTTPParser Integration (already unit-tested, quick smoke check)
+
+    @Test func `health endpoint returns valid JSON`() async throws {
+        let server = DebugServer(port: 19001)
+        try await server.start()
+
+        // Give listener a moment to be ready
+        try await Task.sleep(for: .milliseconds(100))
+
+        let (data, response) = try await URLSession.shared.data(
+            from: #require(URL(string: "http://127.0.0.1:19001/health")))
+        let httpResponse = try #require(response as? HTTPURLResponse)
+
+        #expect(httpResponse.statusCode == 200)
+        #expect(httpResponse.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["status"] as? String == "ok")
+        #expect(json["version"] != nil)
+        #expect(json["uptime"] != nil)
+
+        server.stop()
+    }
+
+    @Test func `unknown path returns 404`() async throws {
+        let server = DebugServer(port: 19002)
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let (data, response) = try await URLSession.shared.data(
+            from: #require(URL(string: "http://127.0.0.1:19002/nonexistent")))
+        let httpResponse = try #require(response as? HTTPURLResponse)
+
+        #expect(httpResponse.statusCode == 404)
+
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["error"] as? String == "Not found")
+
+        server.stop()
+    }
+
+    @Test func `server stop cancels listener`() async throws {
+        let server = DebugServer(port: 19003)
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(100))
+
+        server.stop()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // After stop, connections should be refused
+        do {
+            _ = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19003/health")))
+            Issue.record("Expected connection to be refused after stop")
+        } catch {
+            // Expected — connection refused
+        }
+    }
+
+    @Test func `port in use does not crash`() async throws {
+        let server1 = DebugServer(port: 19004)
+        try await server1.start()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let server2 = DebugServer(port: 19004)
+        do {
+            try await server2.start()
+            Issue.record("Expected start to throw when port is in use")
+        } catch {
+            // Expected — port already bound
+        }
+
+        server1.stop()
+    }
+
+    @Test func `server binds to localhost only`() async throws {
+        let server = DebugServer(port: 19005)
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Verify we can reach it on 127.0.0.1
+        let (_, response) = try await URLSession.shared.data(
+            from: #require(URL(string: "http://127.0.0.1:19005/health")))
+        let httpResponse = try #require(response as? HTTPURLResponse)
+        #expect(httpResponse.statusCode == 200)
+
+        server.stop()
+    }
+
+    @Test func `uptime increases over time`() async throws {
+        let server = DebugServer(port: 19006)
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(200))
+
+        let (data, _) = try await URLSession.shared.data(
+            from: #require(URL(string: "http://127.0.0.1:19006/health")))
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let uptime = try #require(json["uptime"] as? Double)
+
+        #expect(uptime >= 0.1)
+
+        server.stop()
+    }
+}

--- a/Tests/PortuTests/DebugServerTests.swift
+++ b/Tests/PortuTests/DebugServerTests.swift
@@ -65,6 +65,7 @@ struct DebugServerTests {
         defer { server1.stop() }
 
         let server2 = DebugServer(port: 19004)
+        defer { server2.stop() }
         do {
             try await server2.start()
             Issue.record("Expected start to throw when port is in use")

--- a/Tests/PortuTests/DebugServerTests.swift
+++ b/Tests/PortuTests/DebugServerTests.swift
@@ -1,106 +1,108 @@
-import Foundation
-@testable import Portu
-import Testing
+#if DEBUG
+    import Foundation
+    @testable import Portu
+    import Testing
 
-@MainActor
-struct DebugServerTests {
-    // MARK: - Health Endpoint
+    @MainActor
+    struct DebugServerTests {
+        // MARK: - Health Endpoint
 
-    @Test func `health endpoint returns valid JSON`() async throws {
-        let server = DebugServer(port: 19001)
-        try await server.start()
-        defer { server.stop() }
+        @Test func `health endpoint returns valid JSON`() async throws {
+            let server = DebugServer(port: 19001)
+            try await server.start()
+            defer { server.stop() }
 
-        let (data, response) = try await URLSession.shared.data(
-            from: #require(URL(string: "http://127.0.0.1:19001/health")))
-        let httpResponse = try #require(response as? HTTPURLResponse)
+            let (data, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19001/health")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
 
-        #expect(httpResponse.statusCode == 200)
-        #expect(httpResponse.value(forHTTPHeaderField: "Content-Type") == "application/json")
+            #expect(httpResponse.statusCode == 200)
+            #expect(httpResponse.value(forHTTPHeaderField: "Content-Type") == "application/json")
 
-        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        #expect(json["status"] as? String == "ok")
-        #expect(json["version"] != nil)
-        #expect(json["uptime"] != nil)
-    }
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["status"] as? String == "ok")
+            #expect(json["version"] != nil)
+            #expect(json["uptime"] != nil)
+        }
 
-    // MARK: - 404 Fallback
+        // MARK: - 404 Fallback
 
-    @Test func `unknown path returns 404`() async throws {
-        let server = DebugServer(port: 19002)
-        try await server.start()
-        defer { server.stop() }
+        @Test func `unknown path returns 404`() async throws {
+            let server = DebugServer(port: 19002)
+            try await server.start()
+            defer { server.stop() }
 
-        let (data, response) = try await URLSession.shared.data(
-            from: #require(URL(string: "http://127.0.0.1:19002/nonexistent")))
-        let httpResponse = try #require(response as? HTTPURLResponse)
+            let (data, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19002/nonexistent")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
 
-        #expect(httpResponse.statusCode == 404)
+            #expect(httpResponse.statusCode == 404)
 
-        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        #expect(json["error"] as? String == "Not found")
-    }
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["error"] as? String == "Not found")
+        }
 
-    // MARK: - Server Lifecycle
+        // MARK: - Server Lifecycle
 
-    @Test func `server stop cancels listener`() async throws {
-        let server = DebugServer(port: 19003)
-        try await server.start()
+        @Test func `server stop cancels listener`() async throws {
+            let server = DebugServer(port: 19003)
+            try await server.start()
 
-        server.stop()
-        try await Task.sleep(for: .milliseconds(100))
+            server.stop()
+            try await Task.sleep(for: .milliseconds(100))
 
-        do {
-            _ = try await URLSession.shared.data(
-                from: #require(URL(string: "http://127.0.0.1:19003/health")))
-            Issue.record("Expected connection to be refused after stop")
-        } catch {
-            // Expected — connection refused
+            do {
+                _ = try await URLSession.shared.data(
+                    from: #require(URL(string: "http://127.0.0.1:19003/health")))
+                Issue.record("Expected connection to be refused after stop")
+            } catch {
+                // Expected — connection refused
+            }
+        }
+
+        @Test func `port in use does not crash`() async throws {
+            let server1 = DebugServer(port: 19004)
+            try await server1.start()
+            defer { server1.stop() }
+
+            let server2 = DebugServer(port: 19004)
+            defer { server2.stop() }
+            do {
+                try await server2.start()
+                Issue.record("Expected start to throw when port is in use")
+            } catch {
+                // Expected — port already bound
+            }
+        }
+
+        // MARK: - Localhost Binding
+
+        @Test func `server binds to localhost only`() async throws {
+            let server = DebugServer(port: 19005)
+            try await server.start()
+            defer { server.stop() }
+
+            let (_, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19005/health")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
+            #expect(httpResponse.statusCode == 200)
+        }
+
+        // MARK: - Uptime
+
+        @Test func `uptime increases over time`() async throws {
+            let server = DebugServer(port: 19006)
+            try await server.start()
+            defer { server.stop() }
+
+            try await Task.sleep(for: .milliseconds(200))
+
+            let (data, _) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19006/health")))
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let uptime = try #require(json["uptime"] as? Double)
+
+            #expect(uptime >= 0.1)
         }
     }
-
-    @Test func `port in use does not crash`() async throws {
-        let server1 = DebugServer(port: 19004)
-        try await server1.start()
-        defer { server1.stop() }
-
-        let server2 = DebugServer(port: 19004)
-        defer { server2.stop() }
-        do {
-            try await server2.start()
-            Issue.record("Expected start to throw when port is in use")
-        } catch {
-            // Expected — port already bound
-        }
-    }
-
-    // MARK: - Localhost Binding
-
-    @Test func `server binds to localhost only`() async throws {
-        let server = DebugServer(port: 19005)
-        try await server.start()
-        defer { server.stop() }
-
-        let (_, response) = try await URLSession.shared.data(
-            from: #require(URL(string: "http://127.0.0.1:19005/health")))
-        let httpResponse = try #require(response as? HTTPURLResponse)
-        #expect(httpResponse.statusCode == 200)
-    }
-
-    // MARK: - Uptime
-
-    @Test func `uptime increases over time`() async throws {
-        let server = DebugServer(port: 19006)
-        try await server.start()
-        defer { server.stop() }
-
-        try await Task.sleep(for: .milliseconds(200))
-
-        let (data, _) = try await URLSession.shared.data(
-            from: #require(URL(string: "http://127.0.0.1:19006/health")))
-        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        let uptime = try #require(json["uptime"] as? Double)
-
-        #expect(uptime >= 0.1)
-    }
-}
+#endif

--- a/Tests/PortuTests/HTTPParserTests.swift
+++ b/Tests/PortuTests/HTTPParserTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+@testable import Portu
+import Testing
+
+struct HTTPParserTests {
+    // MARK: - Valid GET Requests
+
+    @Test func `parses simple GET request`() {
+        let raw = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request != nil)
+        #expect(request?.method == "GET")
+        #expect(request?.path == "/health")
+        #expect(request?.queryParams.isEmpty == true)
+    }
+
+    @Test func `parses GET with query parameters`() {
+        let raw = "GET /accounts?type=wallet&chain=ethereum HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request != nil)
+        #expect(request?.path == "/accounts")
+        #expect(request?.queryParams["type"] == "wallet")
+        #expect(request?.queryParams["chain"] == "ethereum")
+    }
+
+    @Test func `parses GET with single query parameter`() {
+        let raw = "GET /search?q=bitcoin HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.path == "/search")
+        #expect(request?.queryParams["q"] == "bitcoin")
+    }
+
+    @Test func `parses GET with empty query value`() {
+        let raw = "GET /filter?active= HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.path == "/filter")
+        #expect(request?.queryParams["active"]?.isEmpty == true)
+    }
+
+    @Test func `parses root path`() {
+        let raw = "GET / HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.method == "GET")
+        #expect(request?.path == "/")
+    }
+
+    // MARK: - Other HTTP Methods
+
+    @Test func `parses POST method`() {
+        let raw = "POST /data HTTP/1.1\r\nContent-Length: 0\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.method == "POST")
+        #expect(request?.path == "/data")
+    }
+
+    @Test func `parses DELETE method`() {
+        let raw = "DELETE /accounts/1 HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.method == "DELETE")
+        #expect(request?.path == "/accounts/1")
+    }
+
+    // MARK: - Malformed Requests
+
+    @Test func `returns nil for empty data`() {
+        let request = HTTPParser.parse(Data())
+        #expect(request == nil)
+    }
+
+    @Test func `returns nil for garbage data`() {
+        let request = HTTPParser.parse(Data("not http at all".utf8))
+        #expect(request == nil)
+    }
+
+    @Test func `returns nil for missing path`() {
+        let request = HTTPParser.parse(Data("GET\r\n\r\n".utf8))
+        #expect(request == nil)
+    }
+
+    @Test func `returns nil for missing HTTP version`() {
+        let request = HTTPParser.parse(Data("GET /health\r\n\r\n".utf8))
+        #expect(request == nil)
+    }
+
+    @Test func `returns nil for missing header terminator`() {
+        // No \r\n\r\n — incomplete request
+        let request = HTTPParser.parse(Data("GET /health HTTP/1.1\r\nHost: localhost".utf8))
+        #expect(request == nil)
+    }
+
+    // MARK: - Edge Cases
+
+    @Test func `handles URL-encoded query values`() {
+        let raw = "GET /search?q=hello%20world HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.path == "/search")
+        // Raw value — decoding is caller's responsibility
+        #expect(request?.queryParams["q"] == "hello%20world")
+    }
+
+    @Test func `handles query key without value`() {
+        let raw = "GET /filter?verbose HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.path == "/filter")
+        // Key present with empty string value
+        #expect(request?.queryParams["verbose"]?.isEmpty == true)
+    }
+
+    @Test func `handles deeply nested path`() {
+        let raw = "GET /api/v1/accounts/123/positions HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request?.path == "/api/v1/accounts/123/positions")
+    }
+
+    @Test func `rejects request line longer than 8192 bytes`() {
+        let longPath = String(repeating: "a", count: 8200)
+        let raw = "GET /\(longPath) HTTP/1.1\r\n\r\n"
+        let request = HTTPParser.parse(Data(raw.utf8))
+
+        #expect(request == nil)
+    }
+}

--- a/Tests/PortuTests/HTTPParserTests.swift
+++ b/Tests/PortuTests/HTTPParserTests.swift
@@ -89,6 +89,11 @@ struct HTTPParserTests {
         #expect(request == nil)
     }
 
+    @Test func `returns nil for invalid HTTP version`() {
+        let request = HTTPParser.parse(Data("GET / GARBAGE\r\n\r\n".utf8))
+        #expect(request == nil)
+    }
+
     @Test func `returns nil for missing header terminator`() {
         // No \r\n\r\n — incomplete request
         let request = HTTPParser.parse(Data("GET /health HTTP/1.1\r\nHost: localhost".utf8))

--- a/Tests/PortuTests/HTTPParserTests.swift
+++ b/Tests/PortuTests/HTTPParserTests.swift
@@ -1,137 +1,139 @@
-import Foundation
-@testable import Portu
-import Testing
+#if DEBUG
+    import Foundation
+    @testable import Portu
+    import Testing
 
-struct HTTPParserTests {
-    // MARK: - Valid GET Requests
+    struct HTTPParserTests {
+        // MARK: - Valid GET Requests
 
-    @Test func `parses simple GET request`() {
-        let raw = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
+        @Test func `parses simple GET request`() {
+            let raw = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
 
-        #expect(request != nil)
-        #expect(request?.method == "GET")
-        #expect(request?.path == "/health")
-        #expect(request?.queryParams.isEmpty == true)
+            #expect(request != nil)
+            #expect(request?.method == "GET")
+            #expect(request?.path == "/health")
+            #expect(request?.queryParams.isEmpty == true)
+        }
+
+        @Test func `parses GET with query parameters`() {
+            let raw = "GET /accounts?type=wallet&chain=ethereum HTTP/1.1\r\nHost: localhost\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request != nil)
+            #expect(request?.path == "/accounts")
+            #expect(request?.queryParams["type"] == "wallet")
+            #expect(request?.queryParams["chain"] == "ethereum")
+        }
+
+        @Test func `parses GET with single query parameter`() {
+            let raw = "GET /search?q=bitcoin HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.path == "/search")
+            #expect(request?.queryParams["q"] == "bitcoin")
+        }
+
+        @Test func `parses GET with empty query value`() {
+            let raw = "GET /filter?active= HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.path == "/filter")
+            #expect(request?.queryParams["active"]?.isEmpty == true)
+        }
+
+        @Test func `parses root path`() {
+            let raw = "GET / HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.method == "GET")
+            #expect(request?.path == "/")
+        }
+
+        // MARK: - Other HTTP Methods
+
+        @Test func `parses POST method`() {
+            let raw = "POST /data HTTP/1.1\r\nContent-Length: 0\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.method == "POST")
+            #expect(request?.path == "/data")
+        }
+
+        @Test func `parses DELETE method`() {
+            let raw = "DELETE /accounts/1 HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.method == "DELETE")
+            #expect(request?.path == "/accounts/1")
+        }
+
+        // MARK: - Malformed Requests
+
+        @Test func `returns nil for empty data`() {
+            let request = HTTPParser.parse(Data())
+            #expect(request == nil)
+        }
+
+        @Test func `returns nil for garbage data`() {
+            let request = HTTPParser.parse(Data("not http at all".utf8))
+            #expect(request == nil)
+        }
+
+        @Test func `returns nil for missing path`() {
+            let request = HTTPParser.parse(Data("GET\r\n\r\n".utf8))
+            #expect(request == nil)
+        }
+
+        @Test func `returns nil for missing HTTP version`() {
+            let request = HTTPParser.parse(Data("GET /health\r\n\r\n".utf8))
+            #expect(request == nil)
+        }
+
+        @Test func `returns nil for invalid HTTP version`() {
+            let request = HTTPParser.parse(Data("GET / GARBAGE\r\n\r\n".utf8))
+            #expect(request == nil)
+        }
+
+        @Test func `returns nil for missing header terminator`() {
+            // No \r\n\r\n — incomplete request
+            let request = HTTPParser.parse(Data("GET /health HTTP/1.1\r\nHost: localhost".utf8))
+            #expect(request == nil)
+        }
+
+        // MARK: - Edge Cases
+
+        @Test func `handles URL-encoded query values`() {
+            let raw = "GET /search?q=hello%20world HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.path == "/search")
+            // Raw value — decoding is caller's responsibility
+            #expect(request?.queryParams["q"] == "hello%20world")
+        }
+
+        @Test func `handles query key without value`() {
+            let raw = "GET /filter?verbose HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.path == "/filter")
+            // Key present with empty string value
+            #expect(request?.queryParams["verbose"]?.isEmpty == true)
+        }
+
+        @Test func `handles deeply nested path`() {
+            let raw = "GET /api/v1/accounts/123/positions HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request?.path == "/api/v1/accounts/123/positions")
+        }
+
+        @Test func `rejects request line longer than 8192 bytes`() {
+            let longPath = String(repeating: "a", count: 8200)
+            let raw = "GET /\(longPath) HTTP/1.1\r\n\r\n"
+            let request = HTTPParser.parse(Data(raw.utf8))
+
+            #expect(request == nil)
+        }
     }
-
-    @Test func `parses GET with query parameters`() {
-        let raw = "GET /accounts?type=wallet&chain=ethereum HTTP/1.1\r\nHost: localhost\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request != nil)
-        #expect(request?.path == "/accounts")
-        #expect(request?.queryParams["type"] == "wallet")
-        #expect(request?.queryParams["chain"] == "ethereum")
-    }
-
-    @Test func `parses GET with single query parameter`() {
-        let raw = "GET /search?q=bitcoin HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.path == "/search")
-        #expect(request?.queryParams["q"] == "bitcoin")
-    }
-
-    @Test func `parses GET with empty query value`() {
-        let raw = "GET /filter?active= HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.path == "/filter")
-        #expect(request?.queryParams["active"]?.isEmpty == true)
-    }
-
-    @Test func `parses root path`() {
-        let raw = "GET / HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.method == "GET")
-        #expect(request?.path == "/")
-    }
-
-    // MARK: - Other HTTP Methods
-
-    @Test func `parses POST method`() {
-        let raw = "POST /data HTTP/1.1\r\nContent-Length: 0\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.method == "POST")
-        #expect(request?.path == "/data")
-    }
-
-    @Test func `parses DELETE method`() {
-        let raw = "DELETE /accounts/1 HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.method == "DELETE")
-        #expect(request?.path == "/accounts/1")
-    }
-
-    // MARK: - Malformed Requests
-
-    @Test func `returns nil for empty data`() {
-        let request = HTTPParser.parse(Data())
-        #expect(request == nil)
-    }
-
-    @Test func `returns nil for garbage data`() {
-        let request = HTTPParser.parse(Data("not http at all".utf8))
-        #expect(request == nil)
-    }
-
-    @Test func `returns nil for missing path`() {
-        let request = HTTPParser.parse(Data("GET\r\n\r\n".utf8))
-        #expect(request == nil)
-    }
-
-    @Test func `returns nil for missing HTTP version`() {
-        let request = HTTPParser.parse(Data("GET /health\r\n\r\n".utf8))
-        #expect(request == nil)
-    }
-
-    @Test func `returns nil for invalid HTTP version`() {
-        let request = HTTPParser.parse(Data("GET / GARBAGE\r\n\r\n".utf8))
-        #expect(request == nil)
-    }
-
-    @Test func `returns nil for missing header terminator`() {
-        // No \r\n\r\n — incomplete request
-        let request = HTTPParser.parse(Data("GET /health HTTP/1.1\r\nHost: localhost".utf8))
-        #expect(request == nil)
-    }
-
-    // MARK: - Edge Cases
-
-    @Test func `handles URL-encoded query values`() {
-        let raw = "GET /search?q=hello%20world HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.path == "/search")
-        // Raw value — decoding is caller's responsibility
-        #expect(request?.queryParams["q"] == "hello%20world")
-    }
-
-    @Test func `handles query key without value`() {
-        let raw = "GET /filter?verbose HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.path == "/filter")
-        // Key present with empty string value
-        #expect(request?.queryParams["verbose"]?.isEmpty == true)
-    }
-
-    @Test func `handles deeply nested path`() {
-        let raw = "GET /api/v1/accounts/123/positions HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request?.path == "/api/v1/accounts/123/positions")
-    }
-
-    @Test func `rejects request line longer than 8192 bytes`() {
-        let longPath = String(repeating: "a", count: 8200)
-        let raw = "GET /\(longPath) HTTP/1.1\r\n\r\n"
-        let request = HTTPParser.parse(Data(raw.utf8))
-
-        #expect(request == nil)
-    }
-}
+#endif

--- a/project.yml
+++ b/project.yml
@@ -51,6 +51,7 @@ targets:
       path: Sources/Portu/Resources/Portu.entitlements
       properties:
         com.apple.security.network.client: true
+        com.apple.security.network.server: true
 
   PortuTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

Closes #38 (part of #37 epic)

- Add `DebugServer` — a `@MainActor` HTTP server using `NWListener` bound to `127.0.0.1` with configurable port, routing table, `/health` endpoint, and 404 fallback
- Add `HTTPParser` — minimal HTTP/1.1 request parser extracting method, path, and query parameters
- Add `network.server` entitlement for NWListener port binding
- All debug server code is `#if DEBUG` guarded — no server code or attack surface in Release builds

## Files

| File | Purpose |
|------|---------|
| `Sources/Portu/Debug/HTTPParser.swift` | `HTTPRequest`, `HTTPResponse` types + `HTTPParser.parse()` |
| `Sources/Portu/Debug/DebugServer.swift` | `NWListener` server, routing, `/health`, 404 fallback |
| `Tests/PortuTests/HTTPParserTests.swift` | 14 parser tests (valid requests, malformed input, edge cases) |
| `Tests/PortuTests/DebugServerTests.swift` | 6 integration tests (health, 404, stop, port-in-use, localhost, uptime) |
| `Portu.entitlements` | Added `com.apple.security.network.server` |
| `project.yml` | Added `network.server` entitlement property |

## Test plan

- [x] `just build` succeeds
- [x] `just test` — 182/182 tests pass (20 new)
- [x] `just lint` — no new warnings
- [x] HTTPParser: GET parsing, query params, malformed input, 8KB limit
- [x] DebugServer: health returns 200 JSON, unknown paths return 404, stop cancels listener, port-in-use throws, localhost-only binding, uptime increases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug-only local HTTP server with start/stop lifecycle, routing, JSON responses, and a built-in /health endpoint.
  * Added lightweight HTTP request/response parsing utilities for routing and query extraction.

* **Infrastructure**
  * Enabled local server networking entitlement for debug builds.

* **Tests**
  * Added end-to-end server tests and parser unit tests covering lifecycle, /health, 404s, port conflicts, connectivity, uptime, and parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->