### PR TITLE
feat: TCA state and action endpoints for debug server

### DIFF
--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -38,18 +38,23 @@ extension DependencyValues {
 
 struct PriceServiceClient {
     var fetchPrices: @Sendable ([String]) async throws -> PriceUpdate
+    var invalidateCache: @Sendable () async -> Void
 }
 
 extension PriceServiceClient: DependencyKey {
     static let liveValue = Self(
-        fetchPrices: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") })
+        fetchPrices: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        invalidateCache: { fatalError("PriceServiceClient.liveValue must be overridden at Store creation") })
     static let testValue = Self(
-        fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) })
+        fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) },
+        invalidateCache: {})
 
     static func live(service: PriceService) -> Self {
-        Self(fetchPrices: { coinIds in
-            try await service.fetchPriceUpdate(for: coinIds)
-        })
+        Self(
+            fetchPrices: { coinIds in
+                try await service.fetchPriceUpdate(for: coinIds)
+            },
+            invalidateCache: { await service.invalidateCache() })
     }
 }
 
@@ -213,6 +218,7 @@ struct AppFeature {
 // MARK: - Equatable for Result
 
 extension AppFeature.Action: Equatable {
+    // swiftlint:disable:next cyclomatic_complexity
     static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case let (.sectionSelected(l), .sectionSelected(r)): l == r

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -196,9 +196,10 @@
             }
 
             addRoute("POST", "/actions/price-invalidate") { [weak self] _ in
-                if let priceService = self?.priceService {
-                    Task { await priceService.invalidateCache() }
+                guard let priceService = self?.priceService else {
+                    return Self.jsonResponse(statusCode: 500, body: ["error": "Price service unavailable"])
                 }
+                Task { await priceService.invalidateCache() }
                 return Self.jsonResponse(statusCode: 200, body: ["triggered": true])
             }
         }
@@ -249,7 +250,10 @@
                         if let handler = pathRoutes[request.method] {
                             await handler(request)
                         } else {
-                            Self.jsonResponse(statusCode: 405, body: ["error": "Method not allowed"])
+                            Self.jsonResponse(
+                                statusCode: 405,
+                                body: ["error": "Method not allowed"],
+                                headers: ["Allow": pathRoutes.keys.sorted().joined(separator: ", ")])
                         }
                     } else {
                         Self.jsonResponse(statusCode: 404, body: ["error": "Not found"])
@@ -265,6 +269,9 @@
             header += "Content-Type: application/json\r\n"
             header += "Content-Length: \(response.body.count)\r\n"
             header += "Connection: close\r\n"
+            for (key, value) in response.headers {
+                header += "\(key): \(value)\r\n"
+            }
             header += "\r\n"
 
             var payload = Data(header.utf8)
@@ -286,12 +293,15 @@
 
         // MARK: - Helpers
 
-        nonisolated private static func jsonResponse(statusCode: Int, body: [String: any Sendable]) -> HTTPResponse {
+        nonisolated private static func jsonResponse(
+            statusCode: Int,
+            body: [String: any Sendable],
+            headers: [String: String] = [:]) -> HTTPResponse {
             guard let data = try? JSONSerialization.data(withJSONObject: body) else {
                 assertionFailure("DebugServer: failed to serialize JSON response")
                 return HTTPResponse(statusCode: 500, body: Data("{\"error\":\"serialization failed\"}".utf8))
             }
-            return HTTPResponse(statusCode: statusCode, body: data)
+            return HTTPResponse(statusCode: statusCode, body: data, headers: headers)
         }
     }
 

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -13,22 +13,29 @@
         private var startingListener: NWListener?
         private var routes: [String: [String: @MainActor (HTTPRequest) async -> HTTPResponse]] = [:]
         private var activeConnections: [ObjectIdentifier: NWConnection] = [:]
+        private static let iso8601Formatter = ISO8601DateFormatter()
         private let startTime = ContinuousClock.now
         private let logger = Logger(subsystem: "com.portu.app", category: "DebugServer")
 
         private let modelContainer: ModelContainer?
-        private let store: StoreOf<AppFeature>? // sub-issue #4: TCA state endpoints
+        private let store: StoreOf<AppFeature>?
+        private let priceService: PriceServiceClient?
 
         init(
             port: UInt16 = 9999,
             modelContainer: ModelContainer? = nil,
-            store: StoreOf<AppFeature>? = nil) {
+            store: StoreOf<AppFeature>? = nil,
+            priceService: PriceServiceClient? = nil) {
             self.port = port
             self.modelContainer = modelContainer
             self.store = store
+            self.priceService = priceService
             registerBuiltInRoutes()
             if let modelContainer {
                 DebugEndpoints.register(on: self, modelContainer: modelContainer)
+            }
+            if store != nil {
+                registerTCARoutes()
             }
         }
 
@@ -136,6 +143,66 @@
             }
         }
 
