### PR TITLE
[codex] Redesign settings main view

### DIFF
--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -65,6 +65,26 @@ extension DependencyValues {
     }
 }
 
+// MARK: - PricePollingSettingsClient
+
+struct PricePollingSettingsClient {
+    var refreshInterval: @Sendable () -> Duration
+}
+
+extension PricePollingSettingsClient: DependencyKey {
+    static let liveValue = Self(
+        refreshInterval: { PricePollingSettings.refreshInterval() })
+    static let testValue = Self(
+        refreshInterval: { .seconds(PricePollingSettings.defaultRefreshIntervalSeconds) })
+}
+
+extension DependencyValues {
+    var pricePollingSettings: PricePollingSettingsClient {
+        get { self[PricePollingSettingsClient.self] }
+        set { self[PricePollingSettingsClient.self] = newValue }
+    }
+}
+
 // MARK: - AppFeature
 
 @Reducer
@@ -119,6 +139,7 @@ struct AppFeature {
 
     @Dependency(\.syncEngine) var syncEngine
     @Dependency(\.priceService) var priceService
+    @Dependency(\.pricePollingSettings) var pricePollingSettings
     @Dependency(\.continuousClock) var clock
     @Dependency(\.date.now) var now
 
@@ -188,7 +209,7 @@ struct AppFeature {
                         } catch {
                             await send(.priceFetchFailed(error))
                         }
-                        try await clock.sleep(for: .seconds(30))
+                        try await clock.sleep(for: pricePollingSettings.refreshInterval())
                     }
                 }
                 .cancellable(id: CancelID.pricePolling, cancelInFlight: true)

