### PR TITLE
fix: transactional isolation for syncAccount (#31)

### DIFF
--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -8,8 +8,9 @@ import SwiftData
 final class SyncEngine: @unchecked Sendable {
     private let modelContext: ModelContext
     private let providerFactory: ProviderFactory
-    /// Test seam: overrides upsertAsset when set; nil in production.
-    var upsertAssetOverride: ((TokenDTO) throws -> Asset)?
+    #if DEBUG
+        var upsertAssetOverride: ((TokenDTO) throws -> Asset)?
+    #endif
 
     init(modelContext: ModelContext, providerFactory: ProviderFactory) {
         self.modelContext = modelContext
@@ -155,7 +156,9 @@ final class SyncEngine: @unchecked Sendable {
 
     /// Internal (not private) — called directly by upsert/dedup tests.
     func upsertAsset(from dto: TokenDTO) throws -> Asset {
-        if let override = upsertAssetOverride { return try override(dto) }
+        #if DEBUG
+            if let override = upsertAssetOverride { return try override(dto) }
+        #endif
         // Tier 1: coinGeckoId
         if let cgId = dto.coinGeckoId, !cgId.isEmpty {
             if let existing = try fetchAsset(coinGeckoId: cgId) {

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -4,12 +4,12 @@ import PortuCore
 import PortuNetwork
 import SwiftData
 
-/// Non-final to allow test subclass override of upsertAsset (ThrowingSyncEngine).
-/// Any subclass must remain @MainActor-isolated to preserve the @unchecked Sendable contract.
 @MainActor
-class SyncEngine: @unchecked Sendable {
+final class SyncEngine: @unchecked Sendable {
     private let modelContext: ModelContext
     private let providerFactory: ProviderFactory
+    /// Test seam: overrides upsertAsset when set; nil in production.
+    var upsertAssetOverride: ((TokenDTO) throws -> Asset)?
 
     init(modelContext: ModelContext, providerFactory: ProviderFactory) {
         self.modelContext = modelContext
@@ -153,8 +153,9 @@ class SyncEngine: @unchecked Sendable {
 
     // MARK: - Asset Upsert (3-tier hierarchy)
 
-    /// Internal (not private) so ThrowingSyncEngine can override it in tests.
+    /// Internal (not private) — called directly by upsert/dedup tests.
     func upsertAsset(from dto: TokenDTO) throws -> Asset {
+        if let override = upsertAssetOverride { return try override(dto) }
         // Tier 1: coinGeckoId
         if let cgId = dto.coinGeckoId, !cgId.isEmpty {
             if let existing = try fetchAsset(coinGeckoId: cgId) {

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -5,6 +5,7 @@ import PortuNetwork
 import SwiftData
 
 /// Non-final to allow test subclass override of upsertAsset (ThrowingSyncEngine).
+/// Any subclass must remain @MainActor-isolated to preserve the @unchecked Sendable contract.
 @MainActor
 class SyncEngine: @unchecked Sendable {
     private let modelContext: ModelContext
@@ -64,33 +65,30 @@ class SyncEngine: @unchecked Sendable {
         let defi = try await provider.fetchDeFiPositions(context: context)
         let allDTOs = balances + defi
 
-        // ── Build phase: stage positions and tokens without inserting them ──
-        // If upsertAsset throws mid-loop, no positions have been deleted or
-        // inserted, so the account's data survives the failed attempt (#31).
-        // (Asset upserts may insert new Assets as a side effect; these are
-        // harmless shared reference data reused by future syncs.)
-        var staged: [(Position, [PositionToken])] = []
+        // ── Build phase: stage rebuild data as value types ──
+        // No @Model objects are constructed here — `Position` and `PositionToken`
+        // would auto-register with the ModelContext as soon as a relationship to
+        // an already-managed object (e.g. the resolved Asset) is set during init.
+        // Staging with plain structs keeps the build phase truly side-effect-free
+        // for Position/PositionToken rows (#31). Asset side effects are bounded:
+        // upsertAsset may insert a new Asset row or run updateAssetMetadata on an
+        // existing one, and the subsequent save() of `lastSyncError` flushes
+        // those mutations. They are self-healing — the 3-tier dedup hierarchy in
+        // upsertAsset prevents duplicate Asset accumulation across repeated
+        // partial failures, and the append-only key backfill never overwrites
+        // existing identity keys.
+        var staged: [StagedPosition] = []
 
         for dto in allDTOs {
-            let position = Position(
-                positionType: dto.positionType,
-                chain: dto.chain,
-                protocolId: dto.protocolId,
-                protocolName: dto.protocolName,
-                protocolLogoURL: dto.protocolLogoURL,
-                healthFactor: dto.healthFactor,
-                syncedAt: .now)
-
             var net: Decimal = 0
-            var tokens: [PositionToken] = []
+            var tokens: [StagedToken] = []
             for tokenDTO in dto.tokens {
                 let asset = try upsertAsset(from: tokenDTO)
-                let token = PositionToken(
+                tokens.append(StagedToken(
                     role: tokenDTO.role,
                     amount: tokenDTO.amount,
                     usdValue: tokenDTO.usdValue,
-                    asset: asset)
-                tokens.append(token)
+                    asset: asset))
 
                 if tokenDTO.role.isPositive {
                     net += tokenDTO.usdValue
@@ -100,21 +98,51 @@ class SyncEngine: @unchecked Sendable {
                 // reward: excluded from net
             }
 
-            position.netUSDValue = net
-            staged.append((position, tokens))
+            staged.append(StagedPosition(
+                positionType: dto.positionType,
+                chain: dto.chain,
+                protocolId: dto.protocolId,
+                protocolName: dto.protocolName,
+                protocolLogoURL: dto.protocolLogoURL,
+                healthFactor: dto.healthFactor,
+                netUSDValue: net,
+                tokens: tokens))
         }
 
         // ── Commit phase: all DTOs succeeded — replace positions ──
-        for position in account.positions {
+        // Note: this still uses the main ModelContext, not a scratch context, so
+        // a throw from save() after the delete loop would leave the account
+        // without positions until the next successful sync. The build-phase
+        // isolation in #31 covers the upsertAsset-throws path; commit-phase
+        // resilience would require a child ModelContext (tracked separately).
+        // Snapshot account.positions before deletion — it's a live SwiftData
+        // relationship array that mutates during cascade deletes.
+        for position in Array(account.positions) {
             modelContext.delete(position)
         }
 
-        for (position, tokens) in staged {
-            position.account = account
+        for entry in staged {
+            let position = Position(
+                positionType: entry.positionType,
+                chain: entry.chain,
+                protocolId: entry.protocolId,
+                protocolName: entry.protocolName,
+                protocolLogoURL: entry.protocolLogoURL,
+                healthFactor: entry.healthFactor,
+                netUSDValue: entry.netUSDValue,
+                syncedAt: .now)
+            // Insert before assigning the inverse relationship so SwiftData has
+            // a managed object on both sides when the inverse hook fires.
             modelContext.insert(position)
-            for token in tokens {
-                token.position = position
+            position.account = account
+            for stagedToken in entry.tokens {
+                let token = PositionToken(
+                    role: stagedToken.role,
+                    amount: stagedToken.amount,
+                    usdValue: stagedToken.usdValue,
+                    asset: stagedToken.asset)
                 modelContext.insert(token)
+                token.position = position
             }
         }
 
@@ -125,6 +153,7 @@ class SyncEngine: @unchecked Sendable {
 
     // MARK: - Asset Upsert (3-tier hierarchy)
 
+    /// Internal (not private) so ThrowingSyncEngine can override it in tests.
     func upsertAsset(from dto: TokenDTO) throws -> Asset {
         // Tier 1: coinGeckoId
         if let cgId = dto.coinGeckoId, !cgId.isEmpty {
@@ -368,6 +397,30 @@ class SyncEngine: @unchecked Sendable {
         let descriptor = FetchDescriptor<Asset>()
         return try modelContext.fetch(descriptor).first { $0.sourceKey == sourceKey }
     }
+}
+
+/// Plain-value staging for syncAccount's build phase. Holding @Model instances
+/// (Position/PositionToken) here would cause SwiftData to auto-register them
+/// when their relationships are assigned to already-managed objects, defeating
+/// the build-phase isolation. Pure structs keep the staging side-effect-free.
+private struct StagedPosition {
+    let positionType: PositionType
+    let chain: Chain?
+    let protocolId: String?
+    let protocolName: String?
+    let protocolLogoURL: String?
+    let healthFactor: Double?
+    let netUSDValue: Decimal
+    let tokens: [StagedToken]
+}
+
+private struct StagedToken {
+    let role: TokenRole
+    let amount: Decimal
+    let usdValue: Decimal
+    /// Reference to the already-resolved (managed) Asset. Storing a pointer in
+    /// a value type does not trigger SwiftData tracking.
+    let asset: Asset
 }
 
 private struct AssetSnapshotAccumulator {

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -4,8 +4,9 @@ import PortuCore
 import PortuNetwork
 import SwiftData
 
+/// Non-final to allow test subclass override of upsertAsset (ThrowingSyncEngine).
 @MainActor
-final class SyncEngine: @unchecked Sendable {
+class SyncEngine: @unchecked Sendable {
     private let modelContext: ModelContext
     private let providerFactory: ProviderFactory
 
@@ -63,12 +64,13 @@ final class SyncEngine: @unchecked Sendable {
         let defi = try await provider.fetchDeFiPositions(context: context)
         let allDTOs = balances + defi
 
-        // Delete stale positions from previous sync
-        for position in account.positions {
-            modelContext.delete(position)
-        }
+        // ── Build phase: stage positions and tokens without inserting them ──
+        // If upsertAsset throws mid-loop, no positions have been deleted or
+        // inserted, so the account's data survives the failed attempt (#31).
+        // (Asset upserts may insert new Assets as a side effect; these are
+        // harmless shared reference data reused by future syncs.)
+        var staged: [(Position, [PositionToken])] = []
 
-        // Map DTOs → SwiftData
         for dto in allDTOs {
             let position = Position(
                 positionType: dto.positionType,
@@ -77,19 +79,18 @@ final class SyncEngine: @unchecked Sendable {
                 protocolName: dto.protocolName,
                 protocolLogoURL: dto.protocolLogoURL,
                 healthFactor: dto.healthFactor,
-                account: account,
                 syncedAt: .now)
 
             var net: Decimal = 0
+            var tokens: [PositionToken] = []
             for tokenDTO in dto.tokens {
                 let asset = try upsertAsset(from: tokenDTO)
                 let token = PositionToken(
                     role: tokenDTO.role,
                     amount: tokenDTO.amount,
                     usdValue: tokenDTO.usdValue,
-                    asset: asset,
-                    position: position)
-                modelContext.insert(token)
+                    asset: asset)
+                tokens.append(token)
 
                 if tokenDTO.role.isPositive {
                     net += tokenDTO.usdValue
@@ -100,7 +101,21 @@ final class SyncEngine: @unchecked Sendable {
             }
 
             position.netUSDValue = net
+            staged.append((position, tokens))
+        }
+
+        // ── Commit phase: all DTOs succeeded — replace positions ──
+        for position in account.positions {
+            modelContext.delete(position)
+        }
+
+        for (position, tokens) in staged {
+            position.account = account
             modelContext.insert(position)
+            for token in tokens {
+                token.position = position
+                modelContext.insert(token)
+            }
         }
 
         account.lastSyncedAt = .now

--- a/Tests/PortuTests/SyncEngineTests.swift
+++ b/Tests/PortuTests/SyncEngineTests.swift
@@ -259,6 +259,9 @@ struct SyncEngineTests {
         #expect(fetched.positions.count == 1)
         #expect(fetched.positions.first?.tokens.first?.asset?.symbol == "OLD")
         #expect(fetched.lastSyncError != nil)
+
+        let allTokens = try freshContext.fetch(FetchDescriptor<PositionToken>())
+        #expect(allTokens.count == 1, "No orphan tokens from staged build phase")
     }
 
     @Test func `successful rebuild replaces positions`() async throws {

--- a/Tests/PortuTests/SyncEngineTests.swift
+++ b/Tests/PortuTests/SyncEngineTests.swift
@@ -1,12 +1,15 @@
 import Foundation
 @testable import Portu
 import PortuCore
+import PortuNetwork
 import SwiftData
 import Testing
 
 @MainActor
 struct SyncEngineTests {
-    private func makeTestContext() throws -> (ModelContext, SyncEngine) {
+    /// Use a fresh ModelContext per test — container.mainContext shares thread-local
+    /// state across tests which causes SIGTRAP when multiple containers exist.
+    private func makeModelContext() throws -> ModelContext {
         let schema = Schema([
             Account.self, WalletAddress.self, Position.self,
             PositionToken.self, Asset.self,
@@ -14,9 +17,11 @@ struct SyncEngineTests {
         ])
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: [config])
-        // Use a fresh ModelContext per test — container.mainContext shares thread-local
-        // state across tests which causes SIGTRAP when multiple containers exist.
-        let context = ModelContext(container)
+        return ModelContext(container)
+    }
+
+    private func makeTestContext() throws -> (ModelContext, SyncEngine) {
+        let context = try makeModelContext()
         let factory = ProviderFactory(secretStore: MockSecretStore())
         let engine = SyncEngine(modelContext: context, providerFactory: factory)
         return (context, engine)
@@ -169,6 +174,92 @@ struct SyncEngineTests {
         #expect(allAssets.count == 1)
     }
 
+    // MARK: - Transactional Isolation (#31)
+
+    /// Issue #31: If upsertAsset throws mid-rebuild, existing positions
+    /// must survive — the deferred delete must not have executed.
+    @Test func `failed rebuild preserves existing positions`() async throws {
+        let balances = [
+            PositionDTO(
+                positionType: .idle, chain: .ethereum,
+                protocolId: nil, protocolName: nil, protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")]),
+            PositionDTO(
+                positionType: .idle, chain: .ethereum,
+                protocolId: nil, protocolName: nil, protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "BTC", name: "Bitcoin", coinGeckoId: "bitcoin")])
+        ]
+        let (context, engine) = try makeThrowingContext(balances: balances, throwAfter: 1)
+
+        // Pre-populate: account has one existing position
+        let oldAsset = Asset(symbol: "OLD", name: "Old Token", category: .other)
+        context.insert(oldAsset)
+        let oldToken = PositionToken(role: .balance, amount: 50, usdValue: 1000, asset: oldAsset)
+        let oldPosition = Position(positionType: .idle, netUSDValue: 1000, tokens: [oldToken])
+        let account = Account(name: "Test Wallet", kind: .wallet, dataSource: .zapper, positions: [oldPosition])
+        context.insert(account)
+        try context.save()
+
+        // Sync — first upsertAsset succeeds, second throws
+        do {
+            _ = try await engine.sync()
+            Issue.record("Expected SyncError.allAccountsFailed")
+        } catch let error as SyncError {
+            #expect(error == .allAccountsFailed)
+        }
+
+        // Verify via fresh context: original position must survive
+        let freshContext = ModelContext(context.container)
+        let accounts = try freshContext.fetch(FetchDescriptor<Account>())
+        let fetched = try #require(accounts.first)
+
+        #expect(fetched.positions.count == 1, "Original position must survive failed rebuild")
+        #expect(fetched.positions[0].tokens.first?.asset?.symbol == "OLD")
+        #expect(fetched.lastSyncError != nil, "Error must be recorded")
+    }
+
+    @Test func `successful rebuild replaces positions`() async throws {
+        let balances = [
+            PositionDTO(
+                positionType: .idle, chain: .ethereum,
+                protocolId: nil, protocolName: nil, protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", amount: 10, usdValue: 25000, coinGeckoId: "ethereum")]),
+            PositionDTO(
+                positionType: .lending, chain: .ethereum,
+                protocolId: "aave-v3", protocolName: "Aave V3", protocolLogoURL: nil,
+                healthFactor: 1.5,
+                tokens: [makeTokenDTO(symbol: "USDC", name: "USD Coin", amount: 5000, usdValue: 5000, coinGeckoId: "usd-coin")])
+        ]
+        let (context, engine) = try makeMockContext(balances: balances)
+
+        // Pre-populate: account has one old position
+        let oldAsset = Asset(symbol: "OLD", name: "Old Token", category: .other)
+        context.insert(oldAsset)
+        let oldToken = PositionToken(role: .balance, amount: 50, usdValue: 1000, asset: oldAsset)
+        let oldPosition = Position(positionType: .idle, netUSDValue: 1000, tokens: [oldToken])
+        let account = Account(name: "Test Wallet", kind: .wallet, dataSource: .zapper, positions: [oldPosition])
+        context.insert(account)
+        try context.save()
+
+        let result = try await engine.sync()
+
+        // Old position replaced with 2 new ones
+        let freshContext = ModelContext(context.container)
+        let accounts = try freshContext.fetch(FetchDescriptor<Account>())
+        let fetched = try #require(accounts.first)
+
+        #expect(fetched.positions.count == 2)
+        let symbols = Set(fetched.positions.compactMap { $0.tokens.first?.asset?.symbol })
+        #expect(symbols.contains("ETH"))
+        #expect(symbols.contains("USDC"))
+        #expect(fetched.lastSyncError == nil)
+        #expect(fetched.lastSyncedAt != nil)
+        #expect(result.failedAccounts.isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeTokenDTO(
@@ -192,6 +283,27 @@ struct SyncEngineTests {
             debankId: debankId, coinGeckoId: coinGeckoId,
             sourceKey: sourceKey, logoURL: logoURL,
             category: category, isVerified: isVerified)
+    }
+
+    private func makeMockContext(balances: [PositionDTO]) throws -> (ModelContext, SyncEngine) {
+        let context = try makeModelContext()
+        let provider = StubProvider(balances: balances)
+        let factory = ProviderFactory(resolver: { _, _ in provider })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        return (context, engine)
+    }
+
+    private func makeThrowingContext(
+        balances: [PositionDTO],
+        throwAfter: Int) throws -> (ModelContext, ThrowingSyncEngine) {
+        let context = try makeModelContext()
+        let provider = StubProvider(balances: balances)
+        let factory = ProviderFactory(resolver: { _, _ in provider })
+        let engine = ThrowingSyncEngine(
+            modelContext: context,
+            providerFactory: factory,
+            throwAfter: throwAfter)
+        return (context, engine)
     }
 
     // MARK: - Snapshots
@@ -241,4 +353,45 @@ private final class MockSecretStore: SecretStore, @unchecked Sendable {
     func delete(key: KeychainKey) throws(KeychainError) {
         store.removeValue(forKey: key.rawKey)
     }
+}
+
+// MARK: - StubProvider
+
+private struct StubProvider: PortfolioDataProvider {
+    var capabilities: ProviderCapabilities {
+        ProviderCapabilities()
+    }
+
+    let balances: [PositionDTO]
+
+    func fetchBalances(context _: SyncContext) async throws -> [PositionDTO] {
+        balances
+    }
+}
+
+// MARK: - ThrowingSyncEngine
+
+/// Test subclass that forces upsertAsset to throw after N successful calls,
+/// simulating a mid-rebuild failure for transactional isolation testing.
+@MainActor
+private class ThrowingSyncEngine: SyncEngine {
+    let throwAfter: Int
+    private var upsertCount = 0
+
+    init(modelContext: ModelContext, providerFactory: ProviderFactory, throwAfter: Int) {
+        self.throwAfter = throwAfter
+        super.init(modelContext: modelContext, providerFactory: providerFactory)
+    }
+
+    override func upsertAsset(from dto: TokenDTO) throws -> Asset {
+        upsertCount += 1
+        if upsertCount > throwAfter {
+            throw SyncTestError.forcedUpsertFailure
+        }
+        return try super.upsertAsset(from: dto)
+    }
+}
+
+private enum SyncTestError: Error {
+    case forcedUpsertFailure
 }

--- a/Tests/PortuTests/SyncEngineTests.swift
+++ b/Tests/PortuTests/SyncEngineTests.swift
@@ -7,8 +7,8 @@ import Testing
 
 @MainActor
 struct SyncEngineTests {
-    /// Use a fresh ModelContext per test — container.mainContext shares thread-local
-    /// state across tests which causes SIGTRAP when multiple containers exist.
+    /// Use a fresh ModelContainer per test — reusing container.mainContext across
+    /// tests causes SIGTRAP due to shared thread-local SwiftData state.
     private func makeModelContext() throws -> ModelContext {
         let schema = Schema([
             Account.self, WalletAddress.self, Position.self,
@@ -177,7 +177,7 @@ struct SyncEngineTests {
     // MARK: - Transactional Isolation (#31)
 
     /// Issue #31: If upsertAsset throws mid-rebuild, existing positions
-    /// must survive — the deferred delete must not have executed.
+    /// must survive — the commit-phase delete must not have executed.
     @Test func `failed rebuild preserves existing positions`() async throws {
         let balances = [
             PositionDTO(
@@ -216,8 +216,49 @@ struct SyncEngineTests {
         let fetched = try #require(accounts.first)
 
         #expect(fetched.positions.count == 1, "Original position must survive failed rebuild")
-        #expect(fetched.positions[0].tokens.first?.asset?.symbol == "OLD")
+        #expect(fetched.positions.first?.tokens.first?.asset?.symbol == "OLD")
         #expect(fetched.lastSyncError != nil, "Error must be recorded")
+
+        // No orphan PositionToken rows from the build phase
+        let allTokens = try freshContext.fetch(FetchDescriptor<PositionToken>())
+        #expect(allTokens.count == 1, "No orphan tokens from staged build phase")
+    }
+
+    /// Boundary case: upsertAsset throws on the very first call. The build
+    /// phase stages nothing, so the commit phase is a no-op and existing
+    /// positions remain intact.
+    @Test func `failed rebuild on first upsert preserves existing positions`() async throws {
+        let balances = [
+            PositionDTO(
+                positionType: .idle, chain: .ethereum,
+                protocolId: nil, protocolName: nil, protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
+        ]
+        let (context, engine) = try makeThrowingContext(balances: balances, throwAfter: 0)
+
+        let oldAsset = Asset(symbol: "OLD", name: "Old Token", category: .other)
+        context.insert(oldAsset)
+        let oldToken = PositionToken(role: .balance, amount: 50, usdValue: 1000, asset: oldAsset)
+        let oldPosition = Position(positionType: .idle, netUSDValue: 1000, tokens: [oldToken])
+        let account = Account(name: "Test Wallet", kind: .wallet, dataSource: .zapper, positions: [oldPosition])
+        context.insert(account)
+        try context.save()
+
+        do {
+            _ = try await engine.sync()
+            Issue.record("Expected SyncError.allAccountsFailed")
+        } catch let error as SyncError {
+            #expect(error == .allAccountsFailed)
+        }
+
+        let freshContext = ModelContext(context.container)
+        let accounts = try freshContext.fetch(FetchDescriptor<Account>())
+        let fetched = try #require(accounts.first)
+
+        #expect(fetched.positions.count == 1)
+        #expect(fetched.positions.first?.tokens.first?.asset?.symbol == "OLD")
+        #expect(fetched.lastSyncError != nil)
     }
 
     @Test func `successful rebuild replaces positions`() async throws {
@@ -357,12 +398,18 @@ private final class MockSecretStore: SecretStore, @unchecked Sendable {
 
 // MARK: - StubProvider
 
-private struct StubProvider: PortfolioDataProvider {
-    var capabilities: ProviderCapabilities {
+/// Actor type to match the `PortfolioDataProvider` actor pattern used by real
+/// providers (ZapperProvider, ExchangeProvider) per the project guidelines.
+private actor StubProvider: PortfolioDataProvider {
+    nonisolated var capabilities: ProviderCapabilities {
         ProviderCapabilities()
     }
 
     let balances: [PositionDTO]
+
+    init(balances: [PositionDTO]) {
+        self.balances = balances
+    }
 
     func fetchBalances(context _: SyncContext) async throws -> [PositionDTO] {
         balances
@@ -373,8 +420,13 @@ private struct StubProvider: PortfolioDataProvider {
 
 /// Test subclass that forces upsertAsset to throw after N successful calls,
 /// simulating a mid-rebuild failure for transactional isolation testing.
+/// Single-use: `upsertCount` is not reset between sync() calls, so create a
+/// fresh instance per test.
 @MainActor
 private class ThrowingSyncEngine: SyncEngine {
+    /// Number of successful `upsertAsset` calls before throwing.
+    /// `throwAfter: 0` throws on the first call; `throwAfter: 1` lets the first
+    /// call succeed and throws on the second, and so on.
     let throwAfter: Int
     private var upsertCount = 0
 

--- a/Tests/PortuTests/SyncEngineTests.swift
+++ b/Tests/PortuTests/SyncEngineTests.swift
@@ -336,14 +336,21 @@ struct SyncEngineTests {
 
     private func makeThrowingContext(
         balances: [PositionDTO],
-        throwAfter: Int) throws -> (ModelContext, ThrowingSyncEngine) {
+        throwAfter: Int) throws -> (ModelContext, SyncEngine) {
         let context = try makeModelContext()
         let provider = StubProvider(balances: balances)
         let factory = ProviderFactory(resolver: { _, _ in provider })
-        let engine = ThrowingSyncEngine(
-            modelContext: context,
-            providerFactory: factory,
-            throwAfter: throwAfter)
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        var upsertCount = 0
+        engine.upsertAssetOverride = { dto in
+            upsertCount += 1
+            if upsertCount > throwAfter {
+                throw SyncTestError.forcedUpsertFailure
+            }
+            let asset = Asset(symbol: dto.symbol, name: dto.name, category: dto.category)
+            context.insert(asset)
+            return asset
+        }
         return (context, engine)
     }
 
@@ -413,34 +420,6 @@ private actor StubProvider: PortfolioDataProvider {
 
     func fetchBalances(context _: SyncContext) async throws -> [PositionDTO] {
         balances
-    }
-}
-
-// MARK: - ThrowingSyncEngine
-
-/// Test subclass that forces upsertAsset to throw after N successful calls,
-/// simulating a mid-rebuild failure for transactional isolation testing.
-/// Single-use: `upsertCount` is not reset between sync() calls, so create a
-/// fresh instance per test.
-@MainActor
-private class ThrowingSyncEngine: SyncEngine {
-    /// Number of successful `upsertAsset` calls before throwing.
-    /// `throwAfter: 0` throws on the first call; `throwAfter: 1` lets the first
-    /// call succeed and throws on the second, and so on.
-    let throwAfter: Int
-    private var upsertCount = 0
-
-    init(modelContext: ModelContext, providerFactory: ProviderFactory, throwAfter: Int) {
-        self.throwAfter = throwAfter
-        super.init(modelContext: modelContext, providerFactory: providerFactory)
-    }
-
-    override func upsertAsset(from dto: TokenDTO) throws -> Asset {
-        upsertCount += 1
-        if upsertCount > throwAfter {
-            throw SyncTestError.forcedUpsertFailure
-        }
-        return try super.upsertAsset(from: dto)
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix data loss when `syncAccount` rebuild fails mid-loop. Previously, positions were deleted before rebuilding from API data; if `upsertAsset` threw, the `save()` on the all-accounts-failed path persisted the deletions and partial inserts.
- Restructured into a two-phase build/commit pattern: positions and tokens are staged in memory first, and old positions are only deleted (and new ones inserted) after the build phase succeeds.
- Added regression tests via a `StubProvider` and an `upsertAssetOverride` closure injected into `SyncEngine` to force a mid-rebuild upsert failure.

Closes #31

## Test plan

- [x] New test `failed rebuild preserves existing positions` — fails on the old code, passes on the new
- [x] New test `successful rebuild replaces positions` — regression guard for the success path
- [x] Existing test `lastSyncError persisted when all syncable accounts fail` still passes
- [x] Full Xcode test suite passes (261 tests, 42 suites)
- [x] SPM package tests pass (PortuCore, PortuNetwork, PortuUI)
- [x] SwiftLint clean (no new warnings)