### PR TITLE
feat: debug server activation and Settings UI

### DIFF
--- a/Sources/Portu/App/AppState.swift
+++ b/Sources/Portu/App/AppState.swift
@@ -39,6 +39,7 @@ final class AppState {
 
     #if DEBUG
         var debugServer: DebugServer?
+        var debugServerStartFailed = false
     #endif
 
     /// Syncs all TCA state fields from the store; does not touch `onSyncRequested`.

--- a/Sources/Portu/App/AppState.swift
+++ b/Sources/Portu/App/AppState.swift
@@ -37,6 +37,10 @@ final class AppState {
     /// Bridge: called by features to trigger sync until they're migrated to TCA (Phase 4)
     var onSyncRequested: (@MainActor () -> Void)?
 
+    #if DEBUG
+        var debugServer: DebugServer?
+    #endif
+
     /// Syncs all TCA state fields from the store; does not touch `onSyncRequested`.
     /// Guards each assignment to avoid redundant Observation notifications.
     func bridge(from store: StoreOf<AppFeature>) {

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -66,7 +66,6 @@ struct PortuApp: App {
                         try await debugServer.start()
                         state.debugServer = debugServer
                     } catch {
-                        state.debugServer = nil
                         Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.portu.app", category: "DebugServer")
                             .error("Debug server failed to start: \(String(describing: error), privacy: .public)")
                     }

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -59,12 +59,14 @@ struct PortuApp: App {
                     modelContainer: container,
                     store: store,
                     priceService: .live(service: priceService))
-                appState.debugServer = debugServer
+                let state = appState
                 Task { @MainActor in
                     do {
                         try await debugServer.start()
+                        state.debugServer = debugServer
                     } catch {
-                        Logger(subsystem: "com.portu.app", category: "DebugServer")
+                        state.debugServer = nil
+                        Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.portu.app", category: "DebugServer")
                             .error("Debug server failed to start: \(error)")
                     }
                 }

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -66,6 +66,7 @@ struct PortuApp: App {
                         try await debugServer.start()
                         state.debugServer = debugServer
                     } catch {
+                        state.debugServerStartFailed = true
                         Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.portu.app", category: "DebugServer")
                             .error("Debug server failed to start: \(String(describing: error), privacy: .public)")
                     }

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -67,7 +67,7 @@ struct PortuApp: App {
                     } catch {
                         state.debugServer = nil
                         Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.portu.app", category: "DebugServer")
-                            .error("Debug server failed to start: \(error)")
+                            .error("Debug server failed to start: \(String(describing: error), privacy: .public)")
                     }
                 }
             }

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -1,5 +1,7 @@
 import ComposableArchitecture
-import os
+#if DEBUG
+    import os
+#endif
 import PortuCore
 import PortuNetwork
 import PortuUI

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -59,6 +59,7 @@ struct PortuApp: App {
                     modelContainer: container,
                     store: store,
                     priceService: .live(service: priceService))
+                // App.init is implicitly @MainActor via App protocol conformance
                 let state = appState
                 Task { @MainActor in
                     do {

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import os
 import PortuCore
 import PortuNetwork
 import PortuUI
@@ -26,10 +27,17 @@ struct PortuApp: App {
             }
         }
 
+        #if DEBUG
+            let debugEnabled = DebugMode.isEnabled()
+            let session: URLSession = debugEnabled ? NetworkLogger.debugSession() : .shared
+        #else
+            let session: URLSession = .shared
+        #endif
+
         let syncEngine = SyncEngine(
             modelContext: container.mainContext,
-            providerFactory: ProviderFactory(secretStore: KeychainService()))
-        let priceService = PriceService()
+            providerFactory: ProviderFactory(secretStore: KeychainService(), session: session))
+        let priceService = PriceService(session: session)
 
         self.store = Store(initialState: AppFeature.State(storeIsEphemeral: isEphemeral)) {
             AppFeature()
@@ -43,6 +51,25 @@ struct PortuApp: App {
             store.send(.syncTapped)
         }
         appState.observe(store)
+
+        #if DEBUG
+            if debugEnabled {
+                let debugServer = DebugServer(
+                    port: DebugMode.port(),
+                    modelContainer: container,
+                    store: store,
+                    priceService: .live(service: priceService))
+                appState.debugServer = debugServer
+                Task { @MainActor in
+                    do {
+                        try await debugServer.start()
+                    } catch {
+                        Logger(subsystem: "com.portu.app", category: "DebugServer")
+                            .error("Debug server failed to start: \(error)")
+                    }
+                }
+            }
+        #endif
     }
 
     var body: some Scene {

--- a/Sources/Portu/Debug/DebugMode.swift
+++ b/Sources/Portu/Debug/DebugMode.swift
@@ -1,0 +1,20 @@
+#if DEBUG
+
+    import Foundation
+
+    enum DebugMode {
+        static func isEnabled(
+            arguments: [String] = ProcessInfo.processInfo.arguments,
+            defaults: UserDefaults = .standard) -> Bool {
+            arguments.contains("--debug-server")
+                || defaults.bool(forKey: "debugServerEnabled")
+        }
+
+        static func port(defaults: UserDefaults = .standard) -> UInt16 {
+            let stored = defaults.integer(forKey: "debugServerPort")
+            guard stored > 0, stored <= UInt16.max else { return 9999 }
+            return UInt16(stored)
+        }
+    }
+
+#endif

--- a/Sources/Portu/Debug/DebugMode.swift
+++ b/Sources/Portu/Debug/DebugMode.swift
@@ -6,11 +6,12 @@
         static let enabledKey = "debugServerEnabled"
         static let portKey = "debugServerPort"
         static let defaultPort: UInt16 = 9999
+        static let launchArgument = "--debug-server"
 
         static func isEnabled(
             arguments: [String] = ProcessInfo.processInfo.arguments,
             defaults: UserDefaults = .standard) -> Bool {
-            arguments.contains("--debug-server")
+            arguments.contains(launchArgument)
                 || defaults.bool(forKey: enabledKey)
         }
 

--- a/Sources/Portu/Debug/DebugMode.swift
+++ b/Sources/Portu/Debug/DebugMode.swift
@@ -3,16 +3,20 @@
     import Foundation
 
     enum DebugMode {
+        static let enabledKey = "debugServerEnabled"
+        static let portKey = "debugServerPort"
+        static let defaultPort: UInt16 = 9999
+
         static func isEnabled(
             arguments: [String] = ProcessInfo.processInfo.arguments,
             defaults: UserDefaults = .standard) -> Bool {
             arguments.contains("--debug-server")
-                || defaults.bool(forKey: "debugServerEnabled")
+                || defaults.bool(forKey: enabledKey)
         }
 
         static func port(defaults: UserDefaults = .standard) -> UInt16 {
-            let stored = defaults.integer(forKey: "debugServerPort")
-            guard stored > 0, stored <= UInt16.max else { return 9999 }
+            let stored = defaults.integer(forKey: portKey)
+            guard stored > 0, stored <= UInt16.max else { return defaultPort }
             return UInt16(stored)
         }
     }

--- a/Sources/Portu/Debug/DebugServer.swift
+++ b/Sources/Portu/Debug/DebugServer.swift
@@ -8,7 +8,7 @@
 
     @MainActor
     final class DebugServer {
-        private let port: UInt16
+        let port: UInt16
         private var listener: NWListener?
         private var startingListener: NWListener?
         private var routes: [String: [String: @MainActor (HTTPRequest) async -> HTTPResponse]] = [:]

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -6,14 +6,19 @@
         @Environment(AppState.self) private var appState
         @AppStorage(DebugMode.enabledKey) private var isEnabled = false
         @AppStorage(DebugMode.portKey) private var port = Int(DebugMode.defaultPort)
+        @AppStorage("debugServerToggleSet") private var toggleEverSet = false
 
         private var isRunning: Bool {
             appState.debugServer != nil
         }
 
+        private var launchArgActive: Bool {
+            ProcessInfo.processInfo.arguments.contains("--debug-server")
+        }
+
         private var needsRestart: Bool {
-            let toggleExplicitlySet = UserDefaults.standard.object(forKey: DebugMode.enabledKey) != nil
-            if toggleExplicitlySet, isEnabled != isRunning { return true }
+            if launchArgActive, isRunning, !isEnabled { return false }
+            if toggleEverSet, isEnabled != isRunning { return true }
             if isRunning, let serverPort = appState.debugServer?.port, port != Int(serverPort) { return true }
             return false
         }
@@ -22,6 +27,13 @@
             Form {
                 Section("Debug Server") {
                     Toggle("Enable Debug Server", isOn: $isEnabled)
+                        .onChange(of: isEnabled) { _, _ in toggleEverSet = true }
+
+                    if launchArgActive, isRunning {
+                        Text("Enabled via --debug-server launch argument")
+                            .foregroundStyle(.secondary)
+                            .font(.callout)
+                    }
 
                     LabeledContent("Port") {
                         TextField("Port", value: $port, format: .number)

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -4,8 +4,8 @@
 
     struct DebugSettingsTab: View {
         @Environment(AppState.self) private var appState
-        @AppStorage("debugServerEnabled") private var isEnabled = false
-        @AppStorage("debugServerPort") private var port = 9999
+        @AppStorage(DebugMode.enabledKey) private var isEnabled = false
+        @AppStorage(DebugMode.portKey) private var port = Int(DebugMode.defaultPort)
 
         private var isRunning: Bool {
             appState.debugServer != nil
@@ -26,12 +26,12 @@
                         Circle()
                             .fill(isRunning ? .green : .gray)
                             .frame(width: 8, height: 8)
-                        Text(isRunning ? "Running on port \(port)" : "Stopped")
+                        Text(isRunning ? "Running on port \(appState.debugServer?.port ?? DebugMode.defaultPort)" : "Stopped")
                             .foregroundStyle(.secondary)
                     }
                 }
 
-                if isEnabled, !isRunning {
+                if isEnabled != isRunning {
                     Section {
                         Label("Restart the app to apply changes", systemImage: "arrow.clockwise")
                             .foregroundStyle(.secondary)

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -53,7 +53,7 @@
                             .foregroundStyle(.secondary)
                     }
 
-                    if appState.debugServerStartFailed {
+                    if appState.debugServerStartFailed, isEnabled {
                         Label("Server failed to start — check Console for details", systemImage: "exclamationmark.triangle")
                             .foregroundStyle(.orange)
                             .font(.callout)

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -6,14 +6,14 @@
         @Environment(AppState.self) private var appState
         @AppStorage(DebugMode.enabledKey) private var isEnabled = false
         @AppStorage(DebugMode.portKey) private var port = Int(DebugMode.defaultPort)
-        @AppStorage("debugServerToggleSet") private var toggleEverSet = false
+        @State private var toggleEverSet = false
 
         private var isRunning: Bool {
             appState.debugServer != nil
         }
 
         private var launchArgActive: Bool {
-            ProcessInfo.processInfo.arguments.contains("--debug-server")
+            ProcessInfo.processInfo.arguments.contains(DebugMode.launchArgument)
         }
 
         private var needsRestart: Bool {

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -11,6 +11,13 @@
             appState.debugServer != nil
         }
 
+        private var needsRestart: Bool {
+            let toggleExplicitlySet = UserDefaults.standard.object(forKey: DebugMode.enabledKey) != nil
+            if toggleExplicitlySet, isEnabled != isRunning { return true }
+            if isRunning, let serverPort = appState.debugServer?.port, port != Int(serverPort) { return true }
+            return false
+        }
+
         var body: some View {
             Form {
                 Section("Debug Server") {
@@ -20,6 +27,11 @@
                         TextField("Port", value: $port, format: .number)
                             .frame(width: 80)
                             .multilineTextAlignment(.trailing)
+                            .onChange(of: port) { _, newValue in
+                                if newValue <= 0 || newValue > Int(UInt16.max) {
+                                    port = Int(DebugMode.defaultPort)
+                                }
+                            }
                     }
 
                     HStack(spacing: 6) {
@@ -31,7 +43,7 @@
                     }
                 }
 
-                if isEnabled != isRunning {
+                if needsRestart {
                     Section {
                         Label("Restart the app to apply changes", systemImage: "arrow.clockwise")
                             .foregroundStyle(.secondary)

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -6,7 +6,6 @@
         @Environment(AppState.self) private var appState
         @AppStorage(DebugMode.enabledKey) private var isEnabled = false
         @AppStorage(DebugMode.portKey) private var port = Int(DebugMode.defaultPort)
-        @State private var toggleEverSet = false
 
         private var isRunning: Bool {
             appState.debugServer != nil
@@ -17,8 +16,9 @@
         }
 
         private var needsRestart: Bool {
-            if launchArgActive, isRunning, !isEnabled { return false }
-            if toggleEverSet, isEnabled != isRunning { return true }
+            if launchArgActive, isRunning { return false }
+            if appState.debugServerStartFailed { return false }
+            if isEnabled != isRunning { return true }
             if isRunning, let serverPort = appState.debugServer?.port, port != Int(serverPort) { return true }
             return false
         }
@@ -27,10 +27,9 @@
             Form {
                 Section("Debug Server") {
                     Toggle("Enable Debug Server", isOn: $isEnabled)
-                        .onChange(of: isEnabled) { _, _ in toggleEverSet = true }
 
                     if launchArgActive, isRunning {
-                        Text("Enabled via --debug-server launch argument")
+                        Text("Enabled via \(DebugMode.launchArgument) launch argument")
                             .foregroundStyle(.secondary)
                             .font(.callout)
                     }
@@ -52,6 +51,12 @@
                             .frame(width: 8, height: 8)
                         Text(isRunning ? "Running on port \(appState.debugServer?.port ?? DebugMode.defaultPort)" : "Stopped")
                             .foregroundStyle(.secondary)
+                    }
+
+                    if appState.debugServerStartFailed {
+                        Label("Server failed to start — check Console for details", systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                            .font(.callout)
                     }
                 }
 

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -16,8 +16,10 @@
         }
 
         private var needsRestart: Bool {
-            if launchArgActive, isRunning { return false }
-            if appState.debugServerStartFailed { return false }
+            if launchArgActive {
+                if isRunning, let serverPort = appState.debugServer?.port, port != Int(serverPort) { return true }
+                return false
+            }
             if isEnabled != isRunning { return true }
             if isRunning, let serverPort = appState.debugServer?.port, port != Int(serverPort) { return true }
             return false
@@ -53,7 +55,7 @@
                             .foregroundStyle(.secondary)
                     }
 
-                    if appState.debugServerStartFailed, isEnabled {
+                    if appState.debugServerStartFailed, isEnabled || launchArgActive {
                         Label("Server failed to start — check Console for details", systemImage: "exclamationmark.triangle")
                             .foregroundStyle(.orange)
                             .font(.callout)

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -1,0 +1,53 @@
+#if DEBUG
+
+    import SwiftUI
+
+    struct DebugSettingsTab: View {
+        @Environment(AppState.self) private var appState
+        @AppStorage("debugServerEnabled") private var isEnabled = false
+        @AppStorage("debugServerPort") private var port = 9999
+
+        private var isRunning: Bool {
+            appState.debugServer != nil
+        }
+
+        var body: some View {
+            Form {
+                Section("Debug Server") {
+                    Toggle("Enable Debug Server", isOn: $isEnabled)
+
+                    LabeledContent("Port") {
+                        TextField("Port", value: $port, format: .number)
+                            .frame(width: 80)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(isRunning ? .green : .gray)
+                            .frame(width: 8, height: 8)
+                        Text(isRunning ? "Running on port \(port)" : "Stopped")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if isEnabled, !isRunning {
+                    Section {
+                        Label("Restart the app to apply changes", systemImage: "arrow.clockwise")
+                            .foregroundStyle(.secondary)
+                            .font(.callout)
+                    }
+                }
+
+                Section("Launch Argument") {
+                    Text("Pass `--debug-server` to enable without the toggle.")
+                        .foregroundStyle(.secondary)
+                        .font(.callout)
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle("Debug")
+        }
+    }
+
+#endif

--- a/Sources/Portu/Features/Settings/SettingsView.swift
+++ b/Sources/Portu/Features/Settings/SettingsView.swift
@@ -9,6 +9,11 @@ struct SettingsView: View {
             Tab("API Keys", systemImage: "key.fill") {
                 APIKeysSettingsTab()
             }
+            #if DEBUG
+                Tab("Debug", systemImage: "ant.fill") {
+                    DebugSettingsTab()
+                }
+            #endif
         }
         .frame(width: 450, height: 400)
     }

--- a/Tests/PortuTests/DebugModeTests.swift
+++ b/Tests/PortuTests/DebugModeTests.swift
@@ -1,0 +1,67 @@
+#if DEBUG
+    import Foundation
+    @testable import Portu
+    import Testing
+
+    struct DebugModeTests {
+        // MARK: - isEnabled
+
+        @Test func `enabled when launch arg present`() {
+            let result = DebugMode.isEnabled(
+                arguments: ["Portu", "--debug-server"],
+                defaults: cleanDefaults())
+            #expect(result)
+        }
+
+        @Test func `enabled when user defaults toggled`() {
+            let defaults = cleanDefaults()
+            defaults.set(true, forKey: "debugServerEnabled")
+            let result = DebugMode.isEnabled(arguments: [], defaults: defaults)
+            #expect(result)
+        }
+
+        @Test func `disabled when neither set`() {
+            let result = DebugMode.isEnabled(
+                arguments: [],
+                defaults: cleanDefaults())
+            #expect(!result)
+        }
+
+        @Test func `enabled when both set`() {
+            let defaults = cleanDefaults()
+            defaults.set(true, forKey: "debugServerEnabled")
+            let result = DebugMode.isEnabled(
+                arguments: ["Portu", "--debug-server"],
+                defaults: defaults)
+            #expect(result)
+        }
+
+        // MARK: - port
+
+        @Test func `port defaults to 9999`() {
+            #expect(DebugMode.port(defaults: cleanDefaults()) == 9999)
+        }
+
+        @Test func `port reads from defaults`() {
+            let defaults = cleanDefaults()
+            defaults.set(8080, forKey: "debugServerPort")
+            #expect(DebugMode.port(defaults: defaults) == 8080)
+        }
+
+        @Test func `port ignores zero and negative`() {
+            let defaults = cleanDefaults()
+            defaults.set(0, forKey: "debugServerPort")
+            #expect(DebugMode.port(defaults: defaults) == 9999)
+
+            defaults.set(-1, forKey: "debugServerPort")
+            #expect(DebugMode.port(defaults: defaults) == 9999)
+        }
+
+        // MARK: - Helpers
+
+        private func cleanDefaults() -> UserDefaults {
+            let suite = "com.portu.test.DebugMode.\(UUID().uuidString)"
+            return UserDefaults(suiteName: suite)!
+        }
+    }
+#endif

--- a/Tests/PortuTests/DebugModeTests.swift
+++ b/Tests/PortuTests/DebugModeTests.swift
@@ -15,7 +15,7 @@
 
         @Test func `enabled when user defaults toggled`() {
             let defaults = cleanDefaults()
-            defaults.set(true, forKey: "debugServerEnabled")
+            defaults.set(true, forKey: DebugMode.enabledKey)
             let result = DebugMode.isEnabled(arguments: [], defaults: defaults)
             #expect(result)
         }
@@ -29,7 +29,7 @@
 
         @Test func `enabled when both set`() {
             let defaults = cleanDefaults()
-            defaults.set(true, forKey: "debugServerEnabled")
+            defaults.set(true, forKey: DebugMode.enabledKey)
             let result = DebugMode.isEnabled(
                 arguments: ["Portu", "--debug-server"],
                 defaults: defaults)
@@ -39,22 +39,31 @@
         // MARK: - port
 
         @Test func `port defaults to 9999`() {
-            #expect(DebugMode.port(defaults: cleanDefaults()) == 9999)
+            #expect(DebugMode.port(defaults: cleanDefaults()) == DebugMode.defaultPort)
         }
 
         @Test func `port reads from defaults`() {
             let defaults = cleanDefaults()
-            defaults.set(8080, forKey: "debugServerPort")
+            defaults.set(8080, forKey: DebugMode.portKey)
             #expect(DebugMode.port(defaults: defaults) == 8080)
         }
 
-        @Test func `port ignores zero and negative`() {
+        @Test func `port ignores zero`() {
             let defaults = cleanDefaults()
-            defaults.set(0, forKey: "debugServerPort")
-            #expect(DebugMode.port(defaults: defaults) == 9999)
+            defaults.set(0, forKey: DebugMode.portKey)
+            #expect(DebugMode.port(defaults: defaults) == DebugMode.defaultPort)
+        }
 
-            defaults.set(-1, forKey: "debugServerPort")
-            #expect(DebugMode.port(defaults: defaults) == 9999)
+        @Test func `port ignores negative`() {
+            let defaults = cleanDefaults()
+            defaults.set(-1, forKey: DebugMode.portKey)
+            #expect(DebugMode.port(defaults: defaults) == DebugMode.defaultPort)
+        }
+
+        @Test func `port ignores values above UInt16 max`() {
+            let defaults = cleanDefaults()
+            defaults.set(Int(UInt16.max) + 1, forKey: DebugMode.portKey)
+            #expect(DebugMode.port(defaults: defaults) == DebugMode.defaultPort)
         }
 
         // MARK: - Helpers


### PR DESCRIPTION
## Summary

Closes #42. Final piece of the debug server epic (#37).

- Add `DebugMode` activation logic: `--debug-server` launch arg OR `UserDefaults` toggle
- Inject debug `URLSession` (via `NetworkLogger.debugSession()`) into `ProviderFactory` and `PriceService` when debug mode is active
- Add Debug tab to Settings with enable toggle, port config, and running status indicator
- Store `DebugServer` reference on `AppState` for environment access

**Architectural note**: `SyncEngine` was not modified — `ProviderFactory` already accepts a `session:` parameter, so injection happens at the construction site in `PortuApp.init()`.

## Test plan

- [x] 7 new `DebugModeTests` (launch arg, UserDefaults, neither, both, port default/custom/invalid)
- [x] 256/256 tests pass
- [x] Build succeeds (Debug)
- [x] Lint clean (no new warnings)
- [ ] Manual: launch with `--debug-server`, verify `curl localhost:9999/health`
- [ ] Manual: enable toggle in Settings > Debug, restart, verify server starts
- [ ] Manual: verify network log captures API calls at `/network/log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug settings tab (debug builds only) to enable/disable a debug server, set port, see running/stopped status, and view startup failure warnings; shows when app restart is required and guidance for the launch argument.

* **Chores**
  * Added debug-mode networking and startup wiring and conditional debug server startup.

* **Tests**
  * Added tests for debug-mode detection and port handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->