--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -72,6 +72,15 @@ struct AppFeature {
     @ObservableState
     struct State: Equatable {
         var selectedSection: SidebarSection = .overview
+        var isSettingsPresented = false
+        var detailRoute: AppDetailRoute {
+            isSettingsPresented ? .settings : .section(selectedSection)
+        }
+
+        var sidebarSelection: SidebarSection? {
+            isSettingsPresented ? nil : selectedSection
+        }
+
         var syncStatus: SyncStatus = .idle
         var connectionStatus: ConnectionStatus = .idle
         var prices: [String: Decimal] = [:]
@@ -88,6 +97,7 @@ struct AppFeature {
 
     enum Action {
         case sectionSelected(SidebarSection)
+        case settingsSelected
         case syncTapped
         case syncProgressUpdated(Double)
         case syncCompleted(Result<SyncResult, Error>)
@@ -135,6 +145,11 @@ struct AppFeature {
             switch action {
             case let .sectionSelected(section):
                 state.selectedSection = section
+                state.isSettingsPresented = false
+                return .none
+
+            case .settingsSelected:
+                state.isSettingsPresented = true
                 return .none
 
             case .syncTapped:
@@ -222,6 +237,7 @@ extension AppFeature.Action: Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case let (.sectionSelected(l), .sectionSelected(r)): l == r
+        case (.settingsSelected, .settingsSelected): true
         case (.syncTapped, .syncTapped): true
         case let (.syncProgressUpdated(l), .syncProgressUpdated(r)): l == r
         case let (.syncCompleted(.success(l)), .syncCompleted(.success(r))): l == r

--- a/Sources/Portu/App/AppState.swift
+++ b/Sources/Portu/App/AppState.swift
@@ -11,6 +11,11 @@ enum SidebarSection: Hashable {
     case accounts
 }
 
+enum AppDetailRoute: Equatable {
+    case section(SidebarSection)
+    case settings
+}
+
 enum ConnectionStatus: Hashable {
     case idle
     case fetching

--- a/Sources/Portu/App/ContentView.swift
+++ b/Sources/Portu/App/ContentView.swift
@@ -7,6 +7,11 @@ struct ContentView: View {
     let store: StoreOf<AppFeature>
 
     var body: some View {
+        mainDashboard
+            .frame(minWidth: 900, minHeight: 600)
+    }
+
+    private var mainDashboard: some View {
         VStack(spacing: 0) {
             NavigationSplitView {
                 SidebarView(store: store)
@@ -18,12 +23,21 @@ struct ContentView: View {
             }
             StatusBarView(store: store)
         }
-        .frame(minWidth: 900, minHeight: 600)
     }
 
     @ViewBuilder
     private var detailView: some View {
-        switch store.selectedSection {
+        switch store.detailRoute {
+        case let .section(section):
+            sectionView(section)
+        case .settings:
+            SettingsView()
+        }
+    }
+
+    @ViewBuilder
+    private func sectionView(_ section: SidebarSection) -> some View {
+        switch section {
         case .overview:
             OverviewView(store: store)
         case .exposure:

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -83,11 +83,5 @@ struct PortuApp: App {
                 .environment(appState)
         }
         .modelContainer(container)
-
-        Settings {
-            SettingsView()
-                .environment(appState)
-        }
-        .modelContainer(container)
     }
 }

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -83,5 +83,13 @@ struct PortuApp: App {
                 .environment(appState)
         }
         .modelContainer(container)
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings...") {
+                    store.send(.settingsSelected)
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+        }
     }
 }

--- a/Sources/Portu/App/PricePollingSettings.swift
+++ b/Sources/Portu/App/PricePollingSettings.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum PricePollingSettings {
+    static let refreshIntervalKey = "refreshInterval"
+    static let defaultRefreshIntervalSeconds = 30.0
+    static let allowedRefreshIntervalSeconds: Set<Double> = [15, 30, 60, 300]
+
+    static func refreshIntervalSeconds(defaults: UserDefaults = .standard) -> Double {
+        guard
+            let stored = defaults.object(forKey: refreshIntervalKey) as? Double,
+            allowedRefreshIntervalSeconds.contains(stored)
+        else {
+            return defaultRefreshIntervalSeconds
+        }
+
+        return stored
+    }
+
+    static func refreshInterval(defaults: UserDefaults = .standard) -> Duration {
+        .seconds(refreshIntervalSeconds(defaults: defaults))
+    }
+}

--- a/Sources/Portu/Features/Settings/APIKeysSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/APIKeysSettingsTab.swift
@@ -1,99 +1,236 @@
 import PortuCore
 import SwiftUI
 
+enum APIKeyInputMode: Equatable {
+    case visibleText
+    case secureText
+}
+
+enum APIKeysSettingsLayout {
+    static let inputMode: APIKeyInputMode = .visibleText
+}
+
 struct APIKeysSettingsTab: View {
     @State private var viewModel = APIKeysViewModel()
     @State private var newRPCChain: Chain = .ethereum
     @State private var newRPCURL = ""
-    @State private var showError = false
     @State private var saveTask: Task<Void, Never>?
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                apiKeyField("Zapper", text: $viewModel.zapperAPIKey)
-                apiKeyField("DeBank", text: $viewModel.debankAPIKey)
-                apiKeyField(
-                    "CoinGecko",
-                    text: $viewModel.coingeckoAPIKey,
-                    hint: "Optional. Provides higher rate limits.")
+        SettingsPage(tab: .apiKeys, badge: .autoSave) {
+            VStack(alignment: .leading, spacing: 24) {
+                SettingsSectionCard(
+                    title: "Provider API Keys",
+                    subtitle: "Secrets are stored locally in macOS Keychain.") {
+                        VStack(spacing: 0) {
+                            apiKeyField(
+                                title: "Zapper",
+                                glyph: "Z",
+                                foreground: SettingsDesign.accentBlue,
+                                background: SettingsDesign.blueGlyphBackground,
+                                text: $viewModel.zapperAPIKey)
 
-                rpcSection
+                            SettingsDivider()
+                                .padding(.vertical, 8)
+
+                            apiKeyField(
+                                title: "DeBank",
+                                glyph: "D",
+                                foreground: SettingsDesign.warningOrange,
+                                background: SettingsDesign.orangeGlyphBackground,
+                                text: $viewModel.debankAPIKey)
+
+                            SettingsDivider()
+                                .padding(.vertical, 8)
+
+                            apiKeyField(
+                                title: "CoinGecko",
+                                glyph: "C",
+                                foreground: Color(red: 0.015, green: 0.520, blue: 0.275),
+                                background: Color(red: 0.885, green: 0.985, blue: 0.930),
+                                text: $viewModel.coingeckoAPIKey,
+                                hint: "Optional. Provides higher rate limits.")
+                        }
+                    }
+
+                SettingsSectionCard(
+                    title: "Custom RPCs",
+                    subtitle: "Override a chain's default RPC endpoint when needed.") {
+                        VStack(alignment: .leading, spacing: 22) {
+                            rpcTable
+                            addEndpointSection
+
+                            if let keychainError = viewModel.keychainError {
+                                SettingsInlineNotice(
+                                    title: "Keychain Error",
+                                    message: keychainError,
+                                    style: .error)
+                            }
+                        }
+                    }
             }
-            .padding()
         }
-        .navigationTitle("API Keys")
         .task { if !viewModel.hasLoaded { viewModel.load() } }
-        .onChange(of: viewModel.zapperAPIKey) { debounceSave() }
-        .onChange(of: viewModel.debankAPIKey) { debounceSave() }
-        .onChange(of: viewModel.coingeckoAPIKey) { debounceSave() }
-        .onChange(of: viewModel.keychainError) { _, error in
-            showError = error != nil
-        }
-        .alert("Keychain Error", isPresented: $showError) {
-            Button("OK") { viewModel.keychainError = nil }
-        } message: {
-            Text(viewModel.keychainError ?? "")
-        }
+        .onChange(of: viewModel.zapperAPIKey) { _, _ in debounceSave() }
+        .onChange(of: viewModel.debankAPIKey) { _, _ in debounceSave() }
+        .onChange(of: viewModel.coingeckoAPIKey) { _, _ in debounceSave() }
     }
 
     private func apiKeyField(
-        _ title: String,
+        title: String,
+        glyph: String,
+        foreground: Color,
+        background: Color,
         text: Binding<String>,
         hint: String? = nil) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.headline)
-            TextField("Enter API key", text: text)
-                .textFieldStyle(.roundedBorder)
-            if let hint {
-                Text(hint)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        HStack(alignment: .top, spacing: 14) {
+            SettingsLetterTile(
+                glyph: glyph,
+                foreground: foreground,
+                background: background)
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+
+                if let hint {
+                    Text(hint)
+                        .font(.caption)
+                        .foregroundStyle(SettingsDesign.secondaryText)
+                }
             }
+            .frame(width: 190, alignment: .leading)
+
+            apiKeyInput(text: text)
+                .textFieldStyle(.plain)
+                .font(.footnote)
+                .foregroundStyle(SettingsDesign.primaryText)
+                .settingsInputFrame(height: SettingsMetrics.compactInputHeight)
         }
     }
 
-    private var rpcSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Custom RPCs")
-                .font(.headline)
+    @ViewBuilder
+    private func apiKeyInput(text: Binding<String>) -> some View {
+        switch APIKeysSettingsLayout.inputMode {
+        case .visibleText:
+            TextField("Enter API key", text: text)
+        case .secureText:
+            SecureField("Enter API key", text: text)
+        }
+    }
 
-            ForEach(
-                viewModel.rpcEndpoints.sorted(by: { $0.key.rawValue < $1.key.rawValue }),
-                id: \.key) { chain, url in
-                    HStack {
-                        Text(chain.rawValue.capitalized)
-                            .frame(width: 80, alignment: .leading)
-                        Text(url)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Spacer()
-                        Button(role: .destructive) {
-                            viewModel.removeRPCEndpoint(chain: chain)
-                            debounceSave()
-                        } label: {
-                            Image(systemName: "trash")
-                        }
-                        .buttonStyle(.borderless)
+    private var rpcTable: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 18) {
+                Text("Chain")
+                    .frame(width: 132, alignment: .leading)
+                Text("RPC URL")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text("")
+                    .frame(width: 46)
+            }
+            .font(.caption.weight(.bold))
+            .foregroundStyle(SettingsDesign.secondaryText)
+            .padding(.horizontal, 16)
+            .frame(height: 32)
+
+            if viewModel.rpcEndpoints.isEmpty {
+                HStack(spacing: 18) {
+                    Text("Configured endpoints appear here")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button {} label: {
+                        Image(systemName: "trash")
+                            .font(.system(size: 13, weight: .semibold))
                     }
+                    .buttonStyle(.plain)
+                    .disabled(true)
+                    .settingsIconButton(color: SettingsDesign.warningOrange)
                 }
+                .font(.footnote)
+                .foregroundStyle(SettingsDesign.secondaryText)
+                .padding(.horizontal, 16)
+                .frame(height: 42)
+            } else {
+                ForEach(
+                    viewModel.rpcEndpoints.sorted(by: { $0.key.rawValue < $1.key.rawValue }),
+                    id: \.key) { chain, url in
+                        HStack(spacing: 18) {
+                            Text(chain.rawValue.capitalized)
+                                .foregroundStyle(SettingsDesign.primaryText)
+                                .frame(width: 132, alignment: .leading)
+                            Text(url)
+                                .foregroundStyle(SettingsDesign.secondaryText)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            Button {
+                                viewModel.removeRPCEndpoint(chain: chain)
+                                debounceSave()
+                            } label: {
+                                Image(systemName: "trash")
+                                    .font(.system(size: 13, weight: .semibold))
+                            }
+                            .buttonStyle(.plain)
+                            .settingsIconButton(color: SettingsDesign.warningOrange)
+                        }
+                        .font(.footnote)
+                        .padding(.horizontal, 16)
+                        .frame(height: 42)
+                    }
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(SettingsDesign.subtleCardBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(SettingsDesign.separator, lineWidth: 1))
+    }
+
+    private var addEndpointSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Add endpoint")
+                    .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+                Text("Pick an available chain, enter its RPC URL, then add it.")
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.secondaryText)
+            }
 
             if !availableChains.isEmpty {
-                HStack {
-                    Picker("Chain", selection: $newRPCChain) {
+                HStack(spacing: 14) {
+                    Menu {
                         ForEach(availableChains, id: \.self) { chain in
-                            Text(chain.rawValue.capitalized).tag(chain)
+                            Button(chain.rawValue.capitalized) {
+                                newRPCChain = chain
+                            }
                         }
+                    } label: {
+                        HStack(spacing: 8) {
+                            Text(newRPCChain.rawValue.capitalized)
+                                .lineLimit(1)
+                            Spacer(minLength: 8)
+                            Image(systemName: "chevron.down")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .font(.footnote)
+                        .foregroundStyle(SettingsDesign.primaryText)
                     }
-                    .labelsHidden()
-                    .frame(width: 120)
+                    .menuStyle(.button)
+                    .buttonStyle(.plain)
+                    .settingsMenuFrame(height: SettingsMetrics.compactInputHeight)
+                    .frame(width: 132)
 
                     TextField("RPC URL", text: $newRPCURL)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(.plain)
+                        .font(.footnote)
+                        .foregroundStyle(SettingsDesign.primaryText)
+                        .settingsInputFrame(height: SettingsMetrics.compactInputHeight)
 
-                    Button("Add") {
+                    Button {
                         guard !newRPCURL.isEmpty else { return }
                         viewModel.addRPCEndpoint(chain: newRPCChain, url: newRPCURL)
                         newRPCURL = ""
@@ -101,9 +238,18 @@ struct APIKeysSettingsTab: View {
                             newRPCChain = next
                         }
                         debounceSave()
+                    } label: {
+                        Text("Add")
+                            .font(.footnote.weight(.bold))
                     }
+                    .buttonStyle(.plain)
+                    .settingsPrimaryButton(isDisabled: newRPCURL.isEmpty)
                     .disabled(newRPCURL.isEmpty)
                 }
+            } else {
+                Text("All supported chains have custom endpoints.")
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.secondaryText)
             }
         }
     }
@@ -120,5 +266,101 @@ struct APIKeysSettingsTab: View {
             guard !Task.isCancelled else { return }
             viewModel.save()
         }
+    }
+}
+
+struct SettingsInlineNotice: View {
+    enum Style {
+        case error
+        case action
+    }
+
+    let title: String
+    let message: String?
+    let style: Style
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: message == nil ? 0 : 6) {
+            Text(title)
+                .font(.footnote.weight(.bold))
+            if let message {
+                Text(message)
+                    .font(.footnote)
+            }
+        }
+        .foregroundStyle(foreground)
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, minHeight: message == nil ? 38 : 56, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(background))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(stroke, lineWidth: 1))
+    }
+
+    private var background: Color {
+        switch style {
+        case .error: Color(red: 1.0, green: 0.970, blue: 0.925)
+        case .action: Color(red: 0.910, green: 0.930, blue: 1.0)
+        }
+    }
+
+    private var stroke: Color {
+        switch style {
+        case .error: Color(red: 0.980, green: 0.590, blue: 0.235)
+        case .action: Color(red: 0.600, green: 0.690, blue: 1.0)
+        }
+    }
+
+    private var foreground: Color {
+        switch style {
+        case .error: Color(red: 0.640, green: 0.160, blue: 0.050)
+        case .action: Color(red: 0.245, green: 0.180, blue: 0.780)
+        }
+    }
+}
+
+extension View {
+    func settingsInputFrame(height: CGFloat) -> some View {
+        padding(.horizontal, 12)
+            .frame(height: height)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(SettingsDesign.subtleCardBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+
+    func settingsMenuFrame(height: CGFloat) -> some View {
+        padding(.horizontal, 12)
+            .frame(height: height)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(SettingsDesign.subtleCardBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+
+    func settingsIconButton(color: Color) -> some View {
+        foregroundStyle(color)
+            .frame(width: 42, height: 28)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(color.opacity(0.10)))
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .stroke(color.opacity(0.25), lineWidth: 1))
+    }
+
+    func settingsPrimaryButton(isDisabled: Bool) -> some View {
+        foregroundStyle(isDisabled ? SettingsDesign.secondaryText : Color.white)
+            .frame(width: 64, height: SettingsMetrics.compactControlHeight)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(isDisabled ? Color(red: 0.800, green: 0.830, blue: 0.880) : SettingsDesign.accentBlue))
     }
 }

--- a/Sources/Portu/Features/Settings/APIKeysSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/APIKeysSettingsTab.swift
@@ -6,14 +6,61 @@ enum APIKeyInputMode: Equatable {
     case secureText
 }
 
+private enum APIKeyFieldID: Hashable {
+    case zapper
+    case debank
+    case coingecko
+}
+
+private struct APIKeyFieldDescriptor {
+    let id: APIKeyFieldID
+    let title: String
+    let glyph: String
+    let foreground: Color
+    let background: Color
+    let hint: String?
+}
+
+private extension APIKeyFieldDescriptor {
+    static let zapper = Self(
+        id: .zapper,
+        title: "Zapper",
+        glyph: "Z",
+        foreground: SettingsDesign.accentBlue,
+        background: SettingsDesign.blueGlyphBackground,
+        hint: nil)
+
+    static let debank = Self(
+        id: .debank,
+        title: "DeBank",
+        glyph: "D",
+        foreground: SettingsDesign.warningOrange,
+        background: SettingsDesign.orangeGlyphBackground,
+        hint: nil)
+
+    static let coingecko = Self(
+        id: .coingecko,
+        title: "CoinGecko",
+        glyph: "C",
+        foreground: Color(red: 0.015, green: 0.520, blue: 0.275),
+        background: Color(red: 0.885, green: 0.985, blue: 0.930),
+        hint: "Optional. Provides higher rate limits.")
+}
+
 enum APIKeysSettingsLayout {
-    static let inputMode: APIKeyInputMode = .visibleText
+    static let defaultInputMode: APIKeyInputMode = .secureText
+
+    static func inputMode(isVisible: Bool) -> APIKeyInputMode {
+        isVisible ? .visibleText : defaultInputMode
+    }
 }
 
 struct APIKeysSettingsTab: View {
     @State private var viewModel = APIKeysViewModel()
     @State private var newRPCChain: Chain = .ethereum
     @State private var newRPCURL = ""
+    @State private var visibleAPIKeyFields: Set<APIKeyFieldID> = []
+    @State private var hasPendingSave = false
     @State private var saveTask: Task<Void, Never>?
 
     var body: some View {
@@ -24,32 +71,22 @@ struct APIKeysSettingsTab: View {
                     subtitle: "Secrets are stored locally in macOS Keychain.") {
                         VStack(spacing: 0) {
                             apiKeyField(
-                                title: "Zapper",
-                                glyph: "Z",
-                                foreground: SettingsDesign.accentBlue,
-                                background: SettingsDesign.blueGlyphBackground,
+                                .zapper,
                                 text: $viewModel.zapperAPIKey)
 
                             SettingsDivider()
                                 .padding(.vertical, 8)
 
                             apiKeyField(
-                                title: "DeBank",
-                                glyph: "D",
-                                foreground: SettingsDesign.warningOrange,
-                                background: SettingsDesign.orangeGlyphBackground,
+                                .debank,
                                 text: $viewModel.debankAPIKey)
 
                             SettingsDivider()
                                 .padding(.vertical, 8)
 
                             apiKeyField(
-                                title: "CoinGecko",
-                                glyph: "C",
-                                foreground: Color(red: 0.015, green: 0.520, blue: 0.275),
-                                background: Color(red: 0.885, green: 0.985, blue: 0.930),
-                                text: $viewModel.coingeckoAPIKey,
-                                hint: "Optional. Provides higher rate limits.")
+                                .coingecko,
+                                text: $viewModel.coingeckoAPIKey)
                         }
                     }
 
@@ -74,28 +111,25 @@ struct APIKeysSettingsTab: View {
         .onChange(of: viewModel.zapperAPIKey) { _, _ in debounceSave() }
         .onChange(of: viewModel.debankAPIKey) { _, _ in debounceSave() }
         .onChange(of: viewModel.coingeckoAPIKey) { _, _ in debounceSave() }
+        .onDisappear { flushPendingSave() }
     }
 
     private func apiKeyField(
-        title: String,
-        glyph: String,
-        foreground: Color,
-        background: Color,
-        text: Binding<String>,
-        hint: String? = nil) -> some View {
+        _ descriptor: APIKeyFieldDescriptor,
+        text: Binding<String>) -> some View {
         HStack(alignment: .top, spacing: 14) {
             SettingsLetterTile(
-                glyph: glyph,
-                foreground: foreground,
-                background: background)
+                glyph: descriptor.glyph,
+                foreground: descriptor.foreground,
+                background: descriptor.background)
                 .frame(width: 32, height: 32)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(title)
+                Text(descriptor.title)
                     .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
                     .foregroundStyle(SettingsDesign.primaryText)
 
-                if let hint {
+                if let hint = descriptor.hint {
                     Text(hint)
                         .font(.caption)
                         .foregroundStyle(SettingsDesign.secondaryText)
@@ -103,17 +137,35 @@ struct APIKeysSettingsTab: View {
             }
             .frame(width: 190, alignment: .leading)
 
-            apiKeyInput(text: text)
-                .textFieldStyle(.plain)
-                .font(.footnote)
-                .foregroundStyle(SettingsDesign.primaryText)
-                .settingsInputFrame(height: SettingsMetrics.compactInputHeight)
+            let isVisible = visibleAPIKeyFields.contains(descriptor.id)
+
+            HStack(spacing: 8) {
+                apiKeyInput(
+                    text: text,
+                    mode: APIKeysSettingsLayout.inputMode(isVisible: isVisible))
+                    .textFieldStyle(.plain)
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.primaryText)
+                    .frame(maxWidth: .infinity)
+
+                Button {
+                    toggleVisibility(for: descriptor.id)
+                } label: {
+                    Image(systemName: isVisible ? "eye.slash" : "eye")
+                        .font(.system(size: 13, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(SettingsDesign.secondaryText)
+                .frame(width: 28, height: 28)
+                .accessibilityLabel(isVisible ? "Hide \(descriptor.title) API key" : "Show \(descriptor.title) API key")
+            }
+            .settingsInputFrame(height: SettingsMetrics.compactInputHeight)
         }
     }
 
     @ViewBuilder
-    private func apiKeyInput(text: Binding<String>) -> some View {
-        switch APIKeysSettingsLayout.inputMode {
+    private func apiKeyInput(text: Binding<String>, mode: APIKeyInputMode) -> some View {
+        switch mode {
         case .visibleText:
             TextField("Enter API key", text: text)
         case .secureText:
@@ -258,109 +310,30 @@ struct APIKeysSettingsTab: View {
         Chain.allCases.filter { viewModel.rpcEndpoints[$0] == nil }
     }
 
+    private func toggleVisibility(for field: APIKeyFieldID) {
+        if visibleAPIKeyFields.contains(field) {
+            visibleAPIKeyFields.remove(field)
+        } else {
+            visibleAPIKeyFields.insert(field)
+        }
+    }
+
     private func debounceSave() {
         guard !viewModel.isLoading else { return }
+        hasPendingSave = true
         saveTask?.cancel()
-        saveTask = Task {
+        saveTask = Task { @MainActor in
             try? await Task.sleep(for: .seconds(1))
             guard !Task.isCancelled else { return }
             viewModel.save()
-        }
-    }
-}
-
-struct SettingsInlineNotice: View {
-    enum Style {
-        case error
-        case action
-    }
-
-    let title: String
-    let message: String?
-    let style: Style
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: message == nil ? 0 : 6) {
-            Text(title)
-                .font(.footnote.weight(.bold))
-            if let message {
-                Text(message)
-                    .font(.footnote)
-            }
-        }
-        .foregroundStyle(foreground)
-        .padding(.horizontal, 16)
-        .frame(maxWidth: .infinity, minHeight: message == nil ? 38 : 56, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(background))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(stroke, lineWidth: 1))
-    }
-
-    private var background: Color {
-        switch style {
-        case .error: Color(red: 1.0, green: 0.970, blue: 0.925)
-        case .action: Color(red: 0.910, green: 0.930, blue: 1.0)
+            hasPendingSave = false
         }
     }
 
-    private var stroke: Color {
-        switch style {
-        case .error: Color(red: 0.980, green: 0.590, blue: 0.235)
-        case .action: Color(red: 0.600, green: 0.690, blue: 1.0)
-        }
-    }
-
-    private var foreground: Color {
-        switch style {
-        case .error: Color(red: 0.640, green: 0.160, blue: 0.050)
-        case .action: Color(red: 0.245, green: 0.180, blue: 0.780)
-        }
-    }
-}
-
-extension View {
-    func settingsInputFrame(height: CGFloat) -> some View {
-        padding(.horizontal, 12)
-            .frame(height: height)
-            .frame(maxWidth: .infinity)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(SettingsDesign.subtleCardBackground))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(SettingsDesign.cardStroke, lineWidth: 1))
-    }
-
-    func settingsMenuFrame(height: CGFloat) -> some View {
-        padding(.horizontal, 12)
-            .frame(height: height)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(SettingsDesign.subtleCardBackground))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(SettingsDesign.cardStroke, lineWidth: 1))
-    }
-
-    func settingsIconButton(color: Color) -> some View {
-        foregroundStyle(color)
-            .frame(width: 42, height: 28)
-            .background(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .fill(color.opacity(0.10)))
-            .overlay(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .stroke(color.opacity(0.25), lineWidth: 1))
-    }
-
-    func settingsPrimaryButton(isDisabled: Bool) -> some View {
-        foregroundStyle(isDisabled ? SettingsDesign.secondaryText : Color.white)
-            .frame(width: 64, height: SettingsMetrics.compactControlHeight)
-            .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(isDisabled ? Color(red: 0.800, green: 0.830, blue: 0.880) : SettingsDesign.accentBlue))
+    private func flushPendingSave() {
+        saveTask?.cancel()
+        guard hasPendingSave, !viewModel.isLoading else { return }
+        viewModel.save()
+        hasPendingSave = false
     }
 }

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -6,7 +6,6 @@
         @Environment(AppState.self) private var appState
         @AppStorage(DebugMode.enabledKey) private var isEnabled = false
         @AppStorage(DebugMode.portKey) private var port = Int(DebugMode.defaultPort)
-        @FocusState private var portFieldFocused: Bool
 
         private var isRunning: Bool {
             appState.debugServer != nil
@@ -140,14 +139,8 @@
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(SettingsDesign.primaryText)
                     .multilineTextAlignment(.trailing)
-                    .focused($portFieldFocused)
                     .settingsInputFrame(height: SettingsMetrics.compactInputHeight)
                     .frame(width: 96)
-                    .onAppear {
-                        Task { @MainActor in
-                            portFieldFocused = false
-                        }
-                    }
                     .onChange(of: port) { _, newValue in
                         if newValue <= 0 || newValue > Int(UInt16.max) {
                             port = Int(DebugMode.defaultPort)
@@ -172,17 +165,19 @@
 
                 Spacer(minLength: 18)
 
-                Text("Running on port \(appState.debugServer?.port ?? DebugMode.defaultPort)")
-                    .font(.footnote)
-                    .foregroundStyle(SettingsDesign.secondaryText)
-                    .padding(.horizontal, 14)
-                    .frame(height: 32)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .fill(SettingsDesign.subtleCardBackground))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(SettingsDesign.separator, lineWidth: 1))
+                if let debugServer = appState.debugServer {
+                    Text("Running on port \(debugServer.port)")
+                        .font(.footnote)
+                        .foregroundStyle(SettingsDesign.secondaryText)
+                        .padding(.horizontal, 14)
+                        .frame(height: 32)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(SettingsDesign.subtleCardBackground))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .stroke(SettingsDesign.separator, lineWidth: 1))
+                }
             }
         }
     }

