### PR TITLE
refactor: use gh api for atomic PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,21 +87,23 @@ jobs:
               -f body="<your overall review summary>" \
               -f 'comments[0][path]=<file>' \
               -f 'comments[0][line]=<line_number>' \
+              -f 'comments[0][side]=RIGHT' \
               -f 'comments[0][body]=<comment text>' \
               -f 'comments[1][path]=<file>' \
               -f 'comments[1][line]=<line_number>' \
+              -f 'comments[1][side]=RIGHT' \
               -f 'comments[1][body]=<comment text>'
             ```
 
             Rules:
             - Increment the array index (comments[0], comments[1], ...) for each inline comment.
-            - `line` is the line number in the diff hunk (last line of the relevant range).
+            - `line` is the file line number on the new version of the file. Always use `side=RIGHT`.
             - IMPORTANT: Never use event "APPROVE" or "REQUEST_CHANGES" — always use "COMMENT".
             - If you have no inline comments, omit the comments array entirely and just post the body.
             - Only post GitHub review comments — don't submit review text as messages.
 
           claude_args: |
-            --allowedTools "Bash(gh api repos/*/pulls/*/reviews:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,15 +77,31 @@ jobs:
 
             Note: The PR branch is already checked out in the current working directory.
 
-            Submit all feedback as a single atomic GitHub review:
-            1. Create a pending review with `mcp__github__pull_request_review_write` (method: "create", no event).
-            2. Add inline comments with `mcp__github__add_comment_to_pending_review` (path, line, body).
-            3. Submit the review with `mcp__github__pull_request_review_write` (method: "submit_pending", event: "COMMENT", body: summary).
-            IMPORTANT: Never use event "APPROVE" or "REQUEST_CHANGES" — always use "COMMENT".
-            Only post GitHub review comments — don't submit review text as messages.
+            Submit all feedback as a single atomic GitHub review using `gh api`.
+            Build ONE `gh api` call that creates the review with all inline comments at once:
+
+            ```
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+              --method POST \
+              -f event="COMMENT" \
+              -f body="<your overall review summary>" \
+              -f 'comments[0][path]=<file>' \
+              -f 'comments[0][line]=<line_number>' \
+              -f 'comments[0][body]=<comment text>' \
+              -f 'comments[1][path]=<file>' \
+              -f 'comments[1][line]=<line_number>' \
+              -f 'comments[1][body]=<comment text>'
+            ```
+
+            Rules:
+            - Increment the array index (comments[0], comments[1], ...) for each inline comment.
+            - `line` is the line number in the diff hunk (last line of the relevant range).
+            - IMPORTANT: Never use event "APPROVE" or "REQUEST_CHANGES" — always use "COMMENT".
+            - If you have no inline comments, omit the comments array entirely and just post the body.
+            - Only post GitHub review comments — don't submit review text as messages.
 
           claude_args: |
-            --allowedTools "mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review,Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Bash(gh api repos/*/pulls/*/reviews:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

- Replace 3-step MCP review flow (`mcp__github__pull_request_review_write` + `mcp__github__add_comment_to_pending_review`) with a single atomic `gh api` call to `POST /repos/.../pulls/.../reviews`
- Scope `allowedTools` from `Bash(gh api:*)` to `Bash(gh api repos/*/pulls/*/reviews:*)` for least privilege
- Inline the repo/PR values directly in the example call instead of requiring an extra mapping step

## Why

The MCP review tools weren't reliably creating reviews in the Claude Code Action environment. The `gh api` approach is simpler (one call vs three), atomic (all-or-nothing), and uses `gh` which is pre-installed and auto-authenticated on GitHub runners.

## Test plan

- [ ] Open a test PR and verify the review workflow triggers
- [ ] Confirm the review appears as a single review with inline comments (not individual comment posts)
- [ ] Verify the `allowedTools` scope blocks unrelated `gh api` calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal code review workflow automation to streamline development processes and improve efficiency of review creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->