### PR TITLE
chore: add debug server workflow with dynamic endpoint discovery skill

### DIFF
--- a/.claude/skills/debug-verify/SKILL.md
+++ b/.claude/skills/debug-verify/SKILL.md
@@ -20,7 +20,7 @@ For each route, note the HTTP method, path, query parameters (with defaults and 
 
 Check if the debug server is already running:
 
-```
+```bash
 curl -s http://localhost:9999/health
 ```
 

--- a/.claude/skills/debug-verify/SKILL.md
+++ b/.claude/skills/debug-verify/SKILL.md
@@ -24,7 +24,7 @@ Check if the debug server is already running:
 curl -s http://localhost:9999/health
 ```
 
-If it responds, skip to Step 3. Otherwise, run `just debug-run` to build the app and launch with the debug server. The recipe waits until `/health` responds before returning.
+If it responds, skip to Step 3. Otherwise, run `just debug-run` to build the app and launch with the debug server. The recipe waits up to 30 seconds for `/health` to respond. If it times out or exits with an error, report the failure rather than proceeding — the app may have crashed on startup or port 9999 may be in use.
 
 ## Step 3: Query relevant endpoints
 

--- a/.claude/skills/debug-verify/SKILL.md
+++ b/.claude/skills/debug-verify/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: debug-verify
+description: Launch the debug server and verify runtime state by dynamically discovering endpoints from source code. Use after implementing features or fixing bugs that touch SwiftData models (accounts, positions, assets, snapshots), TCA state (sync, prices), network calls, or any runtime behavior. Also use when the user says "debug-verify", "test the debug server", "check runtime state", "verify the app state", or "curl the debug endpoints". Trigger proactively after writing code that changes sync logic, price fetching, account handling, or data persistence — don't wait for the user to ask.
+---
+
+Verify the running app's runtime state using the embedded debug server on `localhost:9999`.
+
+The debug server's endpoint surface evolves as the app grows — new routes get added across PRs without centralized documentation. Reading the source is the only way to know the full, current API. Static endpoint lists drift within days. This skill exists to prevent that.
+
+## Step 1: Discover all current endpoints from source
+
+Read these two files and find every `addRoute` call to build the complete endpoint map:
+
+- `Sources/Portu/Debug/DebugServer.swift` — health endpoint, TCA state routes, and action routes
+- `Sources/Portu/Debug/DebugEndpoints.swift` — SwiftData state routes, snapshot routes, and network log
+
+For each route, note the HTTP method, path, query parameters (with defaults and clamping), and response shape from the handler closure. This is the authoritative API surface — do not rely on any other source for endpoint information.
+
+## Step 2: Build and launch
+
+Check if the debug server is already running:
+
+```
+curl -s http://localhost:9999/health
+```
+
+If it responds, skip to Step 3. Otherwise, run `just debug-run` to build the app and launch with the debug server. The recipe waits until `/health` responds before returning.
+
+## Step 3: Query relevant endpoints
+
+Using the endpoints discovered in Step 1, select and curl the ones relevant to whatever was just implemented or changed. Use `jq` for readable output. Always start with `GET /health` to confirm the server is alive.
+
+Choose endpoints based on what the recent code change touched — match the data domain (models, sync, prices, network) to the endpoint categories you discovered. If unsure which endpoints are relevant, query broadly rather than narrowly.
+
+Report what each endpoint returned and whether the runtime state reflects the expected changes.
+
+## Step 4: Clean up
+
+Run `just debug-stop` to kill the debug app — unless the user wants to keep it running for manual inspection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ just lint            # Lint all Swift files
 just lint-fix        # Auto-fix lintable violations
 just format          # Format all Swift files
 just clean           # Clean build artifacts
+just debug-run       # Build + launch with debug server
+just debug-stop      # Stop the debug app
 ```
 
 ## Architecture
@@ -61,6 +63,16 @@ The app target (`Sources/Portu/`) imports all three and contains features, app s
 - Run the FULL test suite before considering a behavior complete
 - Read specs from `openspec/changes/` before generating tests
 - Refactor only when tests are GREEN — never refactor and change behavior simultaneously
+
+## Debug Server
+
+A local HTTP debug server (`localhost:9999`) for runtime inspection. `#if DEBUG` guarded.
+
+**When to use:** After implementing features or fixing bugs that change runtime state (SwiftData models, sync, prices, network). Build with `just debug-run`, verify with `/debug-verify`, stop with `just debug-stop`.
+
+Endpoint categories: SwiftData state (accounts, positions, assets, snapshots), TCA state (sync status, prices), actions (trigger sync, invalidate prices), network log. Run `/debug-verify` for dynamic endpoint discovery and verification from source.
+
+When adding new SwiftData models or TCA state, add corresponding debug endpoints in `DebugEndpoints.swift`.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ A local HTTP debug server (`localhost:9999`) for runtime inspection. `#if DEBUG`
 
 Endpoint categories: SwiftData state (accounts, positions, assets, snapshots), TCA state (sync status, prices), actions (trigger sync, invalidate prices), network log. Run `/debug-verify` for dynamic endpoint discovery and verification from source.
 
-When adding new SwiftData models or TCA state, add corresponding debug endpoints in `DebugEndpoints.swift`.
+When adding new SwiftData models or network log endpoints, add them in `DebugEndpoints.swift`. When adding new TCA state or action routes, register them in `DebugServer.swift`.
 
 ## Code Style
 

--- a/justfile
+++ b/justfile
@@ -38,6 +38,21 @@ lint-fix:
 format:
     swiftformat .
 
+# Build and launch with debug server on localhost:9999
+debug-run: build
+    #!/bin/bash
+    APP=$(xcodebuild -scheme Portu -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | awk '{print $3}')/Portu.app
+    open "$APP" --args --debug-server
+    echo "Waiting for debug server..."
+    until curl -s http://localhost:9999/health > /dev/null 2>&1; do sleep 0.5; done
+    curl -s http://localhost:9999/health | jq .
+    echo "Debug server ready at http://localhost:9999"
+
+# Stop the running debug app
+debug-stop:
+    pkill -f "Portu.app/Contents/MacOS/Portu" || true
+    @echo "Debug app stopped"
+
 # Clean build artifacts
 clean:
     xcodebuild -scheme Portu -skipMacroValidation clean

--- a/justfile
+++ b/justfile
@@ -43,6 +43,7 @@ debug-run: build
     #!/bin/bash
     APP=$(xcodebuild -scheme Portu -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | head -1 | cut -d '=' -f 2- | sed 's/^[[:space:]]*//')/Portu.app
     if [ ! -d "$APP" ]; then echo "Could not locate Portu.app at $APP" >&2; exit 1; fi
+    pkill -f "Portu.app/Contents/MacOS/Portu.*--debug-server" 2>/dev/null; sleep 0.5
     open -n "$APP" --args --debug-server
     echo "Waiting for debug server..."
     attempts=0

--- a/justfile
+++ b/justfile
@@ -41,16 +41,22 @@ format:
 # Build and launch with debug server on localhost:9999
 debug-run: build
     #!/bin/bash
-    APP=$(xcodebuild -scheme Portu -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | awk '{print $3}')/Portu.app
-    open "$APP" --args --debug-server
+    APP=$(xcodebuild -scheme Portu -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | head -1 | cut -d '=' -f 2 | xargs)/Portu.app
+    if [ ! -d "$APP" ]; then echo "Could not locate Portu.app at $APP" >&2; exit 1; fi
+    open -n "$APP" --args --debug-server
     echo "Waiting for debug server..."
-    until curl -s http://localhost:9999/health > /dev/null 2>&1; do sleep 0.5; done
+    attempts=0
+    until curl -s http://localhost:9999/health > /dev/null 2>&1; do
+      sleep 0.5
+      attempts=$((attempts + 1))
+      if [ $attempts -ge 60 ]; then echo "Timed out waiting for debug server after 30s" >&2; exit 1; fi
+    done
     curl -s http://localhost:9999/health | jq .
     echo "Debug server ready at http://localhost:9999"
 
 # Stop the running debug app
 debug-stop:
-    pkill -f "Portu.app/Contents/MacOS/Portu" || true
+    pkill -f "Portu.app/Contents/MacOS/Portu.*--debug-server" || true
     @echo "Debug app stopped"
 
 # Clean build artifacts

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ format:
 # Build and launch with debug server on localhost:9999
 debug-run: build
     #!/bin/bash
-    APP=$(xcodebuild -scheme Portu -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | head -1 | cut -d '=' -f 2 | xargs)/Portu.app
+    APP=$(xcodebuild -scheme Portu -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | head -1 | cut -d '=' -f 2- | sed 's/^[[:space:]]*//')/Portu.app
     if [ ! -d "$APP" ]; then echo "Could not locate Portu.app at $APP" >&2; exit 1; fi
     open -n "$APP" --args --debug-server
     echo "Waiting for debug server..."

--- a/justfile
+++ b/justfile
@@ -43,7 +43,7 @@ debug-run: build
     #!/bin/bash
     APP=$(xcodebuild -scheme Portu -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | head -1 | cut -d '=' -f 2- | sed 's/^[[:space:]]*//')/Portu.app
     if [ ! -d "$APP" ]; then echo "Could not locate Portu.app at $APP" >&2; exit 1; fi
-    pkill -f "Portu.app/Contents/MacOS/Portu.*--debug-server" 2>/dev/null; sleep 0.5
+    lsof -ti tcp:9999 | xargs kill 2>/dev/null || true; sleep 0.5
     open -n "$APP" --args --debug-server
     echo "Waiting for debug server..."
     attempts=0
@@ -57,7 +57,7 @@ debug-run: build
 
 # Stop the running debug app
 debug-stop:
-    pkill -f "Portu.app/Contents/MacOS/Portu.*--debug-server" || true
+    lsof -ti tcp:9999 | xargs kill 2>/dev/null || true
     @echo "Debug app stopped"
 
 # Clean build artifacts


### PR DESCRIPTION
## Summary

- Replace static endpoint list in CLAUDE.md (already out of sync — missing `/state/prices` and `/state/sync`) with a hybrid approach: CLAUDE.md carries stable ambient awareness (categories, when to use), `/debug-verify` skill discovers endpoints from source
- Add `just debug-run` / `just debug-stop` recipes for ergonomic debug server lifecycle
- Add instruction to create debug endpoints when adding new SwiftData models or TCA state

## Context

After completing epic #37 (debug server), we identified that the static endpoint list in CLAUDE.md drifted within days — two routes added in PRs #49/#51 were never documented. A team debate (skill advocate vs CLAUDE.md advocate) converged on a hybrid: stable trigger knowledge in CLAUDE.md, dynamic procedural knowledge in a skill that reads source code.

## Test plan

- [x] `just debug-run` builds app and launches with debug server on localhost:9999
- [x] `curl localhost:9999/health` returns JSON with version and uptime
- [x] `just debug-stop` kills the running instance
- [x] App does NOT start debug server without `--debug-server` flag
- [x] `/debug-verify` skill appears in available skills list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `debug-run` and `debug-stop` commands for launching and terminating a local debug server.
  * Debug server accessible at `localhost:9999` enables inspection of app runtime state, data storage, and network activity during development.

* **Documentation**
  * Added debug verification guide with endpoint discovery and testing procedures.
  * Updated build guide with debug server setup instructions and contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->