+        private func registerTCARoutes() {
+            addRoute("GET", "/state/prices") { [weak self] _ in
+                guard let store = self?.store else {
+                    return Self.jsonResponse(statusCode: 500, body: ["error": "Store unavailable"])
+                }
+                let prices = store.prices.mapValues { ($0 as NSDecimalNumber).doubleValue }
+                let changes = store.priceChanges24h.mapValues { ($0 as NSDecimalNumber).doubleValue }
+                var body: [String: any Sendable] = [
+                    "prices": prices,
+                    "changes24h": changes
+                ]
+                if let date = store.lastPriceUpdate {
+                    body["lastUpdate"] = Self.iso8601Formatter.string(from: date)
+                }
+                return Self.jsonResponse(statusCode: 200, body: body)
+            }
+
+            addRoute("GET", "/state/sync") { [weak self] _ in
+                guard let store = self?.store else {
+                    return Self.jsonResponse(statusCode: 500, body: ["error": "Store unavailable"])
+                }
+                var body: [String: any Sendable] = ["storeIsEphemeral": store.storeIsEphemeral]
+                switch store.syncStatus {
+                case .idle:
+                    body["syncStatus"] = "idle"
+                case let .syncing(progress):
+                    body["syncStatus"] = "syncing"
+                    body["progress"] = progress
+                case let .completedWithErrors(failedAccounts):
+                    body["syncStatus"] = "completedWithErrors"
+                    body["failedAccounts"] = failedAccounts
+                case let .error(message):
+                    body["syncStatus"] = "error"
+                    body["errorMessage"] = message
+                }
+                switch store.connectionStatus {
+                case .idle:
+                    body["connectionStatus"] = "idle"
+                case .fetching:
+                    body["connectionStatus"] = "fetching"
+                case let .error(message):
+                    body["connectionStatus"] = "error"
+                    body["connectionErrorMessage"] = message
+                }
+                return Self.jsonResponse(statusCode: 200, body: body)
+            }
+
+            addRoute("POST", "/actions/sync") { [weak self] _ in
+                self?.store?.send(.syncTapped)
+                return Self.jsonResponse(statusCode: 200, body: ["triggered": true])
+            }
+
+            addRoute("POST", "/actions/price-invalidate") { [weak self] _ in
+                if let priceService = self?.priceService {
+                    Task { await priceService.invalidateCache() }
+                }
+                return Self.jsonResponse(statusCode: 200, body: ["triggered": true])
+            }
+        }
+
         // MARK: - Connection Handling
 
         private func finishConnection(_ connection: NWConnection) {
@@ -178,10 +245,12 @@
                         return
                     }
 
-                    let response: HTTPResponse = if
-                        let pathRoutes = self.routes[request.path],
-                        let handler = pathRoutes[request.method] {
-                        await handler(request)
+                    let response: HTTPResponse = if let pathRoutes = self.routes[request.path] {
+                        if let handler = pathRoutes[request.method] {
+                            await handler(request)
+                        } else {
+                            Self.jsonResponse(statusCode: 405, body: ["error": "Method not allowed"])
+                        }
                     } else {
                         Self.jsonResponse(statusCode: 404, body: ["error": "Not found"])
                     }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -191,7 +191,10 @@
             }
 
             addRoute("POST", "/actions/sync") { [weak self] _ in
-                self?.store?.send(.syncTapped)
+                guard let store = self?.store else {
+                    return Self.jsonResponse(statusCode: 500, body: ["error": "Store unavailable"])
+                }
+                store.send(.syncTapped)
                 return Self.jsonResponse(statusCode: 200, body: ["triggered": true])
             }
 