--- a/Sources/Portu/Features/Settings/DebugSettingsTab.swift
+++ b/Sources/Portu/Features/Settings/DebugSettingsTab.swift
@@ -6,6 +6,7 @@
         @Environment(AppState.self) private var appState
         @AppStorage(DebugMode.enabledKey) private var isEnabled = false
         @AppStorage(DebugMode.portKey) private var port = Int(DebugMode.defaultPort)
+        @FocusState private var portFieldFocused: Bool
 
         private var isRunning: Bool {
             appState.debugServer != nil
@@ -26,58 +27,163 @@
         }
 
         var body: some View {
-            Form {
-                Section("Debug Server") {
-                    Toggle("Enable Debug Server", isOn: $isEnabled)
+            SettingsPage(tab: .debug, badge: .debugOnly) {
+                VStack(alignment: .leading, spacing: 24) {
+                    SettingsSectionCard(
+                        title: "Debug Server",
+                        subtitle: "Enable, configure, and inspect the local debug server.") {
+                            VStack(spacing: 0) {
+                                debugToggleRow
 
-                    if launchArgActive, isRunning {
-                        Text("Enabled via \(DebugMode.launchArgument) launch argument")
-                            .foregroundStyle(.secondary)
-                            .font(.callout)
-                    }
+                                SettingsDivider()
+                                    .padding(.vertical, 14)
 
-                    LabeledContent("Port") {
-                        TextField("Port", value: $port, format: .number)
-                            .frame(width: 80)
-                            .multilineTextAlignment(.trailing)
-                            .onChange(of: port) { _, newValue in
-                                if newValue <= 0 || newValue > Int(UInt16.max) {
-                                    port = Int(DebugMode.defaultPort)
+                                portRow
+
+                                SettingsDivider()
+                                    .padding(.vertical, 14)
+
+                                statusRow
+                            }
+                        }
+
+                    SettingsSectionCard(
+                        title: "Conditional Notices",
+                        subtitle: "Shown only when the matching debug state is active.") {
+                            VStack(alignment: .leading, spacing: 12) {
+                                if launchArgActive, isRunning {
+                                    SettingsInlineNotice(
+                                        title: "Enabled via \(DebugMode.launchArgument) launch argument",
+                                        message: nil,
+                                        style: .action)
+                                }
+
+                                if needsRestart {
+                                    SettingsInlineNotice(
+                                        title: "Restart the app to apply changes",
+                                        message: nil,
+                                        style: .action)
+                                }
+
+                                if appState.debugServerStartFailed, isEnabled || launchArgActive {
+                                    SettingsInlineNotice(
+                                        title: "Server failed to start",
+                                        message: "Check Console for details.",
+                                        style: .error)
+                                }
+
+                                if !launchArgActive, !needsRestart, !appState.debugServerStartFailed {
+                                    Text("No active debug notices.")
+                                        .font(.callout)
+                                        .foregroundStyle(SettingsDesign.secondaryText)
+                                        .frame(maxWidth: .infinity, minHeight: 42, alignment: .leading)
                                 }
                             }
-                    }
+                        }
 
-                    HStack(spacing: 6) {
-                        Circle()
-                            .fill(isRunning ? .green : .gray)
-                            .frame(width: 8, height: 8)
-                        Text(isRunning ? "Running on port \(appState.debugServer?.port ?? DebugMode.defaultPort)" : "Stopped")
-                            .foregroundStyle(.secondary)
-                    }
+                    SettingsSectionCard(
+                        title: "Launch Argument",
+                        subtitle: "Enable the server without using the toggle.") {
+                            VStack(alignment: .leading, spacing: 14) {
+                                Text(DebugMode.launchArgument)
+                                    .font(.system(size: 16, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(Color.white)
+                                    .padding(.horizontal, 16)
+                                    .frame(maxWidth: .infinity, minHeight: 46, alignment: .leading)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                            .fill(Color(red: 0.040, green: 0.060, blue: 0.100)))
 
-                    if appState.debugServerStartFailed, isEnabled || launchArgActive {
-                        Label("Server failed to start — check Console for details", systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.orange)
-                            .font(.callout)
-                    }
-                }
-
-                if needsRestart {
-                    Section {
-                        Label("Restart the app to apply changes", systemImage: "arrow.clockwise")
-                            .foregroundStyle(.secondary)
-                            .font(.callout)
-                    }
-                }
-
-                Section("Launch Argument") {
-                    Text("Pass `--debug-server` to enable without the toggle.")
-                        .foregroundStyle(.secondary)
-                        .font(.callout)
+                                Text("When active and running, Portu shows that the debug server was enabled via launch argument.")
+                                    .font(.footnote)
+                                    .foregroundStyle(SettingsDesign.secondaryText)
+                            }
+                        }
                 }
             }
-            .formStyle(.grouped)
-            .navigationTitle("Debug")
+        }
+
+        private var debugToggleRow: some View {
+            HStack(alignment: .center, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Enable Debug Server")
+                        .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                        .foregroundStyle(SettingsDesign.primaryText)
+                    Text("Toggles the local debug server preference.")
+                        .font(.footnote)
+                        .foregroundStyle(SettingsDesign.secondaryText)
+                }
+
+                Spacer(minLength: 18)
+
+                Toggle("Enable Debug Server", isOn: $isEnabled)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+            }
+        }
+
+        private var portRow: some View {
+            HStack(alignment: .center, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Port")
+                        .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                        .foregroundStyle(SettingsDesign.primaryText)
+                    Text("Default port: \(DebugMode.defaultPort)")
+                        .font(.footnote)
+                        .foregroundStyle(SettingsDesign.secondaryText)
+                }
+
+                Spacer(minLength: 18)
+
+                TextField("Port", value: $port, format: .number)
+                    .textFieldStyle(.plain)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+                    .multilineTextAlignment(.trailing)
+                    .focused($portFieldFocused)
+                    .settingsInputFrame(height: SettingsMetrics.compactInputHeight)
+                    .frame(width: 96)
+                    .onAppear {
+                        Task { @MainActor in
+                            portFieldFocused = false
+                        }
+                    }
+                    .onChange(of: port) { _, newValue in
+                        if newValue <= 0 || newValue > Int(UInt16.max) {
+                            port = Int(DebugMode.defaultPort)
+                        }
+                    }
+            }
+        }
+
+        private var statusRow: some View {
+            HStack(spacing: 12) {
+                Text("Status")
+                    .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+
+                Circle()
+                    .fill(isRunning ? Color.green : Color(red: 0.590, green: 0.650, blue: 0.740))
+                    .frame(width: 10, height: 10)
+
+                Text(isRunning ? "Running" : "Stopped")
+                    .font(.body)
+                    .foregroundStyle(SettingsDesign.secondaryText)
+
+                Spacer(minLength: 18)
+
+                Text("Running on port \(appState.debugServer?.port ?? DebugMode.defaultPort)")
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.secondaryText)
+                    .padding(.horizontal, 14)
+                    .frame(height: 32)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(SettingsDesign.subtleCardBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(SettingsDesign.separator, lineWidth: 1))
+            }
         }
     }
 

--- a/Sources/Portu/Features/Settings/SettingsComponents.swift
+++ b/Sources/Portu/Features/Settings/SettingsComponents.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+struct SettingsPage<Content: View>: View {
+    let tab: SettingsTab
+    let badge: SettingsBadge?
+    private let content: Content
+
+    init(
+        tab: SettingsTab,
+        badge: SettingsBadge? = nil,
+        @ViewBuilder content: () -> Content) {
+        self.tab = tab
+        self.badge = badge
+        self.content = content()
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                HStack(alignment: .top, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(tab.title)
+                            .font(.system(size: SettingsMetrics.pageTitleSize, weight: .bold))
+                            .foregroundStyle(SettingsDesign.primaryText)
+                        Text(tab.subtitle)
+                            .font(.body)
+                            .foregroundStyle(SettingsDesign.secondaryText)
+                    }
+
+                    Spacer(minLength: 24)
+
+                    if let badge {
+                        SettingsStatusBadge(badge: badge)
+                            .padding(.top, 4)
+                    }
+                }
+                .padding(.top, 34)
+
+                content
+            }
+            .padding(.horizontal, 42)
+            .padding(.bottom, 40)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollContentBackground(.hidden)
+        .background(SettingsDesign.contentBackground)
+    }
+}
+
+struct SettingsSectionCard<Content: View>: View {
+    let title: String
+    let subtitle: String
+    private let content: Content
+
+    init(
+        title: String,
+        subtitle: String,
+        @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(.system(size: SettingsMetrics.sectionTitleSize, weight: .bold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.secondaryText)
+            }
+
+            SettingsDivider()
+
+            content
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(SettingsDesign.cardBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+}
+
+struct SettingsInfoCard: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(title)
+                .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                .foregroundStyle(SettingsDesign.primaryText)
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(SettingsDesign.secondaryText)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity, minHeight: 76, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(SettingsDesign.subtleCardBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+}
+
+struct SettingsGlyphTile: View {
+    let tab: SettingsTab
+    var isSelected = false
+
+    var body: some View {
+        SettingsLetterTile(
+            glyph: tab.sidebarGlyph,
+            foreground: glyphColor,
+            background: isSelected ? SettingsDesign.selectedGlyphBackground : glyphBackground)
+    }
+
+    private var glyphColor: Color {
+        switch tab {
+        case .general: SettingsDesign.accentBlue
+        case .apiKeys: SettingsDesign.warningOrange
+        case .debug: SettingsDesign.debugOrange
+        }
+    }
+
+    private var glyphBackground: Color {
+        switch tab {
+        case .general: SettingsDesign.blueGlyphBackground
+        case .apiKeys: SettingsDesign.orangeGlyphBackground
+        case .debug: SettingsDesign.peachGlyphBackground
+        }
+    }
+}
+
+struct SettingsLetterTile: View {
+    let glyph: String
+    let foreground: Color
+    let background: Color
+
+    var body: some View {
+        Text(glyph)
+            .font(.caption.weight(.bold))
+            .foregroundStyle(foreground)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(background))
+    }
+}
+
+struct SettingsDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(SettingsDesign.separator)
+            .frame(height: 1)
+    }
+}
+
+struct SettingsBadge: Equatable {
+    enum Style: Equatable {
+        case success
+        case warning
+    }
+
+    let title: String
+    let style: Style
+
+    static let autoSave = SettingsBadge(title: "Auto-save", style: .success)
+    static let debugOnly = SettingsBadge(title: "DEBUG only", style: .warning)
+}
+
+struct SettingsStatusBadge: View {
+    let badge: SettingsBadge
+
+    var body: some View {
+        Text(badge.title)
+            .font(.footnote.weight(.bold))
+            .foregroundStyle(foreground)
+            .frame(width: 132, height: 30)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(background))
+    }
+
+    private var background: Color {
+        switch badge.style {
+        case .success: SettingsDesign.successBadgeBackground
+        case .warning: SettingsDesign.warningBadgeBackground
+        }
+    }
+
+    private var foreground: Color {
+        switch badge.style {
+        case .success: SettingsDesign.successBadgeText
+        case .warning: SettingsDesign.warningBadgeText
+        }
+    }
+}
+
+enum SettingsDesign {
+    static let contentBackground = Color(red: 0.995, green: 0.997, blue: 1.0)
+    static let sidebarBackground = Color(red: 0.945, green: 0.965, blue: 0.995)
+    static let sidebarSearchBackground = Color(red: 0.905, green: 0.925, blue: 0.965)
+    static let sidebarSelection = Color(red: 0.855, green: 0.895, blue: 1.0)
+    static let cardBackground = Color.white
+    static let subtleCardBackground = Color(red: 0.980, green: 0.988, blue: 0.998)
+    static let separator = Color(red: 0.855, green: 0.875, blue: 0.910)
+    static let cardStroke = Color(red: 0.800, green: 0.850, blue: 0.920)
+    static let primaryText = Color(red: 0.045, green: 0.070, blue: 0.125)
+    static let secondaryText = Color(red: 0.390, green: 0.440, blue: 0.560)
+    static let accentBlue = Color(red: 0.055, green: 0.360, blue: 0.840)
+    static let warningOrange = Color(red: 0.925, green: 0.250, blue: 0.050)
+    static let debugOrange = Color(red: 0.830, green: 0.365, blue: 0.070)
+    static let logoBackground = Color(red: 0.900, green: 0.925, blue: 1.0)
+    static let logoForeground = Color(red: 0.340, green: 0.250, blue: 0.900)
+    static let selectedGlyphBackground = Color.white
+    static let blueGlyphBackground = Color(red: 0.930, green: 0.945, blue: 1.0)
+    static let orangeGlyphBackground = Color(red: 1.0, green: 0.955, blue: 0.900)
+    static let peachGlyphBackground = Color(red: 1.0, green: 0.940, blue: 0.895)
+    static let successBadgeBackground = Color(red: 0.870, green: 0.965, blue: 0.925)
+    static let successBadgeText = Color(red: 0.045, green: 0.415, blue: 0.275)
+    static let warningBadgeBackground = Color(red: 1.0, green: 0.935, blue: 0.690)
+    static let warningBadgeText = Color(red: 0.515, green: 0.205, blue: 0.010)
+}

