### PR TITLE
feat: network request logger via URLProtocol with ring buffer

### DIFF
--- a/Sources/Portu/Debug/NetworkLogger.swift
+++ b/Sources/Portu/Debug/NetworkLogger.swift
@@ -35,9 +35,10 @@ actor NetworkLogBuffer {
     private var buffer: [NetworkLogEntry?]
     private var writeIndex = 0
     private var filled = 0
-    let capacity: Int
+    private let capacity: Int
 
     init(capacity: Int = 500) {
+        precondition(capacity > 0, "NetworkLogBuffer capacity must be positive")
         self.capacity = capacity
         self.buffer = Array(repeating: nil, count: capacity)
     }
@@ -60,8 +61,8 @@ actor NetworkLogBuffer {
                 result.append(entry)
             }
         }
-        if let limit { return Array(result.suffix(limit)) }
-        return result
+        guard let limit, limit > 0 else { return result }
+        return Array(result.suffix(limit))
     }
 
     var entryCount: Int {
@@ -77,12 +78,14 @@ actor NetworkLogBuffer {
 
 // MARK: - NetworkLogger
 
+/// URLProtocol serializes startLoading, stopLoading, and all URLSessionDataDelegate
+/// callbacks on its own private queue, so mutable instance state is single-threaded.
 final class NetworkLogger: URLProtocol, @unchecked Sendable {
     private static let handledKey = "NetworkLogger.handled"
     private var internalSession: URLSession?
     private var internalTask: URLSessionDataTask?
     private var startTime: Date?
-    private var responseData = Data()
+    private var responseSizeCounter = 0
 
     /// Test hook: protocol classes prepended to the internal forwarding session.
     /// Globally registered protocols don't apply to URLSession(configuration:) sessions,
@@ -91,7 +94,10 @@ final class NetworkLogger: URLProtocol, @unchecked Sendable {
 
     // swiftlint:disable:next static_over_final_class
     override class func canInit(with request: URLRequest) -> Bool {
-        URLProtocol.property(forKey: handledKey, in: request) == nil
+        guard let scheme = request.url?.scheme, scheme == "http" || scheme == "https" else {
+            return false
+        }
+        return URLProtocol.property(forKey: handledKey, in: request) == nil
     }
 
     // swiftlint:disable:next static_over_final_class
@@ -141,7 +147,7 @@ extension NetworkLogger: URLSessionDataDelegate {
     }
 
     func urlSession(_: URLSession, dataTask _: URLSessionDataTask, didReceive data: Data) {
-        responseData.append(data)
+        responseSizeCounter += data.count
         client?.urlProtocol(self, didLoad: data)
     }
 
@@ -156,12 +162,11 @@ extension NetworkLogger: URLSessionDataDelegate {
             url: request.url?.absoluteString ?? "unknown",
             method: request.httpMethod ?? "GET",
             statusCode: statusCode,
-            responseSizeBytes: responseData.count,
+            responseSizeBytes: responseSizeCounter,
             elapsed: elapsed,
             headers: NetworkLogEntry.redactHeaders(headers),
             errorDescription: error?.localizedDescription)
 
-        responseData = Data()
         Task { await NetworkLogBuffer.shared.append(entry) }
 
         if let error {

--- a/Sources/Portu/Debug/NetworkLogger.swift
+++ b/Sources/Portu/Debug/NetworkLogger.swift
@@ -61,7 +61,8 @@ actor NetworkLogBuffer {
                 result.append(entry)
             }
         }
-        guard let limit, limit > 0 else { return result }
+        guard let limit else { return result }
+        guard limit > 0 else { return [] }
         return Array(result.suffix(limit))
     }
 

--- a/Sources/Portu/Debug/NetworkLogger.swift
+++ b/Sources/Portu/Debug/NetworkLogger.swift
@@ -88,10 +88,12 @@ final class NetworkLogger: URLProtocol, @unchecked Sendable {
     private var startTime: Date?
     private var responseSizeCounter = 0
 
-    /// Test hook: protocol classes prepended to the internal forwarding session.
-    /// Globally registered protocols don't apply to URLSession(configuration:) sessions,
-    /// so tests inject a mock responder here instead.
-    nonisolated(unsafe) static var forwardingProtocolClasses: [AnyClass] = []
+    #if DEBUG
+        /// Test hook: protocol classes prepended to the internal forwarding session.
+        /// Globally registered protocols don't apply to URLSession(configuration:) sessions,
+        /// so tests inject a mock responder here instead.
+        nonisolated(unsafe) static var forwardingProtocolClasses: [AnyClass] = []
+    #endif
 
     // swiftlint:disable:next static_over_final_class
     override class func canInit(with request: URLRequest) -> Bool {
@@ -114,9 +116,11 @@ final class NetworkLogger: URLProtocol, @unchecked Sendable {
         }
         URLProtocol.setProperty(true, forKey: Self.handledKey, in: mutable)
         let config = URLSessionConfiguration.default
-        if !Self.forwardingProtocolClasses.isEmpty {
-            config.protocolClasses = Self.forwardingProtocolClasses + (config.protocolClasses ?? [])
-        }
+        #if DEBUG
+            if !Self.forwardingProtocolClasses.isEmpty {
+                config.protocolClasses = Self.forwardingProtocolClasses + (config.protocolClasses ?? [])
+            }
+        #endif
         internalSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
         internalTask = internalSession?.dataTask(with: mutable as URLRequest)
         internalTask?.resume()
@@ -130,6 +134,7 @@ final class NetworkLogger: URLProtocol, @unchecked Sendable {
 
     static func debugSession() -> URLSession {
         let config = URLSessionConfiguration.default
+        // Replace (not prepend) — this session is fully owned by the logger.
         config.protocolClasses = [NetworkLogger.self]
         return URLSession(configuration: config)
     }
@@ -168,6 +173,8 @@ extension NetworkLogger: URLSessionDataDelegate {
             headers: NetworkLogEntry.redactHeaders(headers),
             errorDescription: error?.localizedDescription)
 
+        // URLSessionDataDelegate is synchronous — bridge to the actor asynchronously.
+        // Entries appear after the next runloop turn; tests use waitForEntries() polling.
         Task { await NetworkLogBuffer.shared.append(entry) }
 
         if let error {

--- a/Sources/Portu/Debug/NetworkLogger.swift
+++ b/Sources/Portu/Debug/NetworkLogger.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+// MARK: - NetworkLogEntry
+
+struct NetworkLogEntry: Codable, Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let url: String
+    let method: String
+    let statusCode: Int?
+    let responseSizeBytes: Int
+    let elapsed: TimeInterval
+    let headers: [String: String]
+    var errorDescription: String? = nil
+
+    private static let sensitiveHeaderNames: Set<String> = [
+        "authorization", "api-key", "api-sign", "api-secret",
+        "cookie", "set-cookie"
+    ]
+
+    static func redactHeaders(_ headers: [String: String]) -> [String: String] {
+        var result = headers
+        for key in headers.keys where sensitiveHeaderNames.contains(key.lowercased()) {
+            result[key] = "***"
+        }
+        return result
+    }
+}
+
+// MARK: - NetworkLogBuffer
+
+actor NetworkLogBuffer {
+    static let shared = NetworkLogBuffer()
+
+    private var buffer: [NetworkLogEntry?]
+    private var writeIndex = 0
+    private var filled = 0
+    let capacity: Int
+
+    init(capacity: Int = 500) {
+        self.capacity = capacity
+        self.buffer = Array(repeating: nil, count: capacity)
+    }
+
+    func append(_ entry: NetworkLogEntry) {
+        buffer[writeIndex] = entry
+        writeIndex = (writeIndex + 1) % capacity
+        filled = min(filled + 1, capacity)
+    }
+
+    func entries(since: Date? = nil, limit: Int? = nil) -> [NetworkLogEntry] {
+        guard filled > 0 else { return [] }
+        let start = filled < capacity ? 0 : writeIndex
+        var result: [NetworkLogEntry] = []
+        result.reserveCapacity(filled)
+        for i in 0 ..< filled {
+            let index = (start + i) % capacity
+            if let entry = buffer[index] {
+                if let since, entry.timestamp < since { continue }
+                result.append(entry)
+            }
+        }
+        if let limit { return Array(result.suffix(limit)) }
+        return result
+    }
+
+    var entryCount: Int {
+        filled
+    }
+
+    func clear() {
+        buffer = Array(repeating: nil, count: capacity)
+        writeIndex = 0
+        filled = 0
+    }
+}
+
+// MARK: - NetworkLogger
+
+final class NetworkLogger: URLProtocol, @unchecked Sendable {
+    private static let handledKey = "NetworkLogger.handled"
+    private var internalSession: URLSession?
+    private var internalTask: URLSessionDataTask?
+    private var startTime: Date?
+    private var responseData = Data()
+
+    /// Test hook: protocol classes prepended to the internal forwarding session.
+    /// Globally registered protocols don't apply to URLSession(configuration:) sessions,
+    /// so tests inject a mock responder here instead.
+    nonisolated(unsafe) static var forwardingProtocolClasses: [AnyClass] = []
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool {
+        URLProtocol.property(forKey: handledKey, in: request) == nil
+    }
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        startTime = Date()
+        guard let mutable = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        URLProtocol.setProperty(true, forKey: Self.handledKey, in: mutable)
+        let config = URLSessionConfiguration.default
+        if !Self.forwardingProtocolClasses.isEmpty {
+            config.protocolClasses = Self.forwardingProtocolClasses + (config.protocolClasses ?? [])
+        }
+        internalSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+        internalTask = internalSession?.dataTask(with: mutable as URLRequest)
+        internalTask?.resume()
+    }
+
+    override func stopLoading() {
+        internalTask?.cancel()
+        internalSession?.invalidateAndCancel()
+        internalSession = nil
+    }
+
+    static func debugSession() -> URLSession {
+        let config = URLSessionConfiguration.default
+        config.protocolClasses = [NetworkLogger.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// MARK: - URLSessionDataDelegate
+
+extension NetworkLogger: URLSessionDataDelegate {
+    func urlSession(
+        _: URLSession,
+        dataTask _: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void) {
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        completionHandler(.allow)
+    }
+
+    func urlSession(_: URLSession, dataTask _: URLSessionDataTask, didReceive data: Data) {
+        responseData.append(data)
+        client?.urlProtocol(self, didLoad: data)
+    }
+
+    func urlSession(_: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
+        let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
+        let statusCode = (task.response as? HTTPURLResponse)?.statusCode
+        let headers = request.allHTTPHeaderFields ?? [:]
+
+        let entry = NetworkLogEntry(
+            id: UUID(),
+            timestamp: startTime ?? Date(),
+            url: request.url?.absoluteString ?? "unknown",
+            method: request.httpMethod ?? "GET",
+            statusCode: statusCode,
+            responseSizeBytes: responseData.count,
+            elapsed: elapsed,
+            headers: NetworkLogEntry.redactHeaders(headers),
+            errorDescription: error?.localizedDescription)
+
+        responseData = Data()
+        Task { await NetworkLogBuffer.shared.append(entry) }
+
+        if let error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        internalSession?.finishTasksAndInvalidate()
+        internalSession = nil
+    }
+}

--- a/Tests/PortuTests/NetworkLogBufferTests.swift
+++ b/Tests/PortuTests/NetworkLogBufferTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+@testable import Portu
+import Testing
+
+struct NetworkLogBufferTests {
+    private func makeEntry(
+        timestamp: Date = Date(),
+        url: String = "https://example.com",
+        method: String = "GET",
+        statusCode: Int? = 200,
+        responseSizeBytes: Int = 100,
+        elapsed: TimeInterval = 0.5,
+        headers: [String: String] = [:]) -> NetworkLogEntry {
+        NetworkLogEntry(
+            id: UUID(),
+            timestamp: timestamp,
+            url: url,
+            method: method,
+            statusCode: statusCode,
+            responseSizeBytes: responseSizeBytes,
+            elapsed: elapsed,
+            headers: headers)
+    }
+
+    @Test func `empty buffer returns empty array`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        let entries = await buffer.entries()
+        #expect(entries.isEmpty)
+        #expect(await buffer.entryCount == 0)
+    }
+
+    @Test func `append and retrieve single entry`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        let entry = makeEntry(url: "https://example.com/api")
+        await buffer.append(entry)
+        let entries = await buffer.entries()
+        #expect(entries.count == 1)
+        #expect(entries[0].url == "https://example.com/api")
+        #expect(await buffer.entryCount == 1)
+    }
+
+    @Test func `append multiple entries`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        for i in 0 ..< 5 {
+            await buffer.append(makeEntry(url: "https://example.com/\(i)"))
+        }
+        let entries = await buffer.entries()
+        #expect(entries.count == 5)
+        #expect(await buffer.entryCount == 5)
+    }
+
+    @Test func `overflow evicts oldest`() async {
+        let buffer = NetworkLogBuffer(capacity: 3)
+        await buffer.append(makeEntry(url: "https://first.com"))
+        await buffer.append(makeEntry(url: "https://second.com"))
+        await buffer.append(makeEntry(url: "https://third.com"))
+        await buffer.append(makeEntry(url: "https://fourth.com"))
+
+        let entries = await buffer.entries()
+        #expect(entries.count == 3)
+        #expect(entries[0].url == "https://second.com")
+        #expect(entries[1].url == "https://third.com")
+        #expect(entries[2].url == "https://fourth.com")
+        #expect(await buffer.entryCount == 3)
+    }
+
+    @Test func `overflow wraps multiple times`() async {
+        let buffer = NetworkLogBuffer(capacity: 3)
+        for i in 0 ..< 10 {
+            await buffer.append(makeEntry(url: "https://example.com/\(i)"))
+        }
+        let entries = await buffer.entries()
+        #expect(entries.count == 3)
+        #expect(entries[0].url == "https://example.com/7")
+        #expect(entries[1].url == "https://example.com/8")
+        #expect(entries[2].url == "https://example.com/9")
+    }
+
+    @Test func `entries filtered by since`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        let base = Date(timeIntervalSince1970: 1000)
+        await buffer.append(makeEntry(timestamp: base, url: "https://old.com"))
+        await buffer.append(makeEntry(timestamp: base.addingTimeInterval(10), url: "https://mid.com"))
+        await buffer.append(makeEntry(timestamp: base.addingTimeInterval(20), url: "https://new.com"))
+
+        let entries = await buffer.entries(since: base.addingTimeInterval(5))
+        #expect(entries.count == 2)
+        #expect(entries[0].url == "https://mid.com")
+        #expect(entries[1].url == "https://new.com")
+    }
+
+    @Test func `entries with limit`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        for i in 0 ..< 5 {
+            await buffer.append(makeEntry(url: "https://example.com/\(i)"))
+        }
+        let entries = await buffer.entries(limit: 2)
+        #expect(entries.count == 2)
+        #expect(entries[0].url == "https://example.com/3")
+        #expect(entries[1].url == "https://example.com/4")
+    }
+
+    @Test func `entries with since and limit`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        let base = Date(timeIntervalSince1970: 1000)
+        for i in 0 ..< 5 {
+            await buffer.append(makeEntry(
+                timestamp: base.addingTimeInterval(Double(i) * 10),
+                url: "https://example.com/\(i)"))
+        }
+        // since=15 keeps entries at t=20,30,40 → limit=2 takes last two
+        let entries = await buffer.entries(since: base.addingTimeInterval(15), limit: 2)
+        #expect(entries.count == 2)
+        #expect(entries[0].url == "https://example.com/3")
+        #expect(entries[1].url == "https://example.com/4")
+    }
+
+    @Test func `clear resets buffer`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        for _ in 0 ..< 5 {
+            await buffer.append(makeEntry())
+        }
+        await buffer.clear()
+        #expect(await buffer.entryCount == 0)
+        #expect(await buffer.entries().isEmpty)
+    }
+
+    @Test func `limit larger than count returns all`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        await buffer.append(makeEntry(url: "https://only.com"))
+        let entries = await buffer.entries(limit: 100)
+        #expect(entries.count == 1)
+        #expect(entries[0].url == "https://only.com")
+    }
+}