--- a/Sources/Portu/Debug/HTTPParser.swift
+++ b/Sources/Portu/Debug/HTTPParser.swift
@@ -11,6 +11,7 @@
     struct HTTPResponse {
         let statusCode: Int
         let body: Data
+        var headers: [String: String] = [:]
 
         var statusText: String {
             switch statusCode {

--- a/Sources/Portu/Debug/HTTPParser.swift
+++ b/Sources/Portu/Debug/HTTPParser.swift
@@ -17,6 +17,7 @@
             case 200: "OK"
             case 400: "Bad Request"
             case 404: "Not Found"
+            case 405: "Method Not Allowed"
             case 500: "Internal Server Error"
             default: "Status \(statusCode)"
             }

--- a/Tests/PortuTests/AppFeatureTests.swift
+++ b/Tests/PortuTests/AppFeatureTests.swift
@@ -153,6 +153,17 @@ struct AppFeatureTests {
         }
     }
 
+    // MARK: - PriceServiceClient invalidateCache
+
+    @Test func `priceServiceClient invalidateCache is callable`() async {
+        nonisolated(unsafe) var called = false
+        let client = PriceServiceClient(
+            fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) },
+            invalidateCache: { called = true })
+        await client.invalidateCache()
+        #expect(called)
+    }
+
     // MARK: - B7: Price Merge (not replace)
 
     @Test func `prices merge with existing`() async {

--- a/Tests/PortuTests/DebugServerTCATests.swift
+++ b/Tests/PortuTests/DebugServerTCATests.swift
@@ -163,8 +163,56 @@
             let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
             #expect(json["triggered"] as? Bool == true)
 
-            try await Task.sleep(for: .milliseconds(50))
+            let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+            while !invalidateCalled, ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
             #expect(invalidateCalled)
+        }
+
+        @Test func `price invalidate returns 500 when priceService is nil`() async throws {
+            let store = makeStore()
+            let server = DebugServer(port: 19029, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            var request = try URLRequest(
+                url: #require(URL(string: "http://127.0.0.1:19029/actions/price-invalidate")))
+            request.httpMethod = "POST"
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = try #require(response as? HTTPURLResponse)
+
+            #expect(httpResponse.statusCode == 500)
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["error"] as? String == "Price service unavailable")
+        }
+
+        // MARK: - Error state serialization
+
+        @Test func `sync endpoint serializes error status with message`() async throws {
+            let store = makeStore(syncStatus: .error("Sync failed"))
+            let server = DebugServer(port: 19030, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, _) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19030/state/sync")))
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["syncStatus"] as? String == "error")
+            #expect(json["errorMessage"] as? String == "Sync failed")
+        }
+
+        @Test func `sync endpoint serializes error connection status`() async throws {
+            let store = makeStore(connectionStatus: .error("Connection lost"))
+            let server = DebugServer(port: 19031, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, _) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19031/state/sync")))
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["connectionStatus"] as? String == "error")
+            #expect(json["connectionErrorMessage"] as? String == "Connection lost")
         }
 
         // MARK: - 405 on TCA routes
@@ -180,6 +228,7 @@
             let (_, response) = try await URLSession.shared.data(for: request)
             let httpResponse = try #require(response as? HTTPURLResponse)
             #expect(httpResponse.statusCode == 405)
+            #expect(httpResponse.value(forHTTPHeaderField: "Allow") == "GET")
         }
     }
 #endif

--- a/Tests/PortuTests/DebugServerTCATests.swift
+++ b/Tests/PortuTests/DebugServerTCATests.swift
@@ -51,7 +51,7 @@
             let prices = try #require(json["prices"] as? [String: Double])
             #expect(prices["bitcoin"] == 50000)
             let changes = try #require(json["changes24h"] as? [String: Double])
-            #expect(changes["bitcoin"] != nil)
+            #expect(changes["bitcoin"] == 2.5)
             #expect(json["lastUpdate"] is String)
         }
 
@@ -229,6 +229,34 @@
             let httpResponse = try #require(response as? HTTPURLResponse)
             #expect(httpResponse.statusCode == 405)
             #expect(httpResponse.value(forHTTPHeaderField: "Allow") == "GET")
+        }
+
+        @Test func `actions sync returns 405 for GET`() async throws {
+            let store = makeStore()
+            let server = DebugServer(port: 19032, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (_, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19032/actions/sync")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
+            #expect(httpResponse.statusCode == 405)
+            #expect(httpResponse.value(forHTTPHeaderField: "Allow") == "POST")
+        }
+
+        @Test func `actions price-invalidate returns 405 for GET`() async throws {
+            let store = makeStore()
+            let server = DebugServer(port: 19033, store: store, priceService: PriceServiceClient(
+                fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) },
+                invalidateCache: {}))
+            try await server.start()
+            defer { server.stop() }
+
+            let (_, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19033/actions/price-invalidate")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
+            #expect(httpResponse.statusCode == 405)
+            #expect(httpResponse.value(forHTTPHeaderField: "Allow") == "POST")
         }
     }
 #endif