--- a/Sources/Portu/Features/Settings/SettingsComponents.swift
+++ b/Sources/Portu/Features/Settings/SettingsComponents.swift
@@ -185,7 +185,8 @@ struct SettingsStatusBadge: View {
         Text(badge.title)
             .font(.footnote.weight(.bold))
             .foregroundStyle(foreground)
-            .frame(width: 132, height: 30)
+            .padding(.horizontal, 16)
+            .frame(minWidth: 100, minHeight: 30)
             .background(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .fill(background))
@@ -203,6 +204,102 @@ struct SettingsStatusBadge: View {
         case .success: SettingsDesign.successBadgeText
         case .warning: SettingsDesign.warningBadgeText
         }
+    }
+}
+
+struct SettingsInlineNotice: View {
+    enum Style {
+        case error
+        case action
+    }
+
+    let title: String
+    let message: String?
+    let style: Style
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: message == nil ? 0 : 6) {
+            Text(title)
+                .font(.footnote.weight(.bold))
+            if let message {
+                Text(message)
+                    .font(.footnote)
+            }
+        }
+        .foregroundStyle(foreground)
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, minHeight: message == nil ? 38 : 56, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(background))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(stroke, lineWidth: 1))
+    }
+
+    private var background: Color {
+        switch style {
+        case .error: Color(red: 1.0, green: 0.970, blue: 0.925)
+        case .action: Color(red: 0.910, green: 0.930, blue: 1.0)
+        }
+    }
+
+    private var stroke: Color {
+        switch style {
+        case .error: Color(red: 0.980, green: 0.590, blue: 0.235)
+        case .action: Color(red: 0.600, green: 0.690, blue: 1.0)
+        }
+    }
+
+    private var foreground: Color {
+        switch style {
+        case .error: Color(red: 0.640, green: 0.160, blue: 0.050)
+        case .action: Color(red: 0.245, green: 0.180, blue: 0.780)
+        }
+    }
+}
+
+extension View {
+    func settingsInputFrame(height: CGFloat) -> some View {
+        padding(.horizontal, 12)
+            .frame(height: height)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(SettingsDesign.subtleCardBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+
+    func settingsMenuFrame(height: CGFloat) -> some View {
+        padding(.horizontal, 12)
+            .frame(height: height)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(SettingsDesign.subtleCardBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+
+    func settingsIconButton(color: Color) -> some View {
+        foregroundStyle(color)
+            .frame(width: 42, height: 28)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(color.opacity(0.10)))
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .stroke(color.opacity(0.25), lineWidth: 1))
+    }
+
+    func settingsPrimaryButton(isDisabled: Bool) -> some View {
+        foregroundStyle(isDisabled ? SettingsDesign.secondaryText : Color.white)
+            .frame(width: 64, height: SettingsMetrics.compactControlHeight)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(isDisabled ? Color(red: 0.800, green: 0.830, blue: 0.880) : SettingsDesign.accentBlue))
     }
 }
 

--- a/Sources/Portu/Features/Settings/SettingsView.swift
+++ b/Sources/Portu/Features/Settings/SettingsView.swift
@@ -1,21 +1,272 @@
 import SwiftUI
 
+enum SettingsTab: String, CaseIterable, Identifiable {
+    case general
+    case apiKeys
+    case debug
+
+    var id: Self {
+        self
+    }
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .apiKeys: "API Keys"
+        case .debug: "Debug"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .general: "Price refresh preferences for portfolio data."
+        case .apiKeys: "Provider credentials and optional custom RPC endpoints."
+        case .debug: "Local debug server controls for development builds."
+        }
+    }
+
+    var sidebarGlyph: String {
+        switch self {
+        case .general: "G"
+        case .apiKeys: "K"
+        case .debug: "D"
+        }
+    }
+
+    static func visibleTabs(debugEnabled: Bool) -> [SettingsTab] {
+        debugEnabled ? [.general, .apiKeys, .debug] : [.general, .apiKeys]
+    }
+
+    static func filter(_ tabs: [SettingsTab], query: String) -> [SettingsTab] {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedQuery.isEmpty else { return tabs }
+
+        return tabs.filter { tab in
+            tab.title.lowercased().contains(normalizedQuery)
+                || tab.subtitle.lowercased().contains(normalizedQuery)
+        }
+    }
+}
+
+enum SettingsMetrics {
+    static let minimumWidth: CGFloat = 720
+    static let minimumHeight: CGFloat = 560
+    static let sidebarWidth: CGFloat = 226
+    static let pageTitleSize: CGFloat = 32
+    static let sectionTitleSize: CGFloat = 20
+    static let rowTitleSize: CGFloat = 18
+    static let sidebarRowTitleSize: CGFloat = 15
+    static let compactControlHeight: CGFloat = 40
+    static let compactInputHeight: CGFloat = 40
+    static let showsBackNavigation = false
+}
+
 struct SettingsView: View {
+    @State private var selectedTab: SettingsTab = .general
+    @State private var searchText = ""
+
+    private var tabs: [SettingsTab] {
+        SettingsTab.visibleTabs(debugEnabled: Self.debugEnabled)
+    }
+
+    private var filteredTabs: [SettingsTab] {
+        SettingsTab.filter(tabs, query: searchText)
+    }
+
     var body: some View {
-        TabView {
-            Tab("General", systemImage: "gear") {
-                GeneralSettingsTab()
-            }
-            Tab("API Keys", systemImage: "key.fill") {
-                APIKeysSettingsTab()
-            }
+        HStack(spacing: 0) {
+            SettingsSidebar(
+                tabs: filteredTabs,
+                allTabs: tabs,
+                selectedTab: $selectedTab,
+                searchText: $searchText)
+
+            Rectangle()
+                .fill(SettingsDesign.separator)
+                .frame(width: 1)
+
+            selectedContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(
+            minWidth: SettingsMetrics.minimumWidth,
+            maxWidth: .infinity,
+            minHeight: SettingsMetrics.minimumHeight,
+            maxHeight: .infinity)
+        .background(SettingsDesign.contentBackground)
+        .onChange(of: filteredTabs) { _, newTabs in
+            guard !newTabs.isEmpty, !newTabs.contains(selectedTab) else { return }
+            selectedTab = newTabs[0]
+        }
+    }
+
+    @ViewBuilder
+    private var selectedContent: some View {
+        switch selectedTab {
+        case .general:
+            GeneralSettingsTab()
+        case .apiKeys:
+            APIKeysSettingsTab()
+        case .debug:
             #if DEBUG
-                Tab("Debug", systemImage: "ant.fill") {
-                    DebugSettingsTab()
+                DebugSettingsTab()
+            #else
+                SettingsPage(tab: .debug) {
+                    SettingsSectionCard(
+                        title: "Debug unavailable",
+                        subtitle: "Debug settings are only available in development builds.") {
+                            EmptyView()
+                        }
                 }
             #endif
         }
-        .frame(width: 450, height: 400)
+    }
+
+    private static var debugEnabled: Bool {
+        #if DEBUG
+            true
+        #else
+            false
+        #endif
+    }
+}
+
+private struct SettingsSidebar: View {
+    let tabs: [SettingsTab]
+    let allTabs: [SettingsTab]
+    @Binding var selectedTab: SettingsTab
+    @Binding var searchText: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            SettingsBrandHeader()
+
+            SettingsSearchField(text: $searchText)
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(tabs) { tab in
+                    Button {
+                        selectedTab = tab
+                    } label: {
+                        SettingsSidebarRow(
+                            tab: tab,
+                            isSelected: selectedTab == tab)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if tabs.isEmpty {
+                    Text("No settings found")
+                        .font(.callout)
+                        .foregroundStyle(SettingsDesign.secondaryText)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                }
+            }
+
+            Spacer(minLength: 24)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Current tabs")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+                Text(allTabs.map(\.title).joined(separator: " · "))
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.secondaryText)
+                    .lineLimit(2)
+            }
+            .padding(.horizontal, 18)
+            .padding(.bottom, 16)
+        }
+        .padding(.top, topPadding)
+        .padding(.horizontal, 16)
+        .frame(width: SettingsMetrics.sidebarWidth)
+        .frame(maxHeight: .infinity)
+        .background(SettingsDesign.sidebarBackground)
+    }
+
+    private var topPadding: CGFloat {
+        42
+    }
+}
+
+private struct SettingsBrandHeader: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(SettingsDesign.logoBackground)
+                Text("P")
+                    .font(.system(size: 26, weight: .black, design: .rounded))
+                    .foregroundStyle(SettingsDesign.logoForeground)
+            }
+            .frame(width: 44, height: 44)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Portu")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+                Text("Settings")
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.secondaryText)
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+}
+
+private struct SettingsSearchField: View {
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(SettingsDesign.secondaryText)
+            ZStack(alignment: .leading) {
+                if text.isEmpty {
+                    Text("Search")
+                        .font(.footnote)
+                        .foregroundStyle(SettingsDesign.secondaryText)
+                }
+
+                TextField("", text: $text)
+                    .textFieldStyle(.plain)
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.primaryText)
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 34)
+        .background(
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(SettingsDesign.sidebarSearchBackground))
+    }
+}
+
+private struct SettingsSidebarRow: View {
+    let tab: SettingsTab
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            SettingsGlyphTile(tab: tab, isSelected: isSelected)
+                .frame(width: 28, height: 28)
+
+            Text(tab.title)
+                .font(.system(size: SettingsMetrics.sidebarRowTitleSize, weight: .semibold))
+                .foregroundStyle(isSelected ? SettingsDesign.accentBlue : SettingsDesign.primaryText)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.leading, 12)
+        .padding(.trailing, 12)
+        .frame(height: 44)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(isSelected ? SettingsDesign.sidebarSelection : .clear))
+        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 }
 
