### PR TITLE
feat: SwiftData state query endpoints for debug server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,8 @@ The app target (`Sources/Portu/`) imports all three and contains features, app s
 ## Testing
 
 - Use **Swift Testing** (`import Testing`), not XCTest
-- Syntax: `@Suite`, `@Test`, `#expect()`, `#require()`, async test methods
+- Syntax: `@Test`, `#expect()`, `#require()`, async test methods
+- Use `@Suite(.serialized)` only when tests share mutable state — do not add plain `@Suite` without traits
 - Tests live in each package's `Tests/` directory and `Tests/PortuTests/`
 
 ## TDD Rules

--- a/Sources/Portu/Debug/DebugEndpoints.swift
+++ b/Sources/Portu/Debug/DebugEndpoints.swift
@@ -1,0 +1,291 @@
+#if DEBUG
+
+    import Foundation
+    import PortuCore
+    import SwiftData
+
+    @MainActor
+    enum DebugEndpoints {
+        private static let iso8601: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+
+        // MARK: - Route Registration
+
+        static func register(on server: DebugServer, modelContainer: ModelContainer) {
+            server.addRoute("GET", "/state/accounts") { _ in
+                accounts(context: ModelContext(modelContainer))
+            }
+
+            server.addRoute("GET", "/state/positions") { request in
+                positions(context: ModelContext(modelContainer), request: request)
+            }
+
+            server.addRoute("GET", "/state/assets") { request in
+                assets(context: ModelContext(modelContainer), request: request)
+            }
+
+            server.addRoute("GET", "/state/snapshots/portfolio") { request in
+                portfolioSnapshots(context: ModelContext(modelContainer), request: request)
+            }
+
+            server.addRoute("GET", "/state/snapshots/account") { request in
+                accountSnapshots(context: ModelContext(modelContainer), request: request)
+            }
+
+            server.addRoute("GET", "/state/snapshots/asset") { request in
+                assetSnapshots(context: ModelContext(modelContainer), request: request)
+            }
+
+            server.addRoute("GET", "/network/log") { request in
+                await networkLog(request: request)
+            }
+        }
+
+        // MARK: - /state/accounts
+
+        static func accounts(context: ModelContext) -> HTTPResponse {
+            guard let accounts = try? context.fetch(FetchDescriptor<Account>()) else {
+                return errorResponse("Failed to fetch accounts")
+            }
+            let body: [[String: any Sendable]] = accounts.map { account in
+                var dict: [String: any Sendable] = [
+                    "id": account.id.uuidString,
+                    "name": account.name,
+                    "kind": account.kind.rawValue,
+                    "dataSource": account.dataSource.rawValue,
+                    "isActive": account.isActive,
+                    "positionCount": account.positions.count
+                ]
+                if let date = account.lastSyncedAt {
+                    dict["lastSyncedAt"] = iso8601.string(from: date)
+                }
+                if let error = account.lastSyncError {
+                    dict["lastSyncError"] = error
+                }
+                return dict
+            }
+            return jsonArrayResponse(body)
+        }
+
+        // MARK: - /state/positions
+
+        static func positions(context: ModelContext, request: HTTPRequest) -> HTTPResponse {
+            if let rawId = request.queryParams["accountId"] {
+                guard let accountId = UUID(uuidString: rawId) else {
+                    return errorResponse("Invalid accountId", statusCode: 400)
+                }
+                guard let positions = try? context.fetch(FetchDescriptor<Position>()) else {
+                    return errorResponse("Failed to fetch positions")
+                }
+                let filtered = positions.filter { $0.account?.id == accountId }
+                return jsonArrayResponse(filtered.map(positionDict))
+            }
+
+            guard let positions = try? context.fetch(FetchDescriptor<Position>()) else {
+                return errorResponse("Failed to fetch positions")
+            }
+            return jsonArrayResponse(positions.map(positionDict))
+        }
+
+        private static func positionDict(_ position: Position) -> [String: any Sendable] {
+            var dict: [String: any Sendable] = [
+                "id": position.id.uuidString,
+                "positionType": position.positionType.rawValue,
+                "netUSDValue": position.netUSDValue.jsonDouble,
+                "tokenCount": position.tokens.count
+            ]
+            if let chain = position.chain {
+                dict["chain"] = chain.rawValue
+            }
+            if let name = position.protocolName {
+                dict["protocolName"] = name
+            }
+            return dict
+        }
+
+        // MARK: - /state/assets
+
+        static func assets(context: ModelContext, request: HTTPRequest) -> HTTPResponse {
+            let limit = request.intParam("limit", default: 50)
+            let offset = request.intParam("offset", default: 0)
+
+            guard let allAssets = try? context.fetch(FetchDescriptor<Asset>()) else {
+                return errorResponse("Failed to fetch assets")
+            }
+
+            let paginated = Array(allAssets.dropFirst(offset).prefix(limit))
+            let body: [[String: any Sendable]] = paginated.map { asset in
+                var dict: [String: any Sendable] = [
+                    "id": asset.id.uuidString,
+                    "symbol": asset.symbol,
+                    "name": asset.name,
+                    "category": asset.category.rawValue,
+                    "isVerified": asset.isVerified
+                ]
+                if let geckoId = asset.coinGeckoId {
+                    dict["coinGeckoId"] = geckoId
+                }
+                return dict
+            }
+            return jsonArrayResponse(body)
+        }
+
+        // MARK: - /state/snapshots/portfolio
+
+        static func portfolioSnapshots(context: ModelContext, request: HTTPRequest) -> HTTPResponse {
+            let limit = request.intParam("limit", default: 10)
+
+            var descriptor = FetchDescriptor<PortfolioSnapshot>(
+                sortBy: [SortDescriptor(\.timestamp, order: .reverse)])
+            descriptor.fetchLimit = limit
+
+            guard let snapshots = try? context.fetch(descriptor) else {
+                return errorResponse("Failed to fetch portfolio snapshots")
+            }
+
+            let body: [[String: any Sendable]] = snapshots.map { snap in
+                [
+                    "id": snap.id.uuidString,
+                    "timestamp": iso8601.string(from: snap.timestamp),
+                    "totalValue": snap.totalValue.jsonDouble,
+                    "idleValue": snap.idleValue.jsonDouble,
+                    "deployedValue": snap.deployedValue.jsonDouble,
+                    "debtValue": snap.debtValue.jsonDouble,
+                    "isPartial": snap.isPartial
+                ]
+            }
+            return jsonArrayResponse(body)
+        }
+
+        // MARK: - /state/snapshots/account
+
+        static func accountSnapshots(context: ModelContext, request: HTTPRequest) -> HTTPResponse {
+            guard let rawId = request.queryParams["accountId"] else {
+                return errorResponse("Missing required parameter: accountId", statusCode: 400)
+            }
+            guard let accountId = UUID(uuidString: rawId) else {
+                return errorResponse("Invalid accountId", statusCode: 400)
+            }
+            let limit = request.intParam("limit", default: 10)
+
+            let descriptor = FetchDescriptor<AccountSnapshot>(
+                sortBy: [SortDescriptor(\.timestamp, order: .reverse)])
+
+            guard let snapshots = try? context.fetch(descriptor) else {
+                return errorResponse("Failed to fetch account snapshots")
+            }
+
+            let filtered = Array(snapshots.lazy.filter { $0.accountId == accountId }.prefix(limit))
+            let body: [[String: any Sendable]] = filtered.map { snap in
+                [
+                    "id": snap.id.uuidString,
+                    "timestamp": iso8601.string(from: snap.timestamp),
+                    "accountId": snap.accountId.uuidString,
+                    "totalValue": snap.totalValue.jsonDouble,
+                    "isFresh": snap.isFresh
+                ]
+            }
+            return jsonArrayResponse(body)
+        }
+
+        // MARK: - /state/snapshots/asset
+
+        static func assetSnapshots(context: ModelContext, request: HTTPRequest) -> HTTPResponse {
+            guard let rawId = request.queryParams["assetId"] else {
+                return errorResponse("Missing required parameter: assetId", statusCode: 400)
+            }
+            guard let assetId = UUID(uuidString: rawId) else {
+                return errorResponse("Invalid assetId", statusCode: 400)
+            }
+            let limit = request.intParam("limit", default: 10)
+
+            let descriptor = FetchDescriptor<AssetSnapshot>(
+                sortBy: [SortDescriptor(\.timestamp, order: .reverse)])
+
+            guard let snapshots = try? context.fetch(descriptor) else {
+                return errorResponse("Failed to fetch asset snapshots")
+            }
+
+            let filtered = Array(snapshots.lazy.filter { $0.assetId == assetId }.prefix(limit))
+            let body: [[String: any Sendable]] = filtered.map { snap in
+                [
+                    "id": snap.id.uuidString,
+                    "timestamp": iso8601.string(from: snap.timestamp),
+                    "assetId": snap.assetId.uuidString,
+                    "symbol": snap.symbol,
+                    "category": snap.category.rawValue,
+                    "amount": snap.amount.jsonDouble,
+                    "usdValue": snap.usdValue.jsonDouble,
+                    "borrowAmount": snap.borrowAmount.jsonDouble,
+                    "borrowUsdValue": snap.borrowUsdValue.jsonDouble
+                ]
+            }
+            return jsonArrayResponse(body)
+        }
+
+        // MARK: - /network/log
+
+        static func networkLog(
+            buffer: NetworkLogBuffer = .shared,
+            request: HTTPRequest) async -> HTTPResponse {
+            let limit = request.intParam("limit", default: 50)
+            let since = request.queryParams["since"].flatMap { iso8601.date(from: $0) }
+
+            let entries = await buffer.entries(since: since, limit: limit)
+            let body: [[String: any Sendable]] = entries.map { entry in
+                var dict: [String: any Sendable] = [
+                    "id": entry.id.uuidString,
+                    "timestamp": iso8601.string(from: entry.timestamp),
+                    "url": entry.url,
+                    "method": entry.method,
+                    "responseSizeBytes": entry.responseSizeBytes,
+                    "elapsed": entry.elapsed
+                ]
+                if let code = entry.statusCode {
+                    dict["statusCode"] = code
+                }
+                if let error = entry.errorDescription {
+                    dict["errorDescription"] = error
+                }
+                return dict
+            }
+            return jsonArrayResponse(body)
+        }
+
+        // MARK: - JSON Helpers
+
+        private static func jsonArrayResponse(_ body: [[String: any Sendable]], statusCode: Int = 200) -> HTTPResponse {
+            guard let data = try? JSONSerialization.data(withJSONObject: body) else {
+                return errorResponse("serialization failed")
+            }
+            return HTTPResponse(statusCode: statusCode, body: data)
+        }
+
+        private static func errorResponse(_ message: String, statusCode: Int = 500) -> HTTPResponse {
+            guard let data = try? JSONSerialization.data(withJSONObject: ["error": message]) else {
+                return HTTPResponse(statusCode: 500, body: Data("{\"error\":\"serialization failed\"}".utf8))
+            }
+            return HTTPResponse(statusCode: statusCode, body: data)
+        }
+    }
+
+    // MARK: - Query Param Helpers
+
+    extension HTTPRequest {
+        func intParam(_ key: String, default defaultValue: Int) -> Int {
+            queryParams[key].flatMap(Int.init) ?? defaultValue
+        }
+    }
+
+    // MARK: - Decimal JSON Serialization
+
+    extension Decimal {
+        var jsonDouble: Double {
+            (self as NSDecimalNumber).doubleValue
+        }
+    }
+
+#endif

