### PR TITLE
refactor: use atomic GitHub review API for code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,12 +77,15 @@ jobs:
 
             Note: The PR branch is already checked out in the current working directory.
 
-            Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
+            Submit all feedback as a single atomic GitHub review:
+            1. Create a pending review with `mcp__github__pull_request_review_write` (method: "create", no event).
+            2. Add inline comments with `mcp__github__add_comment_to_pending_review` (path, line, body).
+            3. Submit the review with `mcp__github__pull_request_review_write` (method: "submit_pending", event: "COMMENT", body: summary).
+            IMPORTANT: Never use event "APPROVE" or "REQUEST_CHANGES" — always use "COMMENT".
+            Only post GitHub review comments — don't submit review text as messages.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review,Bash(gh pr diff:*),Bash(gh pr view:*)"
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Switch from individual `mcp__github_inline_comment__create_inline_comment` + `gh pr comment` to the GitHub MCP server's pending review workflow
- All review feedback now lands as a single atomic GitHub review (create → add inline comments → submit)
- Restricted to `event: "COMMENT"` only — prevents accidental APPROVE/REQUEST_CHANGES

## Test plan
- [ ] Open a test PR and verify the Claude Code review action triggers
- [ ] Confirm the GitHub MCP server (`mcp__github__*`) is provisioned (check action logs for MCP server setup)
- [ ] Verify inline comments + summary appear as one grouped review, not scattered comments
- [ ] Confirm no APPROVE/REQUEST_CHANGES events are submitted