@@ -23,17 +274,101 @@ private struct GeneralSettingsTab: View {
     @AppStorage("refreshInterval") private var refreshInterval = 30.0
 
     var body: some View {
-        Form {
-            Section("Price Updates") {
-                Picker("Refresh interval", selection: $refreshInterval) {
-                    Text("15 seconds").tag(15.0)
-                    Text("30 seconds").tag(30.0)
-                    Text("1 minute").tag(60.0)
-                    Text("5 minutes").tag(300.0)
+        SettingsPage(tab: .general) {
+            VStack(alignment: .leading, spacing: 24) {
+                SettingsSectionCard(
+                    title: "Price Updates",
+                    subtitle: "Choose how often Portu refreshes token pricing.") {
+                        HStack(alignment: .top, spacing: 14) {
+                            SettingsGlyphTile(tab: .general)
+                                .frame(width: 32, height: 32)
+
+                            VStack(alignment: .leading, spacing: 14) {
+                                VStack(alignment: .leading, spacing: 5) {
+                                    Text("Refresh interval")
+                                        .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                                        .foregroundStyle(SettingsDesign.primaryText)
+                                    Text("Default: 30 seconds")
+                                        .font(.footnote)
+                                        .foregroundStyle(SettingsDesign.secondaryText)
+                                }
+
+                                RefreshIntervalControl(selection: $refreshInterval)
+                            }
+                        }
+                    }
+
+                SettingsInfoCard(
+                    title: "Auto-saved",
+                    message: "This setting is stored locally with AppStorage and applies across Portu views.")
+            }
+        }
+    }
+}
+
+private enum RefreshIntervalOption: Double, CaseIterable, Identifiable {
+    case fifteenSeconds = 15
+    case thirtySeconds = 30
+    case oneMinute = 60
+    case fiveMinutes = 300
+
+    var id: Double {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .fifteenSeconds: "15 seconds"
+        case .thirtySeconds: "30 seconds"
+        case .oneMinute: "1 minute"
+        case .fiveMinutes: "5 minutes"
+        }
+    }
+}
+
+private struct RefreshIntervalControl: View {
+    @Binding var selection: Double
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(RefreshIntervalOption.allCases) { option in
+                Button {
+                    selection = option.rawValue
+                } label: {
+                    Text(option.title)
+                        .font(.footnote.weight(isSelected(option) ? .bold : .regular))
+                        .foregroundStyle(isSelected(option) ? SettingsDesign.primaryText : SettingsDesign.secondaryText)
+                        .frame(width: 84, height: 34)
+                        .background(selectedBackground(for: option))
+                }
+                .buttonStyle(.plain)
+
+                if option != .fiveMinutes {
+                    Rectangle()
+                        .fill(SettingsDesign.separator)
+                        .frame(width: 1, height: 24)
                 }
             }
         }
-        .formStyle(.grouped)
-        .navigationTitle("General")
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(red: 0.930, green: 0.950, blue: 0.980)))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+
+    private func isSelected(_ option: RefreshIntervalOption) -> Bool {
+        selection == option.rawValue
+    }
+
+    @ViewBuilder
+    private func selectedBackground(for option: RefreshIntervalOption) -> some View {
+        if isSelected(option) {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.white)
+                .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 1)
+        }
     }
 }

