### PR TITLE
chore: enable XcodeBuildMCP macOS workflow

### DIFF
--- a/.xcodebuildmcp/config.yaml
+++ b/.xcodebuildmcp/config.yaml
@@ -1,0 +1,4 @@
+schemaVersion: 1
+
+enabledWorkflows:
+  - macos


### PR DESCRIPTION
## Summary
- Add `.xcodebuildmcp/config.yaml` enabling the `macos` workflow
- Ensures macOS build/run/test tools are available to agents running in worktrees

## Context
XcodeBuildMCP only enables simulator workflows by default. Since Portu is a macOS app, the macOS workflow needs to be explicitly enabled via config. This file must be committed so git worktrees (used by `isolation: "worktree"` agents) inherit it.

## Test plan
- [ ] Restart Claude Code session and verify macOS tools appear in XcodeBuildMCP
- [ ] Run `xcodebuildmcp tools --workflow macos` to confirm tools are listed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Xcodebuild MCP configuration file to enable macOS workflow for build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->