--- a/Sources/Portu/Debug/DebugEndpoints.swift
+++ b/Sources/Portu/Debug/DebugEndpoints.swift
@@ -121,7 +121,7 @@
             let limit = request.intParam("limit", default: 50)
             let offset = request.intParam("offset", default: 0)
 
-            var descriptor = FetchDescriptor<Asset>(sortBy: [SortDescriptor(\.symbol)])
+            var descriptor = FetchDescriptor<Asset>(sortBy: [SortDescriptor(\.symbol), SortDescriptor(\.id)])
             descriptor.fetchOffset = offset
             descriptor.fetchLimit = limit
 

--- a/Sources/Portu/Debug/DebugEndpoints.swift
+++ b/Sources/Portu/Debug/DebugEndpoints.swift
@@ -12,6 +12,12 @@
             return formatter
         }()
 
+        private static let iso8601NoFractional: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter
+        }()
+
         // MARK: - Route Registration
 
         static func register(on server: DebugServer, modelContainer: ModelContainer) {
@@ -73,21 +79,21 @@
         // MARK: - /state/positions
 
         static func positions(context: ModelContext, request: HTTPRequest) -> HTTPResponse {
-            if let rawId = request.queryParams["accountId"] {
-                guard let accountId = UUID(uuidString: rawId) else {
-                    return errorResponse("Invalid accountId", statusCode: 400)
-                }
-                guard let positions = try? context.fetch(FetchDescriptor<Position>()) else {
-                    return errorResponse("Failed to fetch positions")
-                }
-                let filtered = positions.filter { $0.account?.id == accountId }
-                return jsonArrayResponse(filtered.map(positionDict))
-            }
+            let limit = request.intParam("limit", default: 100)
 
             guard let positions = try? context.fetch(FetchDescriptor<Position>()) else {
                 return errorResponse("Failed to fetch positions")
             }
-            return jsonArrayResponse(positions.map(positionDict))
+
+            if let rawId = request.queryParams["accountId"] {
+                guard let accountId = UUID(uuidString: rawId) else {
+                    return errorResponse("Invalid accountId", statusCode: 400)
+                }
+                let filtered = positions.filter { $0.account?.id == accountId }
+                return jsonArrayResponse(Array(filtered.prefix(limit)).map(positionDict))
+            }
+
+            return jsonArrayResponse(Array(positions.prefix(limit)).map(positionDict))
         }
 
         private static func positionDict(_ position: Position) -> [String: any Sendable] {
@@ -177,15 +183,15 @@
             }
             let limit = request.intParam("limit", default: 10)
 
-            let descriptor = FetchDescriptor<AccountSnapshot>(
+            var descriptor = FetchDescriptor<AccountSnapshot>(
+                predicate: #Predicate { $0.accountId == accountId },
                 sortBy: [SortDescriptor(\.timestamp, order: .reverse)])
+            descriptor.fetchLimit = limit
 
             guard let snapshots = try? context.fetch(descriptor) else {
                 return errorResponse("Failed to fetch account snapshots")
             }
-
-            let filtered = Array(snapshots.lazy.filter { $0.accountId == accountId }.prefix(limit))
-            let body: [[String: any Sendable]] = filtered.map { snap in
+            let body: [[String: any Sendable]] = snapshots.map { snap in
                 [
                     "id": snap.id.uuidString,
                     "timestamp": iso8601.string(from: snap.timestamp),
@@ -208,15 +214,15 @@
             }
             let limit = request.intParam("limit", default: 10)
 
-            let descriptor = FetchDescriptor<AssetSnapshot>(
+            var descriptor = FetchDescriptor<AssetSnapshot>(
+                predicate: #Predicate { $0.assetId == assetId },
                 sortBy: [SortDescriptor(\.timestamp, order: .reverse)])
+            descriptor.fetchLimit = limit
 
             guard let snapshots = try? context.fetch(descriptor) else {
                 return errorResponse("Failed to fetch asset snapshots")
             }
-
-            let filtered = Array(snapshots.lazy.filter { $0.assetId == assetId }.prefix(limit))
-            let body: [[String: any Sendable]] = filtered.map { snap in
+            let body: [[String: any Sendable]] = snapshots.map { snap in
                 [
                     "id": snap.id.uuidString,
                     "timestamp": iso8601.string(from: snap.timestamp),
@@ -240,7 +246,8 @@
             let limit = request.intParam("limit", default: 50)
             let since: Date?
             if let rawSince = request.queryParams["since"] {
-                guard let parsed = iso8601.date(from: rawSince.removingPercentEncoding ?? rawSince) else {
+                let decoded = rawSince.removingPercentEncoding ?? rawSince
+                guard let parsed = iso8601.date(from: decoded) ?? iso8601NoFractional.date(from: decoded) else {
                     return errorResponse("Invalid since parameter", statusCode: 400)
                 }
                 since = parsed
@@ -293,7 +300,7 @@
 
     extension HTTPRequest {
         func intParam(_ key: String, default defaultValue: Int) -> Int {
-            max(queryParams[key].flatMap(Int.init) ?? defaultValue, 0)
+            min(max(queryParams[key].flatMap(Int.init) ?? defaultValue, 0), 1000)
         }
     }
 

--- a/Sources/Portu/Debug/DebugEndpoints.swift
+++ b/Sources/Portu/Debug/DebugEndpoints.swift
@@ -103,6 +103,9 @@
             if let name = position.protocolName {
                 dict["protocolName"] = name
             }
+            if let accountId = position.account?.id {
+                dict["accountId"] = accountId.uuidString
+            }
             return dict
         }
 
@@ -112,12 +115,15 @@
             let limit = request.intParam("limit", default: 50)
             let offset = request.intParam("offset", default: 0)
 
-            guard let allAssets = try? context.fetch(FetchDescriptor<Asset>()) else {
+            var descriptor = FetchDescriptor<Asset>(sortBy: [SortDescriptor(\.symbol)])
+            descriptor.fetchOffset = offset
+            descriptor.fetchLimit = limit
+
+            guard let assets = try? context.fetch(descriptor) else {
                 return errorResponse("Failed to fetch assets")
             }
 
-            let paginated = Array(allAssets.dropFirst(offset).prefix(limit))
-            let body: [[String: any Sendable]] = paginated.map { asset in
+            let body: [[String: any Sendable]] = assets.map { asset in
                 var dict: [String: any Sendable] = [
                     "id": asset.id.uuidString,
                     "symbol": asset.symbol,
@@ -232,7 +238,15 @@
             buffer: NetworkLogBuffer = .shared,
             request: HTTPRequest) async -> HTTPResponse {
             let limit = request.intParam("limit", default: 50)
-            let since = request.queryParams["since"].flatMap { iso8601.date(from: $0) }
+            let since: Date?
+            if let rawSince = request.queryParams["since"] {
+                guard let parsed = iso8601.date(from: rawSince.removingPercentEncoding ?? rawSince) else {
+                    return errorResponse("Invalid since parameter", statusCode: 400)
+                }
+                since = parsed
+            } else {
+                since = nil
+            }
 
             let entries = await buffer.entries(since: since, limit: limit)
             let body: [[String: any Sendable]] = entries.map { entry in
@@ -249,6 +263,9 @@
                 }
                 if let error = entry.errorDescription {
                     dict["errorDescription"] = error
+                }
+                if !entry.headers.isEmpty {
+                    dict["headers"] = entry.headers
                 }
                 return dict
             }
@@ -276,7 +293,7 @@
 
     extension HTTPRequest {
         func intParam(_ key: String, default defaultValue: Int) -> Int {
-            queryParams[key].flatMap(Int.init) ?? defaultValue
+            max(queryParams[key].flatMap(Int.init) ?? defaultValue, 0)
         }
     }
 

--- a/Sources/Portu/Debug/DebugEndpoints.swift
+++ b/Sources/Portu/Debug/DebugEndpoints.swift
@@ -81,19 +81,23 @@
         static func positions(context: ModelContext, request: HTTPRequest) -> HTTPResponse {
             let limit = request.intParam("limit", default: 100)
 
-            guard let positions = try? context.fetch(FetchDescriptor<Position>()) else {
-                return errorResponse("Failed to fetch positions")
-            }
-
             if let rawId = request.queryParams["accountId"] {
                 guard let accountId = UUID(uuidString: rawId) else {
                     return errorResponse("Invalid accountId", statusCode: 400)
+                }
+                guard let positions = try? context.fetch(FetchDescriptor<Position>()) else {
+                    return errorResponse("Failed to fetch positions")
                 }
                 let filtered = positions.filter { $0.account?.id == accountId }
                 return jsonArrayResponse(Array(filtered.prefix(limit)).map(positionDict))
             }
 
-            return jsonArrayResponse(Array(positions.prefix(limit)).map(positionDict))
+            var descriptor = FetchDescriptor<Position>()
+            descriptor.fetchLimit = limit
+            guard let positions = try? context.fetch(descriptor) else {
+                return errorResponse("Failed to fetch positions")
+            }
+            return jsonArrayResponse(positions.map(positionDict))
         }
 
         private static func positionDict(_ position: Position) -> [String: any Sendable] {

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -11,14 +11,13 @@
         private let port: UInt16
         private var listener: NWListener?
         private var startingListener: NWListener?
-        private var routes: [String: [String: @MainActor (HTTPRequest) -> HTTPResponse]] = [:]
+        private var routes: [String: [String: @MainActor (HTTPRequest) async -> HTTPResponse]] = [:]
         private var activeConnections: [ObjectIdentifier: NWConnection] = [:]
         private let startTime = ContinuousClock.now
         private let logger = Logger(subsystem: "com.portu.app", category: "DebugServer")
 
-        // Stored for future endpoints (sub-issues #3, #4)
         private let modelContainer: ModelContainer?
-        private let store: StoreOf<AppFeature>?
+        private let store: StoreOf<AppFeature>? // sub-issue #4: TCA state endpoints
 
         init(
             port: UInt16 = 9999,
@@ -28,6 +27,9 @@
             self.modelContainer = modelContainer
             self.store = store
             registerBuiltInRoutes()
+            if let modelContainer {
+                DebugEndpoints.register(on: self, modelContainer: modelContainer)
+            }
         }
 
         // MARK: - Lifecycle
@@ -115,7 +117,7 @@
 
         // MARK: - Routing
 
-        func addRoute(_ method: String, _ path: String, handler: @MainActor @escaping (HTTPRequest) -> HTTPResponse) {
+        func addRoute(_ method: String, _ path: String, handler: @MainActor @escaping (HTTPRequest) async -> HTTPResponse) {
             routes[path, default: [:]][method] = handler
         }
 
@@ -179,7 +181,7 @@
                     let response: HTTPResponse = if
                         let pathRoutes = self.routes[request.path],
                         let handler = pathRoutes[request.method] {
-                        handler(request)
+                        await handler(request)
                     } else {
                         Self.jsonResponse(statusCode: 404, body: ["error": "Not found"])
                     }

--- a/Tests/PortuTests/DebugEndpointsTests.swift
+++ b/Tests/PortuTests/DebugEndpointsTests.swift
@@ -1,0 +1,404 @@
+#if DEBUG
+    import Foundation
+    @testable import Portu
+    import PortuCore
+    import SwiftData
+    import Testing
+
+    @MainActor
+    struct DebugEndpointsTests {
+        private func makeTestContainer() throws -> ModelContainer {
+            let schema = Schema([
+                Account.self, WalletAddress.self, Position.self,
+                PositionToken.self, Asset.self,
+                PortfolioSnapshot.self, AccountSnapshot.self, AssetSnapshot.self
+            ])
+            let config = ModelConfiguration(isStoredInMemoryOnly: true)
+            return try ModelContainer(for: schema, configurations: [config])
+        }
+
+        // MARK: - /state/accounts
+
+        @Test func `accounts returns all accounts with correct fields`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let syncDate = Date(timeIntervalSince1970: 1_700_000_000)
+            let token = PositionToken(role: .balance, amount: 10, usdValue: 500)
+            let position = Position(positionType: .idle, netUSDValue: 500, tokens: [token])
+            let account = Account(
+                name: "My Wallet", kind: .wallet, dataSource: .zapper,
+                positions: [position], lastSyncedAt: syncDate, lastSyncError: "timeout")
+            context.insert(account)
+            try context.save()
+
+            let response = DebugEndpoints.accounts(context: context)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            let item = json[0]
+            #expect(item["name"] as? String == "My Wallet")
+            #expect(item["kind"] as? String == "wallet")
+            #expect(item["dataSource"] as? String == "zapper")
+            #expect(item["isActive"] as? Bool == true)
+            #expect(item["positionCount"] as? Int == 1)
+            #expect(item["lastSyncedAt"] != nil)
+            #expect(item["lastSyncError"] as? String == "timeout")
+        }
+
+        @Test func `accounts empty database returns empty array`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let response = DebugEndpoints.accounts(context: context)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.isEmpty)
+        }
+
+        // MARK: - /state/positions
+
+        @Test func `positions returns all positions`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let position = Position(
+                positionType: .lending, chain: .ethereum,
+                protocolName: "Aave", netUSDValue: 1000)
+            let account = Account(
+                name: "Wallet", kind: .wallet, dataSource: .zapper,
+                positions: [position])
+            context.insert(account)
+            try context.save()
+
+            let request = HTTPRequest(method: "GET", path: "/state/positions", queryParams: [:])
+            let response = DebugEndpoints.positions(context: context, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            #expect(json[0]["positionType"] as? String == "lending")
+            #expect(json[0]["chain"] as? String == "ethereum")
+            #expect(json[0]["protocolName"] as? String == "Aave")
+            #expect(json[0]["netUSDValue"] as? Double == 1000.0)
+            #expect(json[0]["tokenCount"] as? Int == 0)
+        }
+
+        @Test func `positions filters by accountId`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let pos1 = Position(positionType: .idle, netUSDValue: 100)
+            let pos2 = Position(positionType: .staking, netUSDValue: 200)
+            let account1 = Account(name: "A", kind: .wallet, dataSource: .zapper, positions: [pos1])
+            let account2 = Account(name: "B", kind: .wallet, dataSource: .zapper, positions: [pos2])
+            context.insert(account1)
+            context.insert(account2)
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/positions",
+                queryParams: ["accountId": account1.id.uuidString])
+            let response = DebugEndpoints.positions(context: context, request: request)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            #expect(json[0]["positionType"] as? String == "idle")
+        }
+
+        @Test func `positions invalid accountId returns 400`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/positions",
+                queryParams: ["accountId": "not-a-uuid"])
+            let response = DebugEndpoints.positions(context: context, request: request)
+            #expect(response.statusCode == 400)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+            #expect(json["error"] as? String == "Invalid accountId")
+        }
+
+        // MARK: - /state/assets
+
+        @Test func `assets returns paginated results`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            for i in 0 ..< 5 {
+                context.insert(Asset(symbol: "T\(i)", name: "Token \(i)", category: .other))
+            }
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/assets",
+                queryParams: ["limit": "2", "offset": "1"])
+            let response = DebugEndpoints.assets(context: context, request: request)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 2)
+        }
+
+        @Test func `assets includes correct fields`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let asset = Asset(
+                symbol: "ETH", name: "Ethereum",
+                coinGeckoId: "ethereum", category: .major, isVerified: true)
+            context.insert(asset)
+            try context.save()
+
+            let request = HTTPRequest(method: "GET", path: "/state/assets", queryParams: [:])
+            let response = DebugEndpoints.assets(context: context, request: request)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            let item = json[0]
+            #expect(item["symbol"] as? String == "ETH")
+            #expect(item["name"] as? String == "Ethereum")
+            #expect(item["coinGeckoId"] as? String == "ethereum")
+            #expect(item["category"] as? String == "major")
+            #expect(item["isVerified"] as? Bool == true)
+        }
+
+        // MARK: - /state/snapshots/portfolio
+
+        @Test func `portfolio snapshots sorted by timestamp desc`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let batchId = UUID()
+            let old = PortfolioSnapshot(
+                syncBatchId: batchId,
+                timestamp: Date(timeIntervalSince1970: 1_000_000),
+                totalValue: 100, idleValue: 50, deployedValue: 40,
+                debtValue: 10, isPartial: false)
+            let recent = PortfolioSnapshot(
+                syncBatchId: batchId,
+                timestamp: Date(timeIntervalSince1970: 2_000_000),
+                totalValue: 200, idleValue: 100, deployedValue: 80,
+                debtValue: 20, isPartial: true)
+            context.insert(old)
+            context.insert(recent)
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/portfolio",
+                queryParams: ["limit": "10"])
+            let response = DebugEndpoints.portfolioSnapshots(context: context, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 2)
+            // Most recent first
+            #expect(json[0]["totalValue"] as? Double == 200.0)
+            #expect(json[1]["totalValue"] as? Double == 100.0)
+            #expect(json[0]["isPartial"] as? Bool == true)
+        }
+
+        @Test func `portfolio snapshots respects limit`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let batchId = UUID()
+            for i in 0 ..< 5 {
+                context.insert(PortfolioSnapshot(
+                    syncBatchId: batchId,
+                    timestamp: Date(timeIntervalSince1970: Double(i) * 1000),
+                    totalValue: Decimal(i * 100), idleValue: 0, deployedValue: 0,
+                    debtValue: 0, isPartial: false))
+            }
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/portfolio",
+                queryParams: ["limit": "2"])
+            let response = DebugEndpoints.portfolioSnapshots(context: context, request: request)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 2)
+        }
+
+        // MARK: - /state/snapshots/account
+
+        @Test func `account snapshots filtered by accountId`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let targetId = UUID()
+            let otherId = UUID()
+            let batchId = UUID()
+            context.insert(AccountSnapshot(
+                syncBatchId: batchId, timestamp: .now,
+                accountId: targetId, totalValue: 1000, isFresh: true))
+            context.insert(AccountSnapshot(
+                syncBatchId: batchId, timestamp: .now,
+                accountId: otherId, totalValue: 2000, isFresh: false))
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/account",
+                queryParams: ["accountId": targetId.uuidString])
+            let response = DebugEndpoints.accountSnapshots(context: context, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            #expect(json[0]["totalValue"] as? Double == 1000.0)
+            #expect(json[0]["isFresh"] as? Bool == true)
+        }
+
+        @Test func `account snapshots missing accountId returns 400`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/account", queryParams: [:])
+            let response = DebugEndpoints.accountSnapshots(context: context, request: request)
+            #expect(response.statusCode == 400)
+        }
+
+        @Test func `account snapshots invalid accountId returns 400`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/account",
+                queryParams: ["accountId": "bad"])
+            let response = DebugEndpoints.accountSnapshots(context: context, request: request)
+            #expect(response.statusCode == 400)
+        }
+
+        // MARK: - /state/snapshots/asset
+
+        @Test func `asset snapshots filtered by assetId`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let targetId = UUID()
+            let batchId = UUID()
+            context.insert(AssetSnapshot(
+                syncBatchId: batchId, timestamp: .now,
+                accountId: UUID(), assetId: targetId,
+                symbol: "ETH", category: .major,
+                amount: 10, usdValue: 25000))
+            context.insert(AssetSnapshot(
+                syncBatchId: batchId, timestamp: .now,
+                accountId: UUID(), assetId: UUID(),
+                symbol: "BTC", category: .major,
+                amount: 1, usdValue: 67000))
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/asset",
+                queryParams: ["assetId": targetId.uuidString])
+            let response = DebugEndpoints.assetSnapshots(context: context, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            #expect(json[0]["symbol"] as? String == "ETH")
+            #expect(json[0]["amount"] as? Double == 10.0)
+            #expect(json[0]["usdValue"] as? Double == 25000.0)
+        }
+
+        @Test func `asset snapshots missing assetId returns 400`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/asset", queryParams: [:])
+            let response = DebugEndpoints.assetSnapshots(context: context, request: request)
+            #expect(response.statusCode == 400)
+        }
+
+        // MARK: - /network/log
+
+        @Test func `network log returns entries`() async throws {
+            let buffer = NetworkLogBuffer(capacity: 10)
+            let entry = NetworkLogEntry(
+                id: UUID(),
+                timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+                url: "https://api.example.com/data",
+                method: "GET",
+                statusCode: 200,
+                responseSizeBytes: 1024,
+                elapsed: 0.35,
+                headers: [:])
+            await buffer.append(entry)
+
+            let request = HTTPRequest(method: "GET", path: "/network/log", queryParams: ["limit": "50"])
+            let response = await DebugEndpoints.networkLog(buffer: buffer, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            #expect(json[0]["url"] as? String == "https://api.example.com/data")
+            #expect(json[0]["method"] as? String == "GET")
+            #expect(json[0]["statusCode"] as? Int == 200)
+            #expect(json[0]["responseSizeBytes"] as? Int == 1024)
+            #expect(json[0]["elapsed"] as? Double == 0.35)
+        }
+
+        @Test func `network log empty buffer returns empty array`() async throws {
+            let buffer = NetworkLogBuffer(capacity: 10)
+
+            let request = HTTPRequest(method: "GET", path: "/network/log", queryParams: [:])
+            let response = await DebugEndpoints.networkLog(buffer: buffer, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.isEmpty)
+        }
+
+        // MARK: - Decimal Serialization
+
+        @Test func `decimal values serialize as numbers not strings`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            context.insert(PortfolioSnapshot(
+                syncBatchId: UUID(), timestamp: .now,
+                totalValue: 12345.67, idleValue: 100.50,
+                deployedValue: 200.25, debtValue: 50, isPartial: false))
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/snapshots/portfolio", queryParams: [:])
+            let response = DebugEndpoints.portfolioSnapshots(context: context, request: request)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            let item = try #require(json.first)
+            #expect(item["totalValue"] is Double)
+            #expect(item["totalValue"] as? Double == 12345.67)
+            #expect(item["idleValue"] as? Double == 100.50)
+        }
+
+        // MARK: - Integration: Route Registration
+
+        @Test func `routes registered via DebugServer`() async throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+            context.insert(Account(name: "Integrated", kind: .manual, dataSource: .manual))
+            try context.save()
+
+            let server = DebugServer(port: 19040, modelContainer: container)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19040/state/accounts")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
+            #expect(httpResponse.statusCode == 200)
+            #expect(httpResponse.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+            #expect(json.count == 1)
+            #expect(json[0]["name"] as? String == "Integrated")
+        }
+    }
+#endif