--- a/Tests/PortuTests/NetworkLogBufferTests.swift
+++ b/Tests/PortuTests/NetworkLogBufferTests.swift
@@ -115,6 +115,13 @@ struct NetworkLogBufferTests {
         #expect(entries[1].url == "https://example.com/4")
     }
 
+    @Test func `limit zero returns empty`() async {
+        let buffer = NetworkLogBuffer(capacity: 10)
+        await buffer.append(makeEntry(url: "https://example.com"))
+        let entries = await buffer.entries(limit: 0)
+        #expect(entries.isEmpty)
+    }
+
     @Test func `clear resets buffer`() async {
         let buffer = NetworkLogBuffer(capacity: 10)
         for _ in 0 ..< 5 {

--- a/Tests/PortuTests/NetworkLogEntryTests.swift
+++ b/Tests/PortuTests/NetworkLogEntryTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+@testable import Portu
+import Testing
+
+struct NetworkLogEntryTests {
+    @Test func `entry captures all metadata`() {
+        let entry = NetworkLogEntry(
+            id: UUID(),
+            timestamp: Date(),
+            url: "https://api.example.com/v1/data",
+            method: "POST",
+            statusCode: 200,
+            responseSizeBytes: 1024,
+            elapsed: 0.5,
+            headers: ["Content-Type": "application/json"])
+        #expect(entry.url == "https://api.example.com/v1/data")
+        #expect(entry.method == "POST")
+        #expect(entry.statusCode == 200)
+        #expect(entry.responseSizeBytes == 1024)
+        #expect(entry.elapsed == 0.5)
+        #expect(entry.errorDescription == nil)
+    }
+
+    @Test func `redacts authorization header`() {
+        let redacted = NetworkLogEntry.redactHeaders(["Authorization": "Bearer sk-12345"])
+        #expect(redacted["Authorization"] == "***")
+    }
+
+    @Test func `redacts API key header`() {
+        let redacted = NetworkLogEntry.redactHeaders(["API-Key": "my-secret-key"])
+        #expect(redacted["API-Key"] == "***")
+    }
+
+    @Test func `redacts API sign header`() {
+        let redacted = NetworkLogEntry.redactHeaders(["API-Sign": "hmac-signature"])
+        #expect(redacted["API-Sign"] == "***")
+    }
+
+    @Test func `redacts API secret header`() {
+        let redacted = NetworkLogEntry.redactHeaders(["API-Secret": "my-secret"])
+        #expect(redacted["API-Secret"] == "***")
+    }
+
+    @Test func `preserves non sensitive headers`() {
+        let redacted = NetworkLogEntry.redactHeaders([
+            "Content-Type": "application/json",
+            "Accept": "text/html"
+        ])
+        #expect(redacted["Content-Type"] == "application/json")
+        #expect(redacted["Accept"] == "text/html")
+    }
+
+    @Test func `mixed sensitive and non sensitive headers`() {
+        let redacted = NetworkLogEntry.redactHeaders([
+            "Authorization": "Bearer token",
+            "Content-Type": "application/json",
+            "API-Key": "key123"
+        ])
+        #expect(redacted["Authorization"] == "***")
+        #expect(redacted["Content-Type"] == "application/json")
+        #expect(redacted["API-Key"] == "***")
+    }
+
+    @Test func `case insensitive header redaction`() {
+        let redacted = NetworkLogEntry.redactHeaders([
+            "authorization": "Bearer token",
+            "api-key": "key"
+        ])
+        #expect(redacted["authorization"] == "***")
+        #expect(redacted["api-key"] == "***")
+    }
+
+    @Test func `redacts cookie headers`() {
+        let redacted = NetworkLogEntry.redactHeaders([
+            "Cookie": "session=abc123",
+            "Set-Cookie": "token=xyz",
+            "Accept": "text/html"
+        ])
+        #expect(redacted["Cookie"] == "***")
+        #expect(redacted["Set-Cookie"] == "***")
+        #expect(redacted["Accept"] == "text/html")
+    }
+
+    @Test func `empty headers returns empty`() {
+        let redacted = NetworkLogEntry.redactHeaders([:])
+        #expect(redacted.isEmpty)
+    }
+
+    @Test func `entry round trips codable`() throws {
+        let entry = NetworkLogEntry(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1000),
+            url: "https://example.com",
+            method: "GET",
+            statusCode: 200,
+            responseSizeBytes: 512,
+            elapsed: 1.0,
+            headers: ["Content-Type": "application/json"])
+        let data = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(NetworkLogEntry.self, from: data)
+        #expect(decoded.id == entry.id)
+        #expect(decoded.url == entry.url)
+        #expect(decoded.method == entry.method)
+        #expect(decoded.statusCode == entry.statusCode)
+        #expect(decoded.responseSizeBytes == entry.responseSizeBytes)
+    }
+
+    @Test func `nil status code for failed request`() {
+        let entry = NetworkLogEntry(
+            id: UUID(),
+            timestamp: Date(),
+            url: "https://example.com",
+            method: "GET",
+            statusCode: nil,
+            responseSizeBytes: 0,
+            elapsed: 0.1,
+            headers: [:],
+            errorDescription: "The Internet connection appears to be offline.")
+        #expect(entry.statusCode == nil)
+        #expect(entry.errorDescription == "The Internet connection appears to be offline.")
+    }
+}

--- a/Tests/PortuTests/NetworkLogEntryTests.swift
+++ b/Tests/PortuTests/NetworkLogEntryTests.swift
@@ -99,10 +99,14 @@ struct NetworkLogEntryTests {
         let data = try JSONEncoder().encode(entry)
         let decoded = try JSONDecoder().decode(NetworkLogEntry.self, from: data)
         #expect(decoded.id == entry.id)
+        #expect(decoded.timestamp == entry.timestamp)
         #expect(decoded.url == entry.url)
         #expect(decoded.method == entry.method)
         #expect(decoded.statusCode == entry.statusCode)
         #expect(decoded.responseSizeBytes == entry.responseSizeBytes)
+        #expect(decoded.elapsed == entry.elapsed)
+        #expect(decoded.headers == entry.headers)
+        #expect(decoded.errorDescription == entry.errorDescription)
     }
 
     @Test func `nil status code for failed request`() {

--- a/Tests/PortuTests/NetworkLoggerTests.swift
+++ b/Tests/PortuTests/NetworkLoggerTests.swift
@@ -36,6 +36,18 @@ private final class LoggerTestProtocol: URLProtocol, @unchecked Sendable {
     override func stopLoading() {}
 }
 
+// MARK: - Helpers
+
+private func waitForEntries(
+    in buffer: NetworkLogBuffer = .shared,
+    count: Int,
+    timeout: TimeInterval = 1.0) async throws {
+    let deadline = Date.now.addingTimeInterval(timeout)
+    while await buffer.entryCount < count, Date.now < deadline {
+        try await Task.sleep(for: .milliseconds(10))
+    }
+}
+
 // MARK: - Integration Tests
 
 @Suite(.serialized) struct NetworkLoggerTests {
@@ -59,8 +71,7 @@ private final class LoggerTestProtocol: URLProtocol, @unchecked Sendable {
         #expect(httpResponse.statusCode == 200)
         #expect(data == LoggerTestProtocol.responseBody)
 
-        // Allow the async Task inside NetworkLogger to complete
-        try await Task.sleep(for: .milliseconds(200))
+        try await waitForEntries(count: 1)
 
         let entries = await NetworkLogBuffer.shared.entries()
         #expect(entries.count == 1)
@@ -84,7 +95,7 @@ private final class LoggerTestProtocol: URLProtocol, @unchecked Sendable {
             #expect(error is URLError)
         }
 
-        try await Task.sleep(for: .milliseconds(200))
+        try await waitForEntries(count: 1)
 
         let entries = await NetworkLogBuffer.shared.entries()
         #expect(entries.count == 1)
@@ -99,11 +110,10 @@ private final class LoggerTestProtocol: URLProtocol, @unchecked Sendable {
         let session = NetworkLogger.debugSession()
         _ = try await session.data(from: #require(URL(string: "https://test.local/large")))
 
-        try await Task.sleep(for: .milliseconds(200))
+        try await waitForEntries(count: 1)
 
         let entries = await NetworkLogBuffer.shared.entries()
         #expect(entries.count == 1)
-        // Entry tracks size but has no body field — only metadata
         #expect(entries[0].responseSizeBytes == 4096)
     }
 
@@ -115,7 +125,7 @@ private final class LoggerTestProtocol: URLProtocol, @unchecked Sendable {
             _ = try await session.data(from: #require(URL(string: "https://test.local/req/\(i)")))
         }
 
-        try await Task.sleep(for: .milliseconds(200))
+        try await waitForEntries(count: 3)
 
         let entries = await NetworkLogBuffer.shared.entries()
         #expect(entries.count == 3)

--- a/Tests/PortuTests/NetworkLoggerTests.swift
+++ b/Tests/PortuTests/NetworkLoggerTests.swift
@@ -46,6 +46,10 @@ private func waitForEntries(
     while await buffer.entryCount < count, Date.now < deadline {
         try await Task.sleep(for: .milliseconds(10))
     }
+    let actual = await buffer.entryCount
+    if actual < count {
+        Issue.record("Timed out waiting for \(count) log entries; got \(actual) after \(timeout)s")
+    }
 }
 
 // MARK: - Integration Tests

--- a/Tests/PortuTests/NetworkLoggerTests.swift
+++ b/Tests/PortuTests/NetworkLoggerTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+@testable import Portu
+import Testing
+
+// MARK: - Mock Protocol for Integration Tests
+
+private final class LoggerTestProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var shouldFail = false
+    nonisolated(unsafe) static var responseBody = Data("test-response-body".utf8)
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host?.hasSuffix(".local") == true
+    }
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        if Self.shouldFail {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseBody)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Integration Tests
+
+@Suite(.serialized) struct NetworkLoggerTests {
+    init() async {
+        await NetworkLogBuffer.shared.clear()
+        LoggerTestProtocol.shouldFail = false
+        LoggerTestProtocol.responseBody = Data("test-response-body".utf8)
+        NetworkLogger.forwardingProtocolClasses = [LoggerTestProtocol.self]
+    }
+
+    @Test func `request through debug session gets logged`() async throws {
+        defer { NetworkLogger.forwardingProtocolClasses = [] }
+        let session = NetworkLogger.debugSession()
+        var request = try URLRequest(url: #require(URL(string: "https://test.local/api/v1/data")))
+        request.httpMethod = "POST"
+        request.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+        let httpResponse = try #require(response as? HTTPURLResponse)
+
+        #expect(httpResponse.statusCode == 200)
+        #expect(data == LoggerTestProtocol.responseBody)
+
+        // Allow the async Task inside NetworkLogger to complete
+        try await Task.sleep(for: .milliseconds(200))
+
+        let entries = await NetworkLogBuffer.shared.entries()
+        #expect(entries.count == 1)
+        let entry = entries[0]
+        #expect(entry.url == "https://test.local/api/v1/data")
+        #expect(entry.method == "POST")
+        #expect(entry.statusCode == 200)
+        #expect(entry.headers["Authorization"] == "***")
+        #expect(entry.responseSizeBytes == LoggerTestProtocol.responseBody.count)
+    }
+
+    @Test func `failed request logs nil status code and error`() async throws {
+        defer { NetworkLogger.forwardingProtocolClasses = [] }
+        LoggerTestProtocol.shouldFail = true
+
+        let session = NetworkLogger.debugSession()
+        do {
+            _ = try await session.data(from: #require(URL(string: "https://test.local/fail")))
+            Issue.record("Expected network error")
+        } catch {
+            #expect(error is URLError)
+        }
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let entries = await NetworkLogBuffer.shared.entries()
+        #expect(entries.count == 1)
+        #expect(entries[0].statusCode == nil)
+        #expect(entries[0].errorDescription != nil)
+    }
+
+    @Test func `response body is not captured`() async throws {
+        defer { NetworkLogger.forwardingProtocolClasses = [] }
+        LoggerTestProtocol.responseBody = Data(repeating: 0xFF, count: 4096)
+
+        let session = NetworkLogger.debugSession()
+        _ = try await session.data(from: #require(URL(string: "https://test.local/large")))
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let entries = await NetworkLogBuffer.shared.entries()
+        #expect(entries.count == 1)
+        // Entry tracks size but has no body field — only metadata
+        #expect(entries[0].responseSizeBytes == 4096)
+    }
+
+    @Test func `multiple requests all logged`() async throws {
+        defer { NetworkLogger.forwardingProtocolClasses = [] }
+        let session = NetworkLogger.debugSession()
+
+        for i in 0 ..< 3 {
+            _ = try await session.data(from: #require(URL(string: "https://test.local/req/\(i)")))
+        }
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let entries = await NetworkLogBuffer.shared.entries()
+        #expect(entries.count == 3)
+        #expect(entries[0].url == "https://test.local/req/0")
+        #expect(entries[1].url == "https://test.local/req/1")
+        #expect(entries[2].url == "https://test.local/req/2")
+    }
+
+    @Test func `debug session works identically to shared`() async throws {
+        defer { NetworkLogger.forwardingProtocolClasses = [] }
+        let session = NetworkLogger.debugSession()
+        let (data, response) = try await session.data(from: #require(URL(string: "https://test.local/identity")))
+        let httpResponse = try #require(response as? HTTPURLResponse)
+
+        #expect(httpResponse.statusCode == 200)
+        #expect(data == LoggerTestProtocol.responseBody)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #39 (part of #37)

- **`NetworkLogEntry`** — `Sendable`, `Codable` struct capturing URL, method, status code, response size, elapsed time, timestamp, and redacted headers
- **`NetworkLogBuffer`** — actor-isolated ring buffer (500 entries) with `entries(since:limit:)` query API
- **`NetworkLogger`** — `URLProtocol` subclass that intercepts requests via a private forwarding session, logs metadata, and delivers data transparently to callers
- **`debugSession()`** — factory method returning a drop-in `URLSession` with logging enabled
- Header redaction covers `Authorization`, `API-Key`, `API-Sign`, `API-Secret`, `Cookie`, `Set-Cookie` (case-insensitive)
- Response bodies are never captured — only byte count is recorded

## Test plan

- [x] `NetworkLogBufferTests` (10 tests) — append, overflow eviction, wrap-around, since/limit filtering, clear, edge cases
- [x] `NetworkLogEntryTests` (12 tests) — all sensitive headers redacted, case-insensitive matching, cookie headers, Codable round-trip, nil status code
- [x] `NetworkLoggerTests` (5 tests) — end-to-end URLProtocol interception, failed request logging, body-not-captured verification, multiple requests, identity check
- [x] Full test suite passes (186+ tests)
- [x] Build succeeds (Debug)
- [x] SwiftLint clean (zero errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network activity logging with per-request metadata (URL, method, status, response size, elapsed time, headers with sensitive values redacted) and in-app query/clear capabilities for debugging.

* **Tests**
  * Added comprehensive tests for logging, buffer behavior (capacity/ordering), header redaction, serialization, and end-to-end integration of the logger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->