--- a/Tests/PortuTests/DebugServerTCATests.swift
+++ b/Tests/PortuTests/DebugServerTCATests.swift
@@ -1,0 +1,185 @@
+#if DEBUG
+    import ComposableArchitecture
+    import Foundation
+    @testable import Portu
+    import PortuCore
+    import Testing
+
+    @MainActor
+    struct DebugServerTCATests {
+        private func makeStore(
+            prices: [String: Decimal] = [:],
+            priceChanges24h: [String: Decimal] = [:],
+            lastPriceUpdate: Date? = nil,
+            syncStatus: SyncStatus = .idle,
+            connectionStatus: ConnectionStatus = .idle,
+            storeIsEphemeral: Bool = false) -> StoreOf<AppFeature> {
+            var state = AppFeature.State()
+            state.prices = prices
+            state.priceChanges24h = priceChanges24h
+            state.lastPriceUpdate = lastPriceUpdate
+            state.syncStatus = syncStatus
+            state.connectionStatus = connectionStatus
+            state.storeIsEphemeral = storeIsEphemeral
+            return Store(initialState: state) {
+                AppFeature()
+            } withDependencies: {
+                $0.syncEngine = SyncEngineClient(sync: { SyncResult(failedAccounts: []) })
+                $0.priceService = PriceServiceClient(
+                    fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) },
+                    invalidateCache: {})
+            }
+        }
+
+        // MARK: - GET /state/prices
+
+        @Test func `prices endpoint returns coin prices and changes`() async throws {
+            let store = makeStore(
+                prices: ["bitcoin": 50000],
+                priceChanges24h: ["bitcoin": Decimal(2.5)],
+                lastPriceUpdate: Date(timeIntervalSince1970: 1_000_000))
+            let server = DebugServer(port: 19020, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19020/state/prices")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
+
+            #expect(httpResponse.statusCode == 200)
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let prices = try #require(json["prices"] as? [String: Double])
+            #expect(prices["bitcoin"] == 50000)
+            let changes = try #require(json["changes24h"] as? [String: Double])
+            #expect(changes["bitcoin"] != nil)
+            #expect(json["lastUpdate"] is String)
+        }
+
+        @Test func `prices endpoint omits lastUpdate when nil`() async throws {
+            let store = makeStore()
+            let server = DebugServer(port: 19021, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, _) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19021/state/prices")))
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["lastUpdate"] == nil)
+        }
+
+        // MARK: - GET /state/sync
+
+        @Test func `sync endpoint returns idle statuses`() async throws {
+            let store = makeStore(syncStatus: .idle, connectionStatus: .idle, storeIsEphemeral: true)
+            let server = DebugServer(port: 19022, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19022/state/sync")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
+
+            #expect(httpResponse.statusCode == 200)
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["syncStatus"] as? String == "idle")
+            #expect(json["connectionStatus"] as? String == "idle")
+            #expect(json["storeIsEphemeral"] as? Bool == true)
+        }
+
+        @Test func `sync endpoint serializes syncing with progress`() async throws {
+            let store = makeStore(syncStatus: .syncing(progress: 0.75))
+            let server = DebugServer(port: 19023, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, _) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19023/state/sync")))
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["syncStatus"] as? String == "syncing")
+            #expect(json["progress"] as? Double == 0.75)
+        }
+
+        @Test func `sync endpoint serializes completedWithErrors`() async throws {
+            let store = makeStore(syncStatus: .completedWithErrors(failedAccounts: ["acc1", "acc2"]))
+            let server = DebugServer(port: 19024, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, _) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19024/state/sync")))
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["syncStatus"] as? String == "completedWithErrors")
+            #expect(json["failedAccounts"] as? [String] == ["acc1", "acc2"])
+        }
+
+        @Test func `sync endpoint serializes fetching connection status`() async throws {
+            let store = makeStore(connectionStatus: .fetching)
+            let server = DebugServer(port: 19025, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            let (data, _) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19025/state/sync")))
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["connectionStatus"] as? String == "fetching")
+        }
+
+        // MARK: - POST /actions/sync
+
+        @Test func `sync action returns triggered true`() async throws {
+            let store = makeStore()
+            let server = DebugServer(port: 19026, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            var request = try URLRequest(url: #require(URL(string: "http://127.0.0.1:19026/actions/sync")))
+            request.httpMethod = "POST"
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = try #require(response as? HTTPURLResponse)
+
+            #expect(httpResponse.statusCode == 200)
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["triggered"] as? Bool == true)
+        }
+
+        // MARK: - POST /actions/price-invalidate
+
+        @Test func `price invalidate action calls invalidateCache and returns triggered`() async throws {
+            nonisolated(unsafe) var invalidateCalled = false
+            let priceService = PriceServiceClient(
+                fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) },
+                invalidateCache: { invalidateCalled = true })
+            let store = makeStore()
+            let server = DebugServer(port: 19027, store: store, priceService: priceService)
+            try await server.start()
+            defer { server.stop() }
+
+            var request = try URLRequest(url: #require(URL(string: "http://127.0.0.1:19027/actions/price-invalidate")))
+            request.httpMethod = "POST"
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = try #require(response as? HTTPURLResponse)
+
+            #expect(httpResponse.statusCode == 200)
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["triggered"] as? Bool == true)
+
+            try await Task.sleep(for: .milliseconds(50))
+            #expect(invalidateCalled)
+        }
+
+        // MARK: - 405 on TCA routes
+
+        @Test func `state sync returns 405 for wrong method`() async throws {
+            let store = makeStore()
+            let server = DebugServer(port: 19028, store: store)
+            try await server.start()
+            defer { server.stop() }
+
+            var request = try URLRequest(url: #require(URL(string: "http://127.0.0.1:19028/state/sync")))
+            request.httpMethod = "POST"
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = try #require(response as? HTTPURLResponse)
+            #expect(httpResponse.statusCode == 405)
+        }
+    }
+#endif