--- a/Sources/Portu/Features/Settings/SettingsView.swift
+++ b/Sources/Portu/Features/Settings/SettingsView.swift
@@ -77,7 +77,6 @@ struct SettingsView: View {
         HStack(spacing: 0) {
             SettingsSidebar(
                 tabs: filteredTabs,
-                allTabs: tabs,
                 selectedTab: $selectedTab,
                 searchText: $searchText)
 
@@ -133,7 +132,6 @@ struct SettingsView: View {
 
 private struct SettingsSidebar: View {
     let tabs: [SettingsTab]
-    let allTabs: [SettingsTab]
     @Binding var selectedTab: SettingsTab
     @Binding var searchText: String
 
@@ -166,18 +164,6 @@ private struct SettingsSidebar: View {
             }
 
             Spacer(minLength: 24)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Current tabs")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(SettingsDesign.primaryText)
-                Text(allTabs.map(\.title).joined(separator: " · "))
-                    .font(.footnote)
-                    .foregroundStyle(SettingsDesign.secondaryText)
-                    .lineLimit(2)
-            }
-            .padding(.horizontal, 18)
-            .padding(.bottom, 16)
         }
         .padding(.top, topPadding)
         .padding(.horizontal, 16)
@@ -231,10 +217,11 @@ private struct SettingsSearchField: View {
                         .foregroundStyle(SettingsDesign.secondaryText)
                 }
 
-                TextField("", text: $text)
+                TextField("Search", text: $text, prompt: Text(""))
                     .textFieldStyle(.plain)
                     .font(.footnote)
                     .foregroundStyle(SettingsDesign.primaryText)
+                    .accessibilityLabel("Search")
             }
         }
         .padding(.horizontal, 12)