--- a/Tests/PortuTests/DebugEndpointsTests.swift
+++ b/Tests/PortuTests/DebugEndpointsTests.swift
@@ -165,6 +165,23 @@
             #expect(item["isVerified"] as? Bool == true)
         }
 
+        @Test func `assets clamps negative offset to zero`() throws {
+            let container = try makeTestContainer()
+            let context = ModelContext(container)
+
+            context.insert(Asset(symbol: "ETH", name: "Ethereum", category: .major))
+            try context.save()
+
+            let request = HTTPRequest(
+                method: "GET", path: "/state/assets",
+                queryParams: ["offset": "-1"])
+            let response = DebugEndpoints.assets(context: context, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+        }
+
         // MARK: - /state/snapshots/portfolio
 
         @Test func `portfolio snapshots sorted by timestamp desc`() throws {
@@ -344,6 +361,49 @@
             #expect(json[0]["elapsed"] as? Double == 0.35)
         }
 
+        @Test func `network log filters by since parameter`() async throws {
+            let buffer = NetworkLogBuffer(capacity: 10)
+            let old = NetworkLogEntry(
+                id: UUID(),
+                timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+                url: "https://api.example.com/old",
+                method: "GET",
+                statusCode: 200,
+                responseSizeBytes: 512,
+                elapsed: 0.1,
+                headers: [:])
+            let recent = NetworkLogEntry(
+                id: UUID(),
+                timestamp: Date(timeIntervalSince1970: 1_700_100_000),
+                url: "https://api.example.com/recent",
+                method: "POST",
+                statusCode: 201,
+                responseSizeBytes: 256,
+                elapsed: 0.2,
+                headers: [:])
+            await buffer.append(old)
+            await buffer.append(recent)
+
+            let request = HTTPRequest(
+                method: "GET", path: "/network/log",
+                queryParams: ["since": "2023-11-16T00:00:00.000Z"])
+            let response = await DebugEndpoints.networkLog(buffer: buffer, request: request)
+            #expect(response.statusCode == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+            #expect(json.count == 1)
+            #expect(json[0]["url"] as? String == "https://api.example.com/recent")
+        }
+
+        @Test func `network log rejects invalid since parameter`() async {
+            let buffer = NetworkLogBuffer(capacity: 10)
+            let request = HTTPRequest(
+                method: "GET", path: "/network/log",
+                queryParams: ["since": "not-a-date"])
+            let response = await DebugEndpoints.networkLog(buffer: buffer, request: request)
+            #expect(response.statusCode == 400)
+        }
+
         @Test func `network log empty buffer returns empty array`() async throws {
             let buffer = NetworkLogBuffer(capacity: 10)
 
@@ -386,12 +446,13 @@
             context.insert(Account(name: "Integrated", kind: .manual, dataSource: .manual))
             try context.save()
 
-            let server = DebugServer(port: 19040, modelContainer: container)
+            let port = UInt16.random(in: 49152 ... 65535)
+            let server = DebugServer(port: port, modelContainer: container)
             try await server.start()
             defer { server.stop() }
 
             let (data, response) = try await URLSession.shared.data(
-                from: #require(URL(string: "http://127.0.0.1:19040/state/accounts")))
+                from: #require(URL(string: "http://127.0.0.1:\(port)/state/accounts")))
             let httpResponse = try #require(response as? HTTPURLResponse)
             #expect(httpResponse.statusCode == 200)
             #expect(httpResponse.value(forHTTPHeaderField: "Content-Type") == "application/json")


### PR DESCRIPTION
## Summary

- Add 7 GET endpoints to the debug server for inspecting SwiftData persistent state: `/state/accounts`, `/state/positions`, `/state/assets`, `/state/snapshots/portfolio`, `/state/snapshots/account`, `/state/snapshots/asset`, `/network/log`
- Each handler uses `FetchDescriptor` with in-memory filtering (avoids `#Predicate` optional-chaining crash) and `SortDescriptor` for timestamp ordering
- Route handlers changed from sync to async to support `NetworkLogBuffer` actor access

Closes #40

## Test plan

- [x] 18 unit tests covering all 7 endpoints, error cases (invalid/missing UUID → 400), pagination, sort order, and decimal-as-number serialization
- [x] Integration test verifying routes are registered and respond over HTTP
- [x] Full test suite passes (229 tests, 0 failures)
- [x] No new lint warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debug-only HTTP endpoints to inspect accounts, positions, assets, and portfolio/account/asset snapshots with filtering, sorting, pagination, and validation (JSON error responses for invalid inputs)
  * Added a network activity log endpoint with optional time-based filtering and conditional fields in JSON
  * Debug server now handles requests asynchronously

* **Tests**
  * Added comprehensive tests covering endpoints, filtering, pagination, sorting, parameter validation, error responses, and JSON serialization

* **Documentation**
  * Clarified recommended Swift testing annotations and serialized-suite usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->