--- a/Tests/PortuTests/DebugServerTests.swift
+++ b/Tests/PortuTests/DebugServerTests.swift
@@ -88,7 +88,47 @@
             #expect(httpResponse.statusCode == 200)
         }
 
+        // MARK: - 405 Method Not Allowed
+
+        @Test func `known path with wrong method returns 405`() async throws {
+            let server = DebugServer(port: 19010)
+            server.addRoute("GET", "/only-get") { _ in
+                Self.makeOKResponse()
+            }
+            try await server.start()
+            defer { server.stop() }
+
+            var request = try URLRequest(url: #require(URL(string: "http://127.0.0.1:19010/only-get")))
+            request.httpMethod = "POST"
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = try #require(response as? HTTPURLResponse)
+
+            #expect(httpResponse.statusCode == 405)
+
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["error"] as? String == "Method not allowed")
+        }
+
+        @Test func `known path with correct method is not 405`() async throws {
+            let server = DebugServer(port: 19011)
+            server.addRoute("GET", "/only-get") { _ in
+                Self.makeOKResponse()
+            }
+            try await server.start()
+            defer { server.stop() }
+
+            let (_, response) = try await URLSession.shared.data(
+                from: #require(URL(string: "http://127.0.0.1:19011/only-get")))
+            let httpResponse = try #require(response as? HTTPURLResponse)
+
+            #expect(httpResponse.statusCode == 200)
+        }
+
         // MARK: - Uptime
+
+        private static func makeOKResponse() -> HTTPResponse {
+            HTTPResponse(statusCode: 200, body: Data("{}".utf8))
+        }
 
         @Test func `uptime increases over time`() async throws {
             let server = DebugServer(port: 19006)


### PR DESCRIPTION
## Summary

Closes #41 — Part of #37

- Add 4 debug endpoints for agent-driven TCA state inspection and action triggering (GET `/state/prices`, GET `/state/sync`, POST `/actions/sync`, POST `/actions/price-invalidate`)
- Add `PriceServiceClient.invalidateCache` wired to `PriceService.invalidateCache()` actor method
- Add 405 Method Not Allowed routing when path exists but HTTP method doesn't match

## Test plan

- [x] 223 tests passing (12 new: 9 TCA endpoint tests, 2 method-not-allowed tests, 1 PriceServiceClient test)
- [x] `curl localhost:9999/state/prices` returns JSON with `prices`, `changes24h`, `lastUpdate`
- [x] `curl localhost:9999/state/sync` returns human-readable enum serialization
- [x] `curl -X POST localhost:9999/actions/sync` triggers sync cycle
- [x] `curl -X POST localhost:9999/actions/price-invalidate` invalidates price cache
- [x] GET on POST-only path returns 405; POST on GET-only path returns 405
- [x] SyncStatus/ConnectionStatus edge cases (completedWithErrors, syncing progress, error messages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debug endpoints to retrieve current prices, 24-hour changes, sync status, and connection details
  * Added ability to invalidate the price cache via the debug API

* **Bug Fixes**
  * Return 405 Method Not Allowed (with Allow header) for unsupported HTTP methods instead of 404
  * Debug responses now include configured HTTP headers

* **Tests**
  * Added extensive tests for debug endpoints, cache invalidation, and a unit test for cache invalidation callability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->