@@ -271,7 +258,8 @@ private struct SettingsSidebarRow: View {
 }
 
 private struct GeneralSettingsTab: View {
-    @AppStorage("refreshInterval") private var refreshInterval = 30.0
+    @AppStorage(PricePollingSettings.refreshIntervalKey)
+    private var refreshInterval = PricePollingSettings.defaultRefreshIntervalSeconds
 
     var body: some View {
         SettingsPage(tab: .general) {

--- a/Sources/Portu/Features/Sidebar/SidebarLayout.swift
+++ b/Sources/Portu/Features/Sidebar/SidebarLayout.swift
@@ -1,0 +1,94 @@
+struct SidebarLayoutSection: Equatable, Identifiable {
+    let id: String
+    let title: String?
+    let items: [SidebarItem]
+    let isDisabled: Bool
+
+    init(
+        title: String?,
+        items: [SidebarItem],
+        isDisabled: Bool = false) {
+        self.title = title
+        self.items = items
+        self.isDisabled = isDisabled
+        self.id = title ?? items.map(\.id).joined(separator: "-")
+    }
+}
+
+enum SidebarItem: Equatable, Identifiable {
+    case section(SidebarSection)
+    case strategies
+    case settings
+
+    var id: String {
+        switch self {
+        case let .section(section): "section-\(section.id)"
+        case .strategies: "strategies"
+        case .settings: "settings"
+        }
+    }
+}
+
+enum SidebarLayout {
+    static let navigationSections: [SidebarLayoutSection] = [
+        SidebarLayoutSection(
+            title: "PORTU",
+            items: [
+                .section(.overview),
+                .section(.exposure),
+                .section(.performance)
+            ]),
+        SidebarLayoutSection(
+            title: "PORTFOLIO",
+            items: [
+                .section(.allAssets),
+                .section(.allPositions)
+            ]),
+        SidebarLayoutSection(
+            title: "MANAGEMENT",
+            items: [
+                .section(.accounts)
+            ]),
+        SidebarLayoutSection(
+            title: nil,
+            items: [.strategies],
+            isDisabled: true)
+    ]
+
+    static let footerItems: [SidebarItem] = [.settings]
+}
+
+extension SidebarSection {
+    var id: String {
+        switch self {
+        case .overview: "overview"
+        case .exposure: "exposure"
+        case .performance: "performance"
+        case .allAssets: "all-assets"
+        case .allPositions: "all-positions"
+        case .accounts: "accounts"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .overview: "Overview"
+        case .exposure: "Exposure"
+        case .performance: "Performance"
+        case .allAssets: "All Assets"
+        case .allPositions: "All Positions"
+        case .accounts: "Accounts"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .overview: "chart.pie"
+        case .exposure: "chart.bar.xaxis"
+        case .performance: "chart.line.uptrend.xyaxis"
+        case .allAssets: "bitcoinsign.circle"
+        case .allPositions: "list.bullet.rectangle"
+        case .accounts: "person.2"
+        }
+    }
+}

--- a/Sources/Portu/Features/Sidebar/SidebarView.swift
+++ b/Sources/Portu/Features/Sidebar/SidebarView.swift
@@ -39,7 +39,9 @@ private struct SidebarNavigationSection: View {
                 SidebarNavigationRow(item: item)
             }
         } header: {
-            Text(section.title ?? "")
+            if let title = section.title {
+                Text(title)
+            }
         }
         .disabled(section.isDisabled)
     }

--- a/Sources/Portu/Features/Sidebar/SidebarView.swift
+++ b/Sources/Portu/Features/Sidebar/SidebarView.swift
@@ -6,48 +6,95 @@ struct SidebarView: View {
     let store: StoreOf<AppFeature>
 
     var body: some View {
-        List(selection: Binding(
-            get: { store.selectedSection },
-            set: { if let section = $0 { store.send(.sectionSelected(section)) } })) {
-                Section("PORTU") {
-                    Label("Overview", systemImage: "chart.pie")
-                        .tag(SidebarSection.overview)
-                    Label("Exposure", systemImage: "chart.bar.xaxis")
-                        .tag(SidebarSection.exposure)
-                    Label("Performance", systemImage: "chart.line.uptrend.xyaxis")
-                        .tag(SidebarSection.performance)
-                }
-
-                Section("PORTFOLIO") {
-                    Label("All Assets", systemImage: "bitcoinsign.circle")
-                        .tag(SidebarSection.allAssets)
-                    Label("All Positions", systemImage: "list.bullet.rectangle")
-                        .tag(SidebarSection.allPositions)
-                }
-
-                Section("MANAGEMENT") {
-                    Label("Accounts", systemImage: "person.2")
-                        .tag(SidebarSection.accounts)
-                }
-
-                Section {
-                    Label("Strategies", systemImage: "lightbulb")
-                        .foregroundStyle(.tertiary)
-                } header: {
-                    Text("")
-                }
-                .disabled(true)
-
-                Section {
-                    SettingsLink {
-                        Label("Settings", systemImage: "gear")
-                    }
-                    .buttonStyle(.plain)
-                } header: {
-                    Text("")
+        VStack(spacing: 0) {
+            List(selection: selectedSection) {
+                ForEach(SidebarLayout.navigationSections) { section in
+                    SidebarNavigationSection(section: section)
                 }
             }
             .listStyle(.sidebar)
             .navigationTitle("Portu")
+
+            SidebarFooter(
+                items: SidebarLayout.footerItems,
+                isSettingsSelected: store.isSettingsPresented) {
+                    store.send(.settingsSelected)
+                }
+        }
+    }
+
+    private var selectedSection: Binding<SidebarSection?> {
+        Binding(
+            get: { store.sidebarSelection },
+            set: { if let section = $0 { store.send(.sectionSelected(section)) } })
+    }
+}
+
+private struct SidebarNavigationSection: View {
+    let section: SidebarLayoutSection
+
+    var body: some View {
+        Section {
+            ForEach(section.items) { item in
+                SidebarNavigationRow(item: item)
+            }
+        } header: {
+            Text(section.title ?? "")
+        }
+        .disabled(section.isDisabled)
+    }
+}
+
+private struct SidebarNavigationRow: View {
+    let item: SidebarItem
+
+    var body: some View {
+        switch item {
+        case let .section(section):
+            Label(section.title, systemImage: section.systemImage)
+                .tag(section)
+        case .strategies:
+            Label("Strategies", systemImage: "lightbulb")
+                .foregroundStyle(.tertiary)
+        case .settings:
+            EmptyView()
+        }
+    }
+}
+
+private struct SidebarFooter: View {
+    let items: [SidebarItem]
+    let isSettingsSelected: Bool
+    let settingsAction: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+
+            ForEach(items) { item in
+                switch item {
+                case .settings:
+                    Button {
+                        settingsAction()
+                    } label: {
+                        Label("Settings", systemImage: "gear")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                            .foregroundStyle(isSettingsSelected ? Color.accentColor : Color.primary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .fill(isSettingsSelected ? Color.accentColor.opacity(0.16) : .clear))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                case .section, .strategies:
+                    EmptyView()
+                }
+            }
+        }
+        .background(.bar)
     }
 }

--- a/Tests/PortuTests/AppFeatureTests.swift
+++ b/Tests/PortuTests/AppFeatureTests.swift
@@ -50,7 +50,7 @@ struct AppFeatureTests {
     }
 
     @Test func `settings route clears sidebar section selection while preserving selected section`() async {
-        let store = TestStore(initialState: AppFeature.State(selectedSection: .overview)) {
+        let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         }
 
@@ -159,6 +159,45 @@ struct AppFeatureTests {
         }
 
         // Stop polling to clean up the long-running effect
+        await store.send(.stopPricePolling)
+    }
+
+    @Test func `price polling respects configured refresh interval`() async {
+        let testClock = TestClock()
+        let testDate = Date(timeIntervalSince1970: 1_000_000)
+        nonisolated(unsafe) var fetchCount = 0
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.priceService.fetchPrices = { _ in
+                fetchCount += 1
+                return PriceUpdate(prices: ["bitcoin": Decimal(fetchCount)], changes24h: [:])
+            }
+            $0.pricePollingSettings.refreshInterval = { .seconds(5) }
+            $0.continuousClock = testClock
+            $0.date = .constant(testDate)
+        }
+
+        await store.send(.startPricePolling(["bitcoin"])) {
+            $0.connectionStatus = .fetching
+        }
+        await store.receive(\.pricesReceived) {
+            $0.prices = ["bitcoin": 1]
+            $0.lastPriceUpdate = testDate
+            $0.connectionStatus = .idle
+        }
+
+        await testClock.advance(by: .seconds(4))
+        #expect(fetchCount == 1)
+
+        await testClock.advance(by: .seconds(1))
+        await store.receive(\.pricesReceived) {
+            $0.prices = ["bitcoin": 2]
+            $0.lastPriceUpdate = testDate
+            $0.connectionStatus = .idle
+        }
+
         await store.send(.stopPricePolling)
     }
 

--- a/Tests/PortuTests/AppFeatureTests.swift
+++ b/Tests/PortuTests/AppFeatureTests.swift
@@ -21,6 +21,47 @@ struct AppFeatureTests {
         }
     }
 
+    @Test func `section selection exits settings route`() async {
+        let store = TestStore(initialState: AppFeature.State(selectedSection: .performance)) {
+            AppFeature()
+        }
+
+        await store.send(.settingsSelected) {
+            $0.isSettingsPresented = true
+        }
+        await store.send(.sectionSelected(.accounts)) {
+            $0.selectedSection = .accounts
+            $0.isSettingsPresented = false
+        }
+        #expect(store.state.detailRoute == .section(.accounts))
+    }
+
+    @Test func `settings route is presented as detail content`() async {
+        let store = TestStore(initialState: AppFeature.State(selectedSection: .accounts)) {
+            AppFeature()
+        }
+
+        #expect(store.state.detailRoute == .section(.accounts))
+        await store.send(.settingsSelected) {
+            $0.isSettingsPresented = true
+        }
+        #expect(store.state.detailRoute == .settings)
+        #expect(store.state.selectedSection == .accounts)
+    }
+
+    @Test func `settings route clears sidebar section selection while preserving selected section`() async {
+        let store = TestStore(initialState: AppFeature.State(selectedSection: .overview)) {
+            AppFeature()
+        }
+
+        #expect(store.state.sidebarSelection == .overview)
+        await store.send(.settingsSelected) {
+            $0.isSettingsPresented = true
+        }
+        #expect(store.state.sidebarSelection == nil)
+        #expect(store.state.selectedSection == .overview)
+    }
+
     // MARK: - B2: Sync Happy Path
 
     @Test func `sync happy path`() async {

--- a/Tests/PortuTests/SettingsTabTests.swift
+++ b/Tests/PortuTests/SettingsTabTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import Portu
 import Testing
 
@@ -28,7 +29,26 @@ struct SettingsTabTests {
         #expect(SettingsMetrics.showsBackNavigation == false)
     }
 
-    @Test func `api key input fields show entered text`() {
-        #expect(APIKeysSettingsLayout.inputMode == .visibleText)
+    @Test func `api key inputs default secure and reveal only by explicit action`() {
+        #expect(APIKeysSettingsLayout.inputMode(isVisible: false) == .secureText)
+        #expect(APIKeysSettingsLayout.inputMode(isVisible: true) == .visibleText)
+    }
+
+    @Test func `price polling settings use shared defaults key and allowed values`() {
+        let defaults = cleanDefaults()
+
+        #expect(PricePollingSettings.refreshIntervalKey == "refreshInterval")
+        #expect(PricePollingSettings.refreshIntervalSeconds(defaults: defaults) == 30)
+
+        defaults.set(60.0, forKey: PricePollingSettings.refreshIntervalKey)
+        #expect(PricePollingSettings.refreshIntervalSeconds(defaults: defaults) == 60)
+
+        defaults.set(7.0, forKey: PricePollingSettings.refreshIntervalKey)
+        #expect(PricePollingSettings.refreshIntervalSeconds(defaults: defaults) == 30)
+    }
+
+    private func cleanDefaults() -> UserDefaults {
+        let suite = "com.portu.test.SettingsTab.\(UUID().uuidString)"
+        return UserDefaults(suiteName: suite)!
     }
 }

--- a/Tests/PortuTests/SettingsTabTests.swift
+++ b/Tests/PortuTests/SettingsTabTests.swift
@@ -1,0 +1,34 @@
+@testable import Portu
+import Testing
+
+struct SettingsTabTests {
+    @Test func `default visible tabs match settings sidebar order`() {
+        let tabs = SettingsTab.visibleTabs(debugEnabled: true)
+
+        #expect(tabs.map(\.title) == ["General", "API Keys", "Debug"])
+        #expect(tabs.map(\.sidebarGlyph) == ["G", "K", "D"])
+    }
+
+    @Test func `search filters settings tabs by title and subtitle`() {
+        let tabs = SettingsTab.visibleTabs(debugEnabled: true)
+
+        #expect(SettingsTab.filter(tabs, query: "key") == [.apiKeys])
+        #expect(SettingsTab.filter(tabs, query: "server") == [.debug])
+        #expect(SettingsTab.filter(tabs, query: "price") == [.general])
+        #expect(SettingsTab.filter(tabs, query: " ") == tabs)
+    }
+
+    @Test func `settings typography is compact for main detail presentation`() {
+        #expect(SettingsMetrics.pageTitleSize < 38)
+        #expect(SettingsMetrics.sectionTitleSize < 22)
+        #expect(SettingsMetrics.sidebarWidth < 250)
+    }
+
+    @Test func `settings omits explicit back navigation`() {
+        #expect(SettingsMetrics.showsBackNavigation == false)
+    }
+
+    @Test func `api key input fields show entered text`() {
+        #expect(APIKeysSettingsLayout.inputMode == .visibleText)
+    }
+}

--- a/Tests/PortuTests/SidebarLayoutTests.swift
+++ b/Tests/PortuTests/SidebarLayoutTests.swift
@@ -1,0 +1,11 @@
+@testable import Portu
+import Testing
+
+struct SidebarLayoutTests {
+    @Test func `settings lives in bottom footer outside navigation sections`() {
+        let navigationItems = SidebarLayout.navigationSections.flatMap(\.items)
+
+        #expect(!navigationItems.contains(.settings))
+        #expect(SidebarLayout.footerItems == [.settings])
+    }
+}


### PR DESCRIPTION
## Summary
- Integrates Settings into the main app detail route so the sidebar and status bar remain visible.
- Rebuilds the General, API Keys, and Debug settings tabs to match the mockups with compact typography, cards, sidebar search, and bottom-anchored Settings entry.
- Makes API key and RPC input text visible and adds regression coverage for settings routing/layout behavior.

## Validation
- `xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test`
- `./script/build_and_run.sh --verify`
- Runtime accessibility checks verified Settings opens in the main view with sidebar visible, no back navigation, and visible API key/RPC text fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings is now integrated into the main app navigation with dedicated routing.
  * Settings page features a searchable sidebar for easier tab discovery and navigation.

* **Design & UX**
  * Redesigned Settings interface with improved layout and visual consistency.
  * API Keys and Debug settings tabs updated with modernized UI components.
  * Enhanced error handling and inline notices in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->