### PR TITLE
[codex] Redesign Portu views

### DIFF
--- a/Packages/PortuUI/Sources/PortuUI/Components/CapsuleBadge.swift
+++ b/Packages/PortuUI/Sources/PortuUI/Components/CapsuleBadge.swift
@@ -11,9 +11,13 @@ public struct CapsuleBadge: View {
     public var body: some View {
         Text(text)
             .font(.caption)
+            .foregroundStyle(PortuTheme.dashboardText)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(.quaternary)
+            .background(PortuTheme.dashboardMutedPanelBackground)
+            .overlay(
+                Capsule()
+                    .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
             .clipShape(Capsule())
     }
 }

--- a/Packages/PortuUI/Sources/PortuUI/Theme/PortuTheme.swift
+++ b/Packages/PortuUI/Sources/PortuUI/Theme/PortuTheme.swift
@@ -5,6 +5,27 @@ public enum PortuTheme {
     public static let lossColor = Color.red
     public static let neutralColor = Color.secondary
 
+    public static let dashboardBackground = Color(red: 0.045, green: 0.043, blue: 0.039)
+    public static let dashboardSidebarBackground = Color(red: 0.110, green: 0.095, blue: 0.088)
+    public static let dashboardPanelBackground = Color(red: 0.072, green: 0.068, blue: 0.060)
+    public static let dashboardPanelElevatedBackground = Color(red: 0.105, green: 0.096, blue: 0.084)
+    public static let dashboardMutedPanelBackground = Color(red: 0.135, green: 0.123, blue: 0.108)
+    public static let dashboardStroke = Color(red: 0.178, green: 0.160, blue: 0.135)
+    public static let dashboardMutedStroke = Color(red: 0.240, green: 0.212, blue: 0.170)
+    public static let dashboardGold = Color(red: 0.690, green: 0.550, blue: 0.310)
+    public static let dashboardGoldMuted = Color(red: 0.360, green: 0.285, blue: 0.175)
+    public static let dashboardText = Color(red: 0.910, green: 0.885, blue: 0.820)
+    public static let dashboardSecondaryText = Color(red: 0.610, green: 0.570, blue: 0.500)
+    public static let dashboardTertiaryText = Color(red: 0.390, green: 0.355, blue: 0.305)
+    public static let dashboardWarning = Color(red: 0.860, green: 0.330, blue: 0.330)
+    public static let dashboardSuccess = Color(red: 0.360, green: 0.730, blue: 0.455)
+
+    public static let dashboardSidebarWidth: CGFloat = 164
+    public static let dashboardInspectorWidth: CGFloat = 318
+    public static let dashboardPanelCornerRadius: CGFloat = 8
+    public static let dashboardContentSpacing: CGFloat = 12
+    public static let dashboardTableRowHeight: CGFloat = 24
+
     /// Returns gain/loss color based on a value being positive, negative, or zero.
     public static func changeColor(for value: Decimal) -> Color {
         if value > 0 { gainColor } else if value < 0 { lossColor } else { neutralColor }

--- a/Packages/PortuUI/Tests/PortuUITests/PortuUITests.swift
+++ b/Packages/PortuUI/Tests/PortuUITests/PortuUITests.swift
@@ -7,4 +7,11 @@ struct PortuUITests {
         #expect(PortuTheme.changeColor(for: -1.0) == PortuTheme.lossColor)
         #expect(PortuTheme.changeColor(for: 0) == PortuTheme.neutralColor)
     }
+
+    @Test func `dashboard metrics stay compact for dense macOS views`() {
+        #expect(PortuTheme.dashboardSidebarWidth == 164)
+        #expect(PortuTheme.dashboardPanelCornerRadius <= 8)
+        #expect(PortuTheme.dashboardContentSpacing == 12)
+        #expect(PortuTheme.dashboardTableRowHeight <= 26)
+    }
 }

--- a/Sources/Portu/App/ContentView.swift
+++ b/Sources/Portu/App/ContentView.swift
@@ -1,10 +1,12 @@
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
 struct ContentView: View {
     let store: StoreOf<AppFeature>
+    @State private var assetNavigationPath = NavigationPath()
 
     var body: some View {
         mainDashboard
@@ -15,14 +17,27 @@ struct ContentView: View {
         VStack(spacing: 0) {
             NavigationSplitView {
                 SidebarView(store: store)
+                    .navigationSplitViewColumnWidth(
+                        min: PortuTheme.dashboardSidebarWidth,
+                        ideal: PortuTheme.dashboardSidebarWidth,
+                        max: PortuTheme.dashboardSidebarWidth)
             } detail: {
-                detailView
-                    .navigationDestination(for: UUID.self) { assetId in
-                        AssetDetailView(assetId: assetId, store: store)
-                    }
+                NavigationStack(path: $assetNavigationPath) {
+                    detailView
+                        .dashboardPage()
+                        .navigationDestination(for: UUID.self) { assetId in
+                            AssetDetailView(assetId: assetId, store: store)
+                        }
+                }
+                .onChange(of: store.detailRoute) { _, _ in
+                    assetNavigationPath = NavigationPath()
+                }
             }
+            .toolbar(.hidden, for: .windowToolbar)
             StatusBarView(store: store)
         }
+        .background(PortuTheme.dashboardBackground)
+        .environment(\.colorScheme, .dark)
     }
 
     @ViewBuilder
@@ -32,6 +47,7 @@ struct ContentView: View {
             sectionView(section)
         case .settings:
             SettingsView()
+                .environment(\.colorScheme, .light)
         }
     }
 

--- a/Sources/Portu/App/ContentView.swift
+++ b/Sources/Portu/App/ContentView.swift
@@ -33,7 +33,6 @@ struct ContentView: View {
                     assetNavigationPath = NavigationPath()
                 }
             }
-            .toolbar(.hidden, for: .windowToolbar)
             StatusBarView(store: store)
         }
         .background(PortuTheme.dashboardBackground)

--- a/Sources/Portu/App/ContentView.swift
+++ b/Sources/Portu/App/ContentView.swift
@@ -15,13 +15,14 @@ struct ContentView: View {
 
     private var mainDashboard: some View {
         VStack(spacing: 0) {
-            NavigationSplitView {
+            HStack(spacing: 0) {
                 SidebarView(store: store)
-                    .navigationSplitViewColumnWidth(
-                        min: PortuTheme.dashboardSidebarWidth,
-                        ideal: PortuTheme.dashboardSidebarWidth,
-                        max: PortuTheme.dashboardSidebarWidth)
-            } detail: {
+                    .frame(width: PortuTheme.dashboardSidebarWidth)
+
+                Rectangle()
+                    .fill(PortuTheme.dashboardStroke)
+                    .frame(width: 1)
+
                 NavigationStack(path: $assetNavigationPath) {
                     detailView
                         .dashboardPage()
@@ -32,6 +33,7 @@ struct ContentView: View {
                 .onChange(of: store.detailRoute) { _, _ in
                     assetNavigationPath = NavigationPath()
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             StatusBarView(store: store)
         }

--- a/Sources/Portu/App/ContentView.swift
+++ b/Sources/Portu/App/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
             HStack(spacing: 0) {
                 SidebarView(store: store)
                     .frame(width: PortuTheme.dashboardSidebarWidth)
+                    .environment(\.colorScheme, .dark)
 
                 Rectangle()
                     .fill(PortuTheme.dashboardStroke)
@@ -25,9 +26,9 @@ struct ContentView: View {
 
                 NavigationStack(path: $assetNavigationPath) {
                     detailView
-                        .dashboardPage()
                         .navigationDestination(for: UUID.self) { assetId in
                             AssetDetailView(assetId: assetId, store: store)
+                                .dashboardPage()
                         }
                 }
                 .onChange(of: store.detailRoute) { _, _ in
@@ -36,9 +37,9 @@ struct ContentView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             StatusBarView(store: store)
+                .environment(\.colorScheme, .dark)
         }
         .background(PortuTheme.dashboardBackground)
-        .environment(\.colorScheme, .dark)
     }
 
     @ViewBuilder
@@ -46,6 +47,7 @@ struct ContentView: View {
         switch store.detailRoute {
         case let .section(section):
             sectionView(section)
+                .dashboardPage()
         case .settings:
             SettingsView()
                 .environment(\.colorScheme, .light)

--- a/Sources/Portu/App/StatusBarView.swift
+++ b/Sources/Portu/App/StatusBarView.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftUI
 
 struct StatusBarView: View {
@@ -9,7 +10,7 @@ struct StatusBarView: View {
         HStack(spacing: 12) {
             if store.storeIsEphemeral {
                 Label("Database error — using temporary storage", systemImage: "exclamationmark.triangle")
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(PortuTheme.dashboardWarning)
                     .font(.caption)
             }
 
@@ -20,16 +21,21 @@ struct StatusBarView: View {
             if let lastUpdate = store.lastPriceUpdate {
                 Text("Updated \(lastUpdate, format: .relative(presentation: .named))")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
             }
 
             Text("CoinGecko")
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(PortuTheme.dashboardTertiaryText)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(.ultraThinMaterial)
+        .padding(.horizontal, 10)
+        .frame(height: 24)
+        .background(PortuTheme.dashboardPanelBackground)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(PortuTheme.dashboardStroke)
+                .frame(height: 1)
+        }
     }
 
     @ViewBuilder
@@ -38,23 +44,25 @@ struct StatusBarView: View {
         case .idle:
             Label("Ready", systemImage: "checkmark.circle")
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
         case let .syncing(progress):
             HStack(spacing: 6) {
                 ProgressView(value: progress)
                     .frame(width: 60)
+                    .tint(PortuTheme.dashboardGold)
                 Text("Syncing\u{2026}")
                     .font(.caption)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
             }
         case let .completedWithErrors(failed):
             Label("\(failed.count) account(s) failed", systemImage: "exclamationmark.triangle")
                 .font(.caption)
-                .foregroundStyle(.orange)
+                .foregroundStyle(PortuTheme.dashboardWarning)
                 .help("Failed: \(failed.joined(separator: ", "))")
         case let .error(msg):
             Label(msg, systemImage: "xmark.circle")
                 .font(.caption)
-                .foregroundStyle(.red)
+                .foregroundStyle(PortuTheme.dashboardWarning)
         }
     }
 }

--- a/Sources/Portu/Features/Accounts/AccountsView.swift
+++ b/Sources/Portu/Features/Accounts/AccountsView.swift
@@ -44,33 +44,30 @@ struct AccountsView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+            DashboardPageHeader("Accounts")
             toolbar
             accountTable
+                .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
         }
-        .navigationTitle("Accounts")
+        .padding(DashboardStyle.pagePadding)
+        .dashboardPage()
         .sheet(isPresented: Binding(
             get: { store.accounts.showAddSheet },
             set: { store.send(.accounts(.addSheetPresented($0))) })) {
                 AddAccountSheet()
+                    .environment(\.colorScheme, .dark)
         }
     }
 
     // MARK: - Toolbar
 
     private var toolbar: some View {
-        HStack {
-            HStack {
-                Image(systemName: "magnifyingglass")
-                TextField("Search accounts...", text: Binding(
-                    get: { store.accounts.searchText },
-                    set: { store.send(.accounts(.searchTextChanged($0))) }))
-                    .textFieldStyle(.plain)
-            }
-            .padding(6)
-            .background(.quaternary.opacity(0.5))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .frame(width: 200)
+        HStack(spacing: 10) {
+            DashboardSearchField(placeholder: "Search accounts...", text: Binding(
+                get: { store.accounts.searchText },
+                set: { store.send(.accounts(.searchTextChanged($0))) }))
+                .frame(width: 220)
 
             Picker("Group", selection: Binding(
                 get: { store.accounts.filterGroup },
@@ -81,22 +78,28 @@ struct AccountsView: View {
                     }
                 }
                 .frame(width: 150)
+                .dashboardControl()
 
             Toggle("Show Inactive", isOn: Binding(
                 get: { store.accounts.showInactive },
                 set: { _ in store.send(.accounts(.showInactiveToggled)) }))
+                .font(.caption)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .dashboardControl()
 
             Spacer()
 
             Button("Bulk Import") {}
                 .disabled(true)
                 .help("Coming soon")
+                .dashboardControl()
 
             Button("Add Account", systemImage: "plus") {
                 store.send(.accounts(.addSheetPresented(true)))
             }
+            .dashboardControl()
         }
-        .padding()
+        .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
     }
 
     // MARK: - Table
@@ -110,7 +113,7 @@ struct AccountsView: View {
                         .frame(width: 8, height: 8)
                     Text(row.name)
                         .fontWeight(.medium)
-                        .foregroundStyle(row.isActive ? .primary : .secondary)
+                        .foregroundStyle(row.isActive ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
                 }
             }
             .width(min: 100, ideal: 150)
@@ -121,7 +124,7 @@ struct AccountsView: View {
             TableColumn("Address") { row in
                 Text(row.address)
                     .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
             }
             .width(min: 100, ideal: 160)
 
@@ -133,16 +136,18 @@ struct AccountsView: View {
             TableColumn("USD Balance", value: \.balance) { row in
                 VStack(alignment: .trailing) {
                     Text(row.balance, format: .currency(code: "USD"))
+                        .font(DashboardStyle.monoTableFont)
                     if let error = row.lastSyncError {
                         Text(error)
                             .font(.caption2)
-                            .foregroundStyle(.red)
+                            .foregroundStyle(PortuTheme.dashboardWarning)
                             .lineLimit(1)
                     }
                 }
             }
             .width(min: 80, ideal: 120)
         }
+        .dashboardTable()
         .contextMenu(forSelectionType: AccountRowData.ID.self) { selection in
             if let id = selection.first, let account = accounts.first(where: { $0.id == id }) {
                 Button(account.isActive ? "Deactivate" : "Activate") {

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -1,5 +1,5 @@
-// Sources/Portu/Features/Accounts/AddAccountSheet.swift
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -7,7 +7,7 @@ struct AddAccountSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
 
-    @State private var selectedTab = 0
+    @State private var selectedTab: AddAccountTab = .chain
 
     // Chain account fields
     @State private var chainName = ""
@@ -29,32 +29,47 @@ struct AddAccountSheet: View {
     @State private var exchangeAPISecret = ""
     @State private var exchangePassphrase = ""
     @State private var exchangeGroup = ""
+    @State private var exchangeNotes = ""
     @State private var keychainError: String?
 
     var body: some View {
         VStack(spacing: 0) {
-            Text("Add Account")
-                .font(.headline)
-                .padding()
+            header
 
-            TabView(selection: $selectedTab) {
-                chainAccountTab.tabItem { Label("Chain", systemImage: "link") }.tag(0)
-                manualAccountTab.tabItem { Label("Manual", systemImage: "tray") }.tag(1)
-                exchangeAccountTab.tabItem { Label("Exchange", systemImage: "building.columns") }.tag(2)
-            }
-            .frame(height: 350)
+            Divider()
+                .overlay(PortuTheme.dashboardStroke)
 
-            HStack {
-                Button("Cancel") { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-                Spacer()
-                Button("Add") { saveAccount() }
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(!canSave)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    AddAccountTabSelector(selection: $selectedTab)
+
+                    Group {
+                        switch selectedTab {
+                        case .chain:
+                            chainAccountTab
+                        case .manual:
+                            manualAccountTab
+                        case .exchange:
+                            exchangeAccountTab
+                        }
+                    }
+                    .animation(.snappy(duration: 0.18), value: selectedTab)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
             }
-            .padding()
+            .scrollIndicators(.automatic)
+
+            footer
         }
-        .frame(width: 500, height: 480)
+        .frame(width: 780, height: 580)
+        .background(PortuTheme.dashboardPanelBackground)
+        .foregroundStyle(PortuTheme.dashboardText)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+        .environment(\.colorScheme, .dark)
         .alert("Keychain Error", isPresented: Binding(
             get: { keychainError != nil },
             set: { if !$0 { keychainError = nil } })) {
@@ -64,82 +79,261 @@ struct AddAccountSheet: View {
         }
     }
 
+    private var header: some View {
+        HStack(spacing: 12) {
+            Text("Add new account")
+                .font(.system(size: 19, weight: .medium))
+                .foregroundStyle(PortuTheme.dashboardText)
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .frame(width: 30, height: 30)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 20)
+        .frame(height: 58)
+    }
+
     // MARK: - Chain Account Tab
 
     private var chainAccountTab: some View {
-        Form {
-            TextField("Name", text: $chainName)
-            TextField("Wallet Address", text: $chainAddress)
-                .font(.system(.body, design: .monospaced))
+        VStack(alignment: .leading, spacing: 12) {
+            AddAccountSupportPanel(
+                title: "CHAINS WE SUPPORT:",
+                chips: [
+                    .init(title: "Ethereum & L2s", systemImage: "diamond.fill", tint: .purple),
+                    .init(title: "Solana", systemImage: "circle.hexagongrid.fill", tint: .green),
+                    .init(title: "Bitcoin", systemImage: "bitcoinsign.circle.fill", tint: .orange),
+                    .init(title: "Base", systemImage: "b.circle.fill", tint: .blue),
+                    .init(title: "Polygon", systemImage: "hexagon.fill", tint: .purple),
+                    .init(title: "+ 6 more...", systemImage: nil, tint: PortuTheme.dashboardSecondaryText)
+                ],
+                searchPlaceholder: "Search chain to test support",
+                linkTitle: "See full list")
 
-            Picker("Chain Type", selection: $isEVM) {
-                Text("Ethereum & L2s (EVM)").tag(true)
-                Text("Specific Chain").tag(false)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    AddAccountTextField(
+                        title: "Account Address",
+                        placeholder: "Paste wallet address",
+                        text: $chainAddress,
+                        isRequired: true,
+                        isMonospaced: true)
+
+                    chainTypePicker
+                }
+
+                AddAccountTextField(
+                    title: "Account Name",
+                    placeholder: "Account Name",
+                    text: $chainName,
+                    isRequired: true)
+
+                HStack(alignment: .top, spacing: 10) {
+                    AddAccountTextField(
+                        title: "Description",
+                        placeholder: "Descriptive text",
+                        text: $chainNotes)
+
+                    AddAccountTextField(
+                        title: "Account group",
+                        placeholder: "Select a group",
+                        text: $chainGroup)
+                }
+
+                InlineSourceNote(text: "Data source: Zapper API")
             }
+        }
+    }
 
-            if !isEVM {
-                Picker("Chain", selection: $specificChain) {
-                    Text("Solana").tag(Chain.solana)
-                    Text("Bitcoin").tag(Chain.bitcoin)
+    private var chainTypePicker: some View {
+        AddAccountMenuField(
+            title: "Account Type",
+            value: isEVM ? "Ethereum & L2s (EVM)" : specificChain.addAccountTitle,
+            isRequired: true) {
+                Button("Ethereum & L2s (EVM)") {
+                    isEVM = true
+                }
+
+                Divider()
+
+                ForEach([Chain.solana, .bitcoin], id: \.self) { chain in
+                    Button(chain.addAccountTitle) {
+                        specificChain = chain
+                        isEVM = false
+                    }
                 }
             }
-
-            TextField("Group (optional)", text: $chainGroup)
-            TextField("Notes (optional)", text: $chainNotes)
-
-            Text("Data source: Zapper API")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .formStyle(.grouped)
     }
 
     // MARK: - Manual Account Tab
 
     private var manualAccountTab: some View {
-        Form {
-            TextField("Name", text: $manualName)
-            TextField("Group (optional)", text: $manualGroup)
-            TextField("Notes (optional)", text: $manualNotes)
+        VStack(alignment: .leading, spacing: 12) {
+            AddAccountManualInfoPanel()
 
-            Text("Add positions manually after creating the account.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 10) {
+                AddAccountTextField(
+                    title: "Account Name",
+                    placeholder: "Account Name",
+                    text: $manualName,
+                    isRequired: true)
+
+                HStack(alignment: .top, spacing: 10) {
+                    AddAccountTextField(
+                        title: "Description",
+                        placeholder: "Descriptive text",
+                        text: $manualNotes)
+
+                    AddAccountTextField(
+                        title: "Account group",
+                        placeholder: "Select a group",
+                        text: $manualGroup)
+                }
+            }
         }
-        .formStyle(.grouped)
     }
 
     // MARK: - Exchange Account Tab
 
     private var exchangeAccountTab: some View {
-        Form {
-            TextField("Account Name", text: $exchangeName)
-            Picker("Exchange", selection: $exchangeType) {
-                ForEach(ExchangeType.allCases, id: \.self) { type in
-                    Text(type.rawValue.capitalized).tag(type)
+        VStack(alignment: .leading, spacing: 12) {
+            AddAccountSupportPanel(
+                title: "EXCHANGES WE SUPPORT:",
+                chips: [
+                    .init(title: "Kraken", systemImage: "k.circle.fill", tint: .purple),
+                    .init(title: "Coinbase", systemImage: "c.circle.fill", tint: .blue),
+                    .init(title: "Binance", systemImage: "diamond.circle.fill", tint: .yellow)
+                ],
+                searchPlaceholder: nil,
+                linkTitle: "See full list")
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    exchangePicker
+
+                    AddAccountTextField(
+                        title: "Name",
+                        placeholder: "Account Name",
+                        text: $exchangeName,
+                        isRequired: true)
+                }
+
+                AddAccountKeepInMindPanel()
+
+                HStack(alignment: .top, spacing: 10) {
+                    AddAccountSecureField(
+                        title: "API Key",
+                        placeholder: "API Key",
+                        text: $exchangeAPIKey,
+                        isRequired: true)
+
+                    AddAccountSecureField(
+                        title: "Private Key",
+                        placeholder: "Private Key",
+                        text: $exchangeAPISecret,
+                        isRequired: true)
+                }
+
+                if exchangeType == .coinbase {
+                    AddAccountSecureField(
+                        title: "Passphrase",
+                        placeholder: "Passphrase",
+                        text: $exchangePassphrase)
+                }
+
+                HStack(alignment: .top, spacing: 10) {
+                    AddAccountTextField(
+                        title: "Description",
+                        placeholder: "Descriptive text",
+                        text: $exchangeNotes)
+
+                    AddAccountTextField(
+                        title: "Account group",
+                        placeholder: "Select a group",
+                        text: $exchangeGroup)
                 }
             }
-
-            SecureField("API Key", text: $exchangeAPIKey)
-            SecureField("API Secret", text: $exchangeAPISecret)
-            if exchangeType == .coinbase {
-                SecureField("Passphrase", text: $exchangePassphrase)
-            }
-
-            TextField("Group (optional)", text: $exchangeGroup)
-
-            Text("Use read-only API keys for security.")
-                .font(.caption)
-                .foregroundStyle(.orange)
         }
-        .formStyle(.grouped)
+    }
+
+    private var exchangePicker: some View {
+        AddAccountMenuField(
+            title: "Exchange",
+            value: exchangeType.addAccountTitle,
+            isRequired: true) {
+                ForEach(ExchangeType.allCases, id: \.self) { type in
+                    Button(type.addAccountTitle) {
+                        exchangeType = type
+                    }
+                }
+            }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 0) {
+            Divider()
+                .overlay(PortuTheme.dashboardStroke)
+
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(PortuTheme.dashboardText)
+                        .padding(.horizontal, 14)
+                        .frame(height: 34)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(PortuTheme.dashboardMutedPanelBackground))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button {
+                    saveAccount()
+                } label: {
+                    Text("Add Account")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(canSave ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                        .padding(.horizontal, 18)
+                        .frame(height: 34)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(canSave ? PortuTheme.dashboardGoldMuted : PortuTheme.dashboardMutedPanelBackground))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .stroke(canSave ? PortuTheme.dashboardMutedStroke : PortuTheme.dashboardStroke, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSave)
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 54)
+            .background(PortuTheme.dashboardPanelBackground)
+        }
     }
 
     // MARK: - Save
 
     private var canSave: Bool {
         AccountsFeature.canSave(
-            tab: selectedTab,
+            tab: selectedTab.rawValue,
             chainName: chainName,
             chainAddress: chainAddress,
             manualName: manualName,
@@ -150,10 +344,9 @@ struct AddAccountSheet: View {
 
     private func saveAccount() {
         switch selectedTab {
-        case 0: saveChainAccount()
-        case 1: saveManualAccount()
-        case 2: saveExchangeAccount()
-        default: break
+        case .chain: saveChainAccount()
+        case .manual: saveManualAccount()
+        case .exchange: saveExchangeAccount()
         }
         dismiss()
     }
@@ -190,7 +383,8 @@ struct AddAccountSheet: View {
             kind: .exchange,
             exchangeType: exchangeType,
             dataSource: .exchange,
-            group: exchangeGroup.isEmpty ? nil : exchangeGroup)
+            group: exchangeGroup.isEmpty ? nil : exchangeGroup,
+            notes: exchangeNotes.isEmpty ? nil : exchangeNotes)
         modelContext.insert(account)
         try? modelContext.save()
 

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -30,7 +30,7 @@ struct AddAccountSheet: View {
     @State private var exchangePassphrase = ""
     @State private var exchangeGroup = ""
     @State private var exchangeNotes = ""
-    @State private var keychainError: String?
+    @State private var saveError: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -70,12 +70,12 @@ struct AddAccountSheet: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
         .environment(\.colorScheme, .dark)
-        .alert("Keychain Error", isPresented: Binding(
-            get: { keychainError != nil },
-            set: { if !$0 { keychainError = nil } })) {
-                Button("OK") { keychainError = nil }
+        .alert("Unable to Add Account", isPresented: Binding(
+            get: { saveError != nil },
+            set: { if !$0 { saveError = nil } })) {
+                Button("OK") { saveError = nil }
         } message: {
-            Text(keychainError ?? "")
+            Text(saveError ?? "")
         }
     }
 
@@ -343,15 +343,21 @@ struct AddAccountSheet: View {
     }
 
     private func saveAccount() {
-        switch selectedTab {
-        case .chain: saveChainAccount()
-        case .manual: saveManualAccount()
-        case .exchange: saveExchangeAccount()
+        let didSave: Bool = switch selectedTab {
+        case .chain:
+            saveChainAccount()
+        case .manual:
+            saveManualAccount()
+        case .exchange:
+            saveExchangeAccount()
         }
-        dismiss()
+
+        if didSave {
+            dismiss()
+        }
     }
 
-    private func saveChainAccount() {
+    private func saveChainAccount() -> Bool {
         let account = Account(
             name: chainName,
             kind: .wallet,
@@ -362,43 +368,66 @@ struct AddAccountSheet: View {
         let addr = WalletAddress(chain: chain, address: chainAddress, account: account)
         account.addresses = [addr]
 
-        modelContext.insert(account)
-        try? modelContext.save()
+        return insertAndSave(account)
     }
 
-    private func saveManualAccount() {
+    private func saveManualAccount() -> Bool {
         let account = Account(
             name: manualName,
             kind: .manual,
             dataSource: .manual,
             group: manualGroup.isEmpty ? nil : manualGroup,
             notes: manualNotes.isEmpty ? nil : manualNotes)
-        modelContext.insert(account)
-        try? modelContext.save()
+        return insertAndSave(account)
     }
 
-    private func saveExchangeAccount() {
+    private func saveExchangeAccount() -> Bool {
+        let accountId = UUID()
         let account = Account(
+            id: accountId,
             name: exchangeName,
             kind: .exchange,
             exchangeType: exchangeType,
             dataSource: .exchange,
             group: exchangeGroup.isEmpty ? nil : exchangeGroup,
             notes: exchangeNotes.isEmpty ? nil : exchangeNotes)
-        modelContext.insert(account)
-        try? modelContext.save()
 
-        // Store credentials in Keychain
         let keychain = KeychainService()
-        let id = account.id
         do {
-            try keychain.set(key: .exchangeAPIKey(id), value: exchangeAPIKey)
-            try keychain.set(key: .exchangeAPISecret(id), value: exchangeAPISecret)
+            try keychain.set(key: .exchangeAPIKey(accountId), value: exchangeAPIKey)
+            try keychain.set(key: .exchangeAPISecret(accountId), value: exchangeAPISecret)
             if !exchangePassphrase.isEmpty {
-                try keychain.set(key: .exchangePassphrase(id), value: exchangePassphrase)
+                try keychain.set(key: .exchangePassphrase(accountId), value: exchangePassphrase)
             }
         } catch {
-            keychainError = "Failed to save credentials: \(error.localizedDescription)"
+            deleteExchangeCredentials(accountId, keychain: keychain)
+            saveError = "Failed to save credentials: \(error.localizedDescription)"
+            return false
         }
+
+        if insertAndSave(account) {
+            return true
+        }
+
+        deleteExchangeCredentials(accountId, keychain: keychain)
+        return false
+    }
+
+    private func insertAndSave(_ account: Account) -> Bool {
+        modelContext.insert(account)
+        do {
+            try modelContext.save()
+            return true
+        } catch {
+            modelContext.delete(account)
+            saveError = "Failed to save account: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    private func deleteExchangeCredentials(_ accountId: UUID, keychain: KeychainService) {
+        try? keychain.delete(key: .exchangeAPIKey(accountId))
+        try? keychain.delete(key: .exchangeAPISecret(accountId))
+        try? keychain.delete(key: .exchangePassphrase(accountId))
     }
 }

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -97,6 +97,8 @@ struct AddAccountSheet: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(AddAccountAccessibility.closeButtonLabel)
+            .accessibilityHint("Closes the add account sheet.")
         }
         .padding(.horizontal, 20)
         .frame(height: 58)
@@ -273,6 +275,9 @@ struct AddAccountSheet: View {
                 ForEach(ExchangeType.allCases, id: \.self) { type in
                     Button(type.addAccountTitle) {
                         exchangeType = type
+                        exchangePassphrase = AddAccountExchangeSecrets.passphraseAfterSelecting(
+                            type,
+                            currentPassphrase: exchangePassphrase)
                     }
                 }
             }
@@ -396,8 +401,8 @@ struct AddAccountSheet: View {
         do {
             try keychain.set(key: .exchangeAPIKey(accountId), value: exchangeAPIKey)
             try keychain.set(key: .exchangeAPISecret(accountId), value: exchangeAPISecret)
-            if !exchangePassphrase.isEmpty {
-                try keychain.set(key: .exchangePassphrase(accountId), value: exchangePassphrase)
+            if let passphrase = AddAccountExchangeSecrets.persistedPassphrase(exchangePassphrase, for: exchangeType) {
+                try keychain.set(key: .exchangePassphrase(accountId), value: passphrase)
             }
         } catch {
             deleteExchangeCredentials(accountId, keychain: keychain)
@@ -429,5 +434,25 @@ struct AddAccountSheet: View {
         try? keychain.delete(key: .exchangeAPIKey(accountId))
         try? keychain.delete(key: .exchangeAPISecret(accountId))
         try? keychain.delete(key: .exchangePassphrase(accountId))
+    }
+}
+
+enum AddAccountAccessibility {
+    static let closeButtonLabel = "Close"
+}
+
+enum AddAccountExchangeSecrets {
+    static func persistedPassphrase(_ passphrase: String, for exchangeType: ExchangeType) -> String? {
+        guard exchangeType == .coinbase, !passphrase.isEmpty else {
+            return nil
+        }
+
+        return passphrase
+    }
+
+    static func passphraseAfterSelecting(
+        _ exchangeType: ExchangeType,
+        currentPassphrase: String) -> String {
+        exchangeType == .coinbase ? currentPassphrase : ""
     }
 }

--- a/Sources/Portu/Features/Accounts/AddAccountSheetComponents.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetComponents.swift
@@ -126,10 +126,13 @@ struct AddAccountSupportPanel: View {
 
 struct AddAccountSupportChip: View {
     struct Model: Identifiable {
-        let id = UUID()
         let title: String
         let systemImage: String?
         let tint: Color
+
+        var id: String {
+            "\(title)|\(systemImage ?? "")"
+        }
     }
 
     let model: Model

--- a/Sources/Portu/Features/Accounts/AddAccountSheetComponents.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetComponents.swift
@@ -1,0 +1,216 @@
+import PortuUI
+import SwiftUI
+
+enum AddAccountTab: Int, CaseIterable, Identifiable {
+    case chain
+    case manual
+    case exchange
+
+    var id: Self {
+        self
+    }
+
+    var title: String {
+        switch self {
+        case .chain: "Chain account"
+        case .manual: "Manual account"
+        case .exchange: "Exchange account"
+        }
+    }
+}
+
+struct AddAccountTabSelector: View {
+    @Binding var selection: AddAccountTab
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(AddAccountTab.allCases) { tab in
+                Button {
+                    selection = tab
+                } label: {
+                    Text(tab.title)
+                        .font(.system(size: 13, weight: selection == tab ? .medium : .regular))
+                        .foregroundStyle(selection == tab ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 32)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(selection == tab ? PortuTheme.dashboardGoldMuted : Color.clear))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(PortuTheme.dashboardPanelElevatedBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+}
+
+struct AddAccountSupportPanel: View {
+    let title: String
+    let chips: [AddAccountSupportChip.Model]
+    let searchPlaceholder: String?
+    let linkTitle: String
+
+    @State private var supportSearch = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(title)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(PortuTheme.dashboardText)
+
+                FlowLayout(spacing: 5, rowSpacing: 5) {
+                    ForEach(chips) { chip in
+                        AddAccountSupportChip(model: chip)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                Button {} label: {
+                    HStack(spacing: 5) {
+                        Text(linkTitle)
+                        Image(systemName: "arrow.up.forward.square")
+                            .font(.caption)
+                    }
+                    .font(.system(size: 13))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if let searchPlaceholder {
+                HStack(spacing: 7) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 13))
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+
+                    TextField("", text: $supportSearch, prompt: Text(searchPlaceholder))
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 13))
+                        .foregroundStyle(PortuTheme.dashboardText)
+                }
+                .padding(.horizontal, 8)
+                .frame(height: 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(PortuTheme.dashboardPanelBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(PortuTheme.dashboardPanelElevatedBackground.opacity(0.82)))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(PortuTheme.dashboardMutedStroke, lineWidth: 1))
+    }
+}
+
+struct AddAccountSupportChip: View {
+    struct Model: Identifiable {
+        let id = UUID()
+        let title: String
+        let systemImage: String?
+        let tint: Color
+    }
+
+    let model: Model
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if let systemImage = model.systemImage {
+                Image(systemName: systemImage)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white)
+                    .frame(width: 16, height: 16)
+                    .background(Circle().fill(model.tint))
+            }
+
+            Text(model.title)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+        }
+        .foregroundStyle(PortuTheme.dashboardText)
+        .padding(.leading, model.systemImage == nil ? 7 : 5)
+        .padding(.trailing, 7)
+        .frame(height: 24)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(PortuTheme.dashboardMutedPanelBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+}
+
+struct AddAccountManualInfoPanel: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Manual Accounts")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(PortuTheme.dashboardText)
+
+                Text("Use manual accounts to track positions you enter yourself, without connecting a wallet address or exchange API.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 7) {
+                Text("Keep in mind")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(PortuTheme.dashboardText)
+
+                AddAccountInfoRow(
+                    icon: "info.circle",
+                    text: "Use it to track manual positions that do not map to existing accounts.")
+                AddAccountInfoRow(
+                    icon: "info.circle",
+                    text: "For more info, read the full docs",
+                    showsExternalLink: true)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(PortuTheme.dashboardPanelElevatedBackground.opacity(0.78)))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.blue.opacity(0.62), lineWidth: 1))
+    }
+}
+
+struct AddAccountKeepInMindPanel: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Keep in mind")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(PortuTheme.dashboardText)
+
+            AddAccountInfoRow(
+                icon: "exclamationmark.circle",
+                iconColor: PortuTheme.dashboardGold,
+                text: "Make sure to only add API keys with read-only permissions.")
+            AddAccountInfoRow(
+                icon: "exclamationmark.circle",
+                iconColor: PortuTheme.dashboardGold,
+                text: "If needed, whitelist: 34.79.28.87")
+            AddAccountInfoRow(
+                icon: "info.circle",
+                iconColor: PortuTheme.dashboardGold,
+                text: "More info on how to get API keys. Read the docs",
+                showsExternalLink: true)
+        }
+    }
+}

--- a/Sources/Portu/Features/Accounts/AddAccountSheetComponents.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetComponents.swift
@@ -51,12 +51,13 @@ struct AddAccountTabSelector: View {
 }
 
 struct AddAccountSupportPanel: View {
+    @Environment(\.openURL) private var openURL
+
     let title: String
     let chips: [AddAccountSupportChip.Model]
     let searchPlaceholder: String?
     let linkTitle: String
-
-    @State private var supportSearch = ""
+    var linkURL: URL?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -73,7 +74,11 @@ struct AddAccountSupportPanel: View {
 
                 Spacer(minLength: 8)
 
-                Button {} label: {
+                Button {
+                    if let linkURL {
+                        openURL(linkURL)
+                    }
+                } label: {
                     HStack(spacing: 5) {
                         Text(linkTitle)
                         Image(systemName: "arrow.up.forward.square")
@@ -83,6 +88,8 @@ struct AddAccountSupportPanel: View {
                     .foregroundStyle(PortuTheme.dashboardSecondaryText)
                 }
                 .buttonStyle(.plain)
+                .disabled(linkURL == nil)
+                .help(linkURL == nil ? "Support documentation link is not configured yet." : "Open support documentation")
             }
 
             if let searchPlaceholder {
@@ -91,10 +98,10 @@ struct AddAccountSupportPanel: View {
                         .font(.system(size: 13))
                         .foregroundStyle(PortuTheme.dashboardSecondaryText)
 
-                    TextField("", text: $supportSearch, prompt: Text(searchPlaceholder))
-                        .textFieldStyle(.plain)
+                    Text(searchPlaceholder)
                         .font(.system(size: 13))
-                        .foregroundStyle(PortuTheme.dashboardText)
+                        .foregroundStyle(PortuTheme.dashboardTertiaryText)
+                    Spacer(minLength: 0)
                 }
                 .padding(.horizontal, 8)
                 .frame(height: 30)
@@ -104,6 +111,7 @@ struct AddAccountSupportPanel: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                         .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+                .help("Live support lookup is not available yet.")
             }
         }
         .padding(8)
@@ -205,7 +213,7 @@ struct AddAccountKeepInMindPanel: View {
             AddAccountInfoRow(
                 icon: "exclamationmark.circle",
                 iconColor: PortuTheme.dashboardGold,
-                text: "If needed, whitelist: 34.79.28.87")
+                text: "If your exchange supports IP restrictions, follow the current setup guide before enabling them.")
             AddAccountInfoRow(
                 icon: "info.circle",
                 iconColor: PortuTheme.dashboardGold,

--- a/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
@@ -1,0 +1,255 @@
+import PortuCore
+import PortuUI
+import SwiftUI
+
+struct AddAccountInfoRow: View {
+    let icon: String
+    var iconColor: Color = .blue.opacity(0.88)
+    let text: String
+    var showsExternalLink = false
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(iconColor)
+                .frame(width: 14)
+
+            Text(text)
+                .font(.system(size: 12))
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+
+            if showsExternalLink {
+                Image(systemName: "arrow.up.forward.square")
+                    .font(.caption)
+                    .foregroundStyle(PortuTheme.dashboardGold)
+            }
+        }
+    }
+}
+
+struct AddAccountTextField: View {
+    let title: String
+    let placeholder: String
+    @Binding var text: String
+    var isRequired = false
+    var isMonospaced = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            AddAccountFieldLabel(title: title, isRequired: isRequired)
+
+            TextField("", text: $text, prompt: Text(placeholder))
+                .textFieldStyle(.plain)
+                .font(fieldFont)
+                .foregroundStyle(PortuTheme.dashboardText)
+                .padding(.horizontal, 10)
+                .frame(height: 36)
+                .addAccountFieldSurface()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var fieldFont: Font {
+        isMonospaced ? .system(size: 13, design: .monospaced) : .system(size: 13)
+    }
+}
+
+struct AddAccountSecureField: View {
+    let title: String
+    let placeholder: String
+    @Binding var text: String
+    var isRequired = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            AddAccountFieldLabel(title: title, isRequired: isRequired)
+
+            SecureField("", text: $text, prompt: Text(placeholder))
+                .textFieldStyle(.plain)
+                .font(.system(size: 13))
+                .foregroundStyle(PortuTheme.dashboardText)
+                .padding(.horizontal, 10)
+                .frame(height: 36)
+                .addAccountFieldSurface()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct AddAccountMenuField<Content: View>: View {
+    let title: String
+    let value: String
+    var isRequired = false
+    let content: Content
+
+    init(
+        title: String,
+        value: String,
+        isRequired: Bool = false,
+        @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.value = value
+        self.isRequired = isRequired
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            AddAccountFieldLabel(title: title, isRequired: isRequired)
+
+            Menu {
+                content
+            } label: {
+                HStack(spacing: 8) {
+                    Text(value)
+                        .font(.system(size: 13))
+                        .foregroundStyle(PortuTheme.dashboardText)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 8)
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                }
+                .padding(.horizontal, 10)
+                .frame(height: 36)
+                .contentShape(Rectangle())
+                .addAccountFieldSurface()
+            }
+            .menuStyle(.borderlessButton)
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct AddAccountFieldLabel: View {
+    let title: String
+    var isRequired = false
+
+    var body: some View {
+        Text(isRequired ? "\(title) *" : title)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(PortuTheme.dashboardSecondaryText)
+    }
+}
+
+struct InlineSourceNote: View {
+    let text: String
+
+    var body: some View {
+        Label(text, systemImage: "bolt.horizontal.circle")
+            .font(.system(size: 11))
+            .foregroundStyle(PortuTheme.dashboardSecondaryText)
+    }
+}
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+    var rowSpacing: CGFloat = 8
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache _: inout Void) -> CGSize {
+        let rows = rows(in: proposal.width ?? .infinity, subviews: subviews)
+        let width = rows.map(\.width).max() ?? 0
+        let height = rows.reduce(CGFloat.zero) { partial, row in
+            partial + row.height
+        } + CGFloat(max(rows.count - 1, 0)) * rowSpacing
+        return CGSize(width: width, height: height)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal _: ProposedViewSize,
+        subviews: Subviews,
+        cache _: inout Void) {
+        var y = bounds.minY
+        for row in rows(in: bounds.width, subviews: subviews) {
+            var x = bounds.minX
+            for element in row.elements {
+                subviews[element.index].place(
+                    at: CGPoint(x: x, y: y),
+                    proposal: ProposedViewSize(element.size))
+                x += element.size.width + spacing
+            }
+            y += row.height + rowSpacing
+        }
+    }
+
+    private func rows(in maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let nextWidth = current.width == 0 ? size.width : current.width + spacing + size.width
+            if nextWidth > maxWidth, !current.elements.isEmpty {
+                rows.append(current)
+                current = Row()
+            }
+            current.elements.append(Row.Element(index: index, size: size))
+            current.width = current.width == 0 ? size.width : current.width + spacing + size.width
+            current.height = max(current.height, size.height)
+        }
+
+        if !current.elements.isEmpty {
+            rows.append(current)
+        }
+
+        return rows
+    }
+
+    private struct Row {
+        var elements: [Element] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+
+        struct Element {
+            let index: Int
+            let size: CGSize
+        }
+    }
+}
+
+extension View {
+    func addAccountFieldSurface() -> some View {
+        background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(PortuTheme.dashboardMutedPanelBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+}
+
+extension Chain {
+    var addAccountTitle: String {
+        switch self {
+        case .ethereum: "Ethereum"
+        case .polygon: "Polygon"
+        case .arbitrum: "Arbitrum"
+        case .optimism: "Optimism"
+        case .base: "Base"
+        case .bsc: "BNB Smart Chain"
+        case .solana: "Solana"
+        case .bitcoin: "Bitcoin"
+        case .avalanche: "Avalanche"
+        case .monad: "Monad"
+        case .katana: "Katana"
+        }
+    }
+}
+
+extension ExchangeType {
+    var addAccountTitle: String {
+        switch self {
+        case .binance: "Binance"
+        case .coinbase: "Coinbase"
+        case .kraken: "Kraken"
+        }
+    }
+}

--- a/Sources/Portu/Features/AllAssets/AllAssetsView.swift
+++ b/Sources/Portu/Features/AllAssets/AllAssetsView.swift
@@ -1,12 +1,15 @@
 // Sources/Portu/Features/AllAssets/AllAssetsView.swift
 import ComposableArchitecture
+import PortuUI
 import SwiftUI
 
 struct AllAssetsView: View {
     let store: StoreOf<AppFeature>
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+            DashboardPageHeader("All Assets")
+
             Picker("Tab", selection: Binding(
                 get: { store.allAssets.selectedTab },
                 set: { store.send(.allAssets(.tabSelected($0))) })) {
@@ -15,16 +18,24 @@ struct AllAssetsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .padding()
+                .frame(width: 360)
+                .dashboardControl()
 
             switch store.allAssets.selectedTab {
             case .assets: AssetsTab(store: store)
-            case .nfts: nftPlaceholder
-            case .platforms: PlatformsTab()
-            case .networks: NetworksTab()
+            case .nfts:
+                nftPlaceholder
+                    .dashboardCard()
+            case .platforms:
+                PlatformsTab()
+                    .dashboardCard()
+            case .networks:
+                NetworksTab()
+                    .dashboardCard()
             }
         }
-        .navigationTitle("All Assets")
+        .padding(DashboardStyle.pagePadding)
+        .dashboardPage()
     }
 
     private var nftPlaceholder: some View {
@@ -32,5 +43,6 @@ struct AllAssetsView: View {
             "NFT Tracking",
             systemImage: "photo.artframe",
             description: Text("NFT tracking coming soon"))
+            .foregroundStyle(PortuTheme.dashboardSecondaryText)
     }
 }

--- a/Sources/Portu/Features/AllAssets/AssetsTab.swift
+++ b/Sources/Portu/Features/AllAssets/AssetsTab.swift
@@ -11,9 +11,8 @@ struct AssetsTab: View {
     @Query private var allTokens: [PositionToken]
 
     @State private var exportError: String?
-    @State private var sortOrder: [KeyPathComparator<AssetRowData>] = [
-        KeyPathComparator(\.value, order: .reverse)
-    ]
+    @State private var sortColumn: AssetSortColumn = .value
+    @State private var sortAscending = false
 
     /// Map @Query tokens to lightweight entries, aggregate with live prices, filter, sort.
     private var rows: [AssetRowData] {
@@ -21,7 +20,7 @@ struct AssetsTab: View {
 
         let aggregated = AllAssetsFeature.aggregateRows(tokens: entries, prices: store.prices)
         let filtered = AllAssetsFeature.filterRows(aggregated, searchText: store.allAssets.searchText)
-        return filtered.sorted(using: sortOrder)
+        return sortRows(filtered)
     }
 
     // MARK: - Body
@@ -31,6 +30,7 @@ struct AssetsTab: View {
             toolbar
             assetTable
         }
+        .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
         .alert("Export Failed", isPresented: Binding(get: { exportError != nil }, set: { if !$0 { exportError = nil } })) {
             Button("OK") { exportError = nil }
         } message: {
@@ -41,17 +41,11 @@ struct AssetsTab: View {
     // MARK: - Toolbar
 
     private var toolbar: some View {
-        HStack {
-            HStack {
-                Image(systemName: "magnifyingglass")
-                TextField("Search assets...", text: Binding(
-                    get: { store.allAssets.searchText },
-                    set: { store.send(.allAssets(.searchTextChanged($0))) }))
-                    .textFieldStyle(.plain)
-            }
-            .padding(8)
-            .background(.quaternary.opacity(0.5))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+        HStack(spacing: 10) {
+            DashboardSearchField(placeholder: "Search assets...", text: Binding(
+                get: { store.allAssets.searchText },
+                set: { store.send(.allAssets(.searchTextChanged($0))) }))
+                .frame(width: 220)
 
             Spacer()
 
@@ -64,63 +58,186 @@ struct AssetsTab: View {
                 }
                 .pickerStyle(.menu)
                 .frame(width: 140)
+                .dashboardControl()
 
             Button {
                 exportCSV()
             } label: {
                 Label("Export CSV", systemImage: "square.and.arrow.up")
             }
+            .dashboardControl()
         }
-        .padding(.horizontal)
         .padding(.bottom, 8)
     }
 
     // MARK: - Table
 
     private var assetTable: some View {
-        Table(rows, sortOrder: $sortOrder) {
-            TableColumn("Symbol", value: \.symbol) { row in
-                NavigationLink(value: row.id) {
-                    Text(row.symbol).fontWeight(.medium)
-                }
-            }
-            .width(min: 60, ideal: 80)
+        VStack(spacing: 0) {
+            assetTableHeader
 
-            TableColumn("Name", value: \.name) { row in
-                Text(row.name)
-            }
-            .width(min: 100, ideal: 150)
+            Divider()
+                .overlay(PortuTheme.dashboardStroke)
 
-            TableColumn("Category") { row in
-                CapsuleBadge(row.category.rawValue.capitalized)
-            }
-            .width(min: 80, ideal: 100)
-
-            TableColumn("Net Amount", value: \.netAmount) { row in
-                Text(row.netAmount, format: .number.precision(.fractionLength(2 ... 8)))
-                    .foregroundStyle(row.netAmount < 0 ? .red : .primary)
-            }
-            .width(min: 80, ideal: 120)
-
-            TableColumn("Price", value: \.price) { row in
-                HStack(spacing: 4) {
-                    Text(row.price, format: .currency(code: "USD"))
-                    if !row.hasLivePrice {
-                        Image(systemName: "clock")
-                            .font(.caption2)
-                            .foregroundStyle(.orange)
-                            .help("Sync-time price -- no live data")
+            if rows.isEmpty {
+                ContentUnavailableView(
+                    "No assets",
+                    systemImage: "bitcoinsign.circle",
+                    description: Text("Synced balances will appear here."))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .frame(maxWidth: .infinity, minHeight: 280)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                            assetRow(row, index: index)
+                        }
                     }
                 }
             }
-            .width(min: 80, ideal: 100)
-
-            TableColumn("Value", value: \.value) { row in
-                Text(row.value, format: .currency(code: "USD"))
-                    .foregroundStyle(row.value < 0 ? .red : .primary)
-            }
-            .width(min: 80, ideal: 120)
         }
+        .dashboardTable()
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+
+    private var assetTableHeader: some View {
+        HStack(spacing: 12) {
+            sortHeader("Symbol", column: .symbol, width: 96)
+            sortHeader("Name", column: .name)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            sortHeader("Category", column: .category, width: 112)
+            sortHeader("Net Amount", column: .netAmount, width: 150, alignment: .trailing, isTrailing: true)
+            sortHeader("Price", column: .price, width: 132, alignment: .trailing, isTrailing: true)
+            sortHeader("Value", column: .value, width: 140, alignment: .trailing, isTrailing: true)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 34)
+        .background(PortuTheme.dashboardPanelElevatedBackground)
+    }
+
+    private func assetRow(_ row: AssetRowData, index: Int) -> some View {
+        NavigationLink(value: row.id) {
+            HStack(spacing: 12) {
+                Text(row.symbol)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .frame(width: 96, alignment: .leading)
+
+                Text(row.name)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                CapsuleBadge(row.category.rawValue.capitalized)
+                    .frame(width: 112, alignment: .leading)
+
+                Text(row.netAmount, format: .number.precision(.fractionLength(2 ... 8)))
+                    .font(DashboardStyle.monoTableFont)
+                    .foregroundStyle(row.netAmount < 0 ? PortuTheme.dashboardWarning : PortuTheme.dashboardText)
+                    .frame(width: 150, alignment: .trailing)
+
+                HStack(spacing: 4) {
+                    Spacer(minLength: 0)
+                    Text(row.price, format: .currency(code: "USD"))
+                        .font(DashboardStyle.monoTableFont)
+                    if !row.hasLivePrice {
+                        Image(systemName: "clock")
+                            .font(.caption2)
+                            .foregroundStyle(PortuTheme.dashboardGold)
+                            .help("Sync-time price -- no live data")
+                    }
+                }
+                .frame(width: 132, alignment: .trailing)
+
+                Text(row.value, format: .currency(code: "USD"))
+                    .font(DashboardStyle.monoTableFont)
+                    .foregroundStyle(row.value < 0 ? PortuTheme.dashboardWarning : PortuTheme.dashboardText)
+                    .frame(width: 140, alignment: .trailing)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: PortuTheme.dashboardTableRowHeight + 8)
+            .background(index.isMultiple(of: 2) ? Color.clear : PortuTheme.dashboardPanelElevatedBackground.opacity(0.45))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func sortHeader(
+        _ title: String,
+        column: AssetSortColumn,
+        width: CGFloat? = nil,
+        alignment: Alignment = .leading,
+        isTrailing: Bool = false) -> some View {
+        Button {
+            updateSort(column)
+        } label: {
+            HStack(spacing: 4) {
+                if isTrailing {
+                    Spacer(minLength: 0)
+                }
+                Text(title.uppercased())
+                if sortColumn == column {
+                    Image(systemName: sortAscending ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                }
+                if !isTrailing {
+                    Spacer(minLength: 0)
+                }
+            }
+            .frame(width: width, alignment: alignment)
+        }
+        .buttonStyle(.plain)
+        .font(DashboardStyle.labelFont)
+        .foregroundStyle(sortColumn == column ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+        .help("Sort by \(title)")
+    }
+
+    private func updateSort(_ column: AssetSortColumn) {
+        if sortColumn == column {
+            sortAscending.toggle()
+        } else {
+            sortColumn = column
+            sortAscending = column.defaultAscending
+        }
+    }
+
+    private func sortRows(_ rows: [AssetRowData]) -> [AssetRowData] {
+        rows.sorted { lhs, rhs in
+            let result = compare(lhs, rhs, by: sortColumn)
+            if result == .orderedSame {
+                return lhs.symbol.localizedCaseInsensitiveCompare(rhs.symbol) == .orderedAscending
+            }
+            return sortAscending ? result == .orderedAscending : result == .orderedDescending
+        }
+    }
+
+    private func compare(
+        _ lhs: AssetRowData,
+        _ rhs: AssetRowData,
+        by column: AssetSortColumn) -> ComparisonResult {
+        switch column {
+        case .symbol:
+            lhs.symbol.localizedCaseInsensitiveCompare(rhs.symbol)
+        case .name:
+            lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+        case .category:
+            lhs.category.rawValue.localizedCaseInsensitiveCompare(rhs.category.rawValue)
+        case .netAmount:
+            compare(lhs.netAmount, rhs.netAmount)
+        case .price:
+            compare(lhs.price, rhs.price)
+        case .value:
+            compare(lhs.value, rhs.value)
+        }
+    }
+
+    private func compare(_ lhs: Decimal, _ rhs: Decimal) -> ComparisonResult {
+        if lhs < rhs { return .orderedAscending }
+        if lhs > rhs { return .orderedDescending }
+        return .orderedSame
     }
 
     // MARK: - CSV Export
@@ -137,6 +254,24 @@ struct AssetsTab: View {
             } catch {
                 exportError = error.localizedDescription
             }
+        }
+    }
+}
+
+private enum AssetSortColumn {
+    case symbol
+    case name
+    case category
+    case netAmount
+    case price
+    case value
+
+    var defaultAscending: Bool {
+        switch self {
+        case .symbol, .name, .category:
+            true
+        case .netAmount, .price, .value:
+            false
         }
     }
 }

--- a/Sources/Portu/Features/AllAssets/AssetsTab.swift
+++ b/Sources/Portu/Features/AllAssets/AssetsTab.swift
@@ -1,4 +1,5 @@
 // Sources/Portu/Features/AllAssets/AssetsTab.swift
+import AppKit
 import ComposableArchitecture
 import PortuCore
 import PortuUI

--- a/Sources/Portu/Features/AllAssets/NetworksTab.swift
+++ b/Sources/Portu/Features/AllAssets/NetworksTab.swift
@@ -1,5 +1,6 @@
 // Sources/Portu/Features/AllAssets/NetworksTab.swift
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -67,14 +68,17 @@ struct NetworksTab: View {
 
     var body: some View {
         Table(rows) {
-            TableColumn("Network") { row in Text(row.name).fontWeight(.medium) }
+            TableColumn("Network") { row in Text(row.name).fontWeight(.medium).foregroundStyle(PortuTheme.dashboardText) }
             TableColumn("Share %") { row in
                 Text(row.sharePercent, format: .percent.precision(.fractionLength(1)))
+                    .font(DashboardStyle.monoTableFont)
             }
             TableColumn("# Positions") { row in Text("\(row.positionCount)") }
             TableColumn("USD Balance") { row in
                 Text(row.usdBalance, format: .currency(code: "USD"))
+                    .font(DashboardStyle.monoTableFont)
             }
         }
+        .dashboardTable()
     }
 }

--- a/Sources/Portu/Features/AllAssets/PlatformsTab.swift
+++ b/Sources/Portu/Features/AllAssets/PlatformsTab.swift
@@ -1,5 +1,6 @@
 // Sources/Portu/Features/AllAssets/PlatformsTab.swift
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -86,15 +87,18 @@ struct PlatformsTab: View {
 
     var body: some View {
         Table(rows) {
-            TableColumn("Platform") { row in Text(row.name).fontWeight(.medium) }
+            TableColumn("Platform") { row in Text(row.name).fontWeight(.medium).foregroundStyle(PortuTheme.dashboardText) }
             TableColumn("Share %") { row in
                 Text(row.sharePercent, format: .percent.precision(.fractionLength(1)))
+                    .font(DashboardStyle.monoTableFont)
             }
             TableColumn("# Networks") { row in Text("\(row.networkCount)") }
             TableColumn("# Positions") { row in Text("\(row.positionCount)") }
             TableColumn("USD Balance") { row in
                 Text(row.usdBalance, format: .currency(code: "USD"))
+                    .font(DashboardStyle.monoTableFont)
             }
         }
+        .dashboardTable()
     }
 }

--- a/Sources/Portu/Features/AssetDetail/AssetDetailView.swift
+++ b/Sources/Portu/Features/AssetDetail/AssetDetailView.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -7,6 +8,7 @@ struct AssetDetailView: View {
     let assetId: UUID
     let store: StoreOf<AppFeature>
 
+    @Environment(\.dismiss) private var dismiss
     @Query private var assets: [Asset]
 
     private var asset: Asset? {
@@ -17,63 +19,61 @@ struct AssetDetailView: View {
         if let asset {
             HSplitView {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 20) {
-                        // Breadcrumb
-                        HStack {
-                            Button("← Assets") {
+                    VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+                        DashboardPageHeader(asset.name, subtitle: asset.symbol) {
+                            Button {
+                                dismiss()
                                 store.send(.sectionSelected(.allAssets))
+                            } label: {
+                                Label("Assets", systemImage: "chevron.left")
                             }
-                            .buttonStyle(.plain)
-                            .foregroundStyle(.secondary)
-                            Text(">")
-                                .foregroundStyle(.tertiary)
-                            Text(asset.symbol)
-                                .fontWeight(.medium)
+                            .dashboardControl()
                         }
-                        .font(.caption)
 
-                        // Header
-                        HStack(alignment: .firstTextBaseline) {
-                            Text(asset.name)
-                                .font(.title.weight(.semibold))
-                            Text(asset.symbol)
-                                .font(.title2)
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            if
-                                let info = AssetDetailFeature.headerPriceInfo(
-                                    coinGeckoId: asset.coinGeckoId,
-                                    prices: store.prices,
-                                    changes24h: store.priceChanges24h) {
-                                VStack(alignment: .trailing) {
-                                    Text(info.price, format: .currency(code: "USD"))
-                                        .font(.title2.weight(.semibold))
+                        if
+                            let info = AssetDetailFeature.headerPriceInfo(
+                                coinGeckoId: asset.coinGeckoId,
+                                prices: store.prices,
+                                changes24h: store.priceChanges24h) {
+                            DashboardCard {
+                                HStack(alignment: .firstTextBaseline) {
+                                    DashboardMetricBlock(
+                                        title: "Price",
+                                        value: info.price.formatted(.currency(code: "USD")))
+                                    Spacer()
                                     if let change = info.change24h {
                                         HStack(spacing: 4) {
                                             Image(systemName: change >= 0 ? "arrow.up.right" : "arrow.down.right")
                                             Text(change, format: .percent.precision(.fractionLength(2)))
                                         }
-                                        .foregroundStyle(change >= 0 ? .green : .red)
+                                        .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                                        .foregroundStyle(change >= 0 ? PortuTheme.dashboardSuccess : PortuTheme.dashboardWarning)
                                     }
                                 }
                             }
                         }
 
                         AssetPriceChart(assetId: assetId, coinGeckoId: asset.coinGeckoId, store: store)
+                            .dashboardCard()
                         AssetHoldingsSummary(assetId: assetId, store: store)
+                            .dashboardCard()
                         AssetPositionsTable(assetId: assetId, store: store)
+                            .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
                     }
-                    .padding()
+                    .padding(DashboardStyle.pagePadding)
                 }
                 .frame(minWidth: 500)
                 .layoutPriority(3)
+                .background(PortuTheme.dashboardBackground)
 
                 AssetMetadataSidebar(asset: asset)
                     .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
                     .layoutPriority(1)
             }
+            .dashboardPage()
         } else {
             ContentUnavailableView("Asset Not Found", systemImage: "questionmark.circle")
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
         }
     }
 }

--- a/Sources/Portu/Features/AssetDetail/AssetHoldingsSummary.swift
+++ b/Sources/Portu/Features/AssetDetail/AssetHoldingsSummary.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -17,37 +18,41 @@ struct AssetHoldingsSummary: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Holdings Summary")
-                .font(.headline)
+                .font(DashboardStyle.sectionTitleFont)
+                .foregroundStyle(PortuTheme.dashboardText)
 
             HStack(spacing: 24) {
                 VStack(alignment: .leading) {
-                    Text("Accounts").font(.caption).foregroundStyle(.secondary)
-                    Text("\(summary.accountCount)").font(.title3.weight(.semibold))
+                    Text("Accounts").font(.caption).foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    Text("\(summary.accountCount)")
+                        .font(.system(size: 18, weight: .semibold, design: .monospaced))
                 }
                 VStack(alignment: .leading) {
-                    Text("Total Amount").font(.caption).foregroundStyle(.secondary)
+                    Text("Total Amount").font(.caption).foregroundStyle(PortuTheme.dashboardSecondaryText)
                     Text(summary.totalAmount, format: .number.precision(.fractionLength(2 ... 8)))
-                        .font(.title3.weight(.semibold))
+                        .font(.system(size: 18, weight: .semibold, design: .monospaced))
                 }
                 VStack(alignment: .leading) {
-                    Text("Total Value").font(.caption).foregroundStyle(.secondary)
+                    Text("Total Value").font(.caption).foregroundStyle(PortuTheme.dashboardSecondaryText)
                     Text(summary.totalValue, format: .currency(code: "USD"))
-                        .font(.title3.weight(.semibold))
+                        .font(.system(size: 18, weight: .semibold, design: .monospaced))
                 }
             }
 
             if !summary.byChain.isEmpty {
                 Text("On Networks").font(.subheadline.weight(.medium))
+                    .foregroundStyle(PortuTheme.dashboardText)
                 ForEach(summary.byChain) { chain in
                     HStack {
                         Text(chain.name)
                         Spacer()
                         Text(chain.share, format: .percent.precision(.fractionLength(1)))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(PortuTheme.dashboardSecondaryText)
                         Text(chain.value, format: .currency(code: "USD"))
+                            .font(DashboardStyle.monoTableFont)
                             .frame(width: 100, alignment: .trailing)
                     }
-                    .font(.body)
+                    .font(.caption)
                 }
             }
         }

--- a/Sources/Portu/Features/AssetDetail/AssetMetadataSidebar.swift
+++ b/Sources/Portu/Features/AssetDetail/AssetMetadataSidebar.swift
@@ -8,7 +8,6 @@ struct AssetMetadataSidebar: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                // Logo
                 if let logoURL = asset.logoURL, let url = URL(string: logoURL) {
                     AsyncImage(url: url) { image in
                         image.resizable().scaledToFit()
@@ -21,40 +20,47 @@ struct AssetMetadataSidebar: View {
                     .clipShape(Circle())
                 }
 
-                // Name and symbol
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(asset.name).font(.title3.weight(.semibold))
-                    Text(asset.symbol).font(.body).foregroundStyle(.secondary)
+                    Text(asset.name)
+                        .font(DashboardStyle.sectionTitleFont)
+                        .foregroundStyle(PortuTheme.dashboardText)
+                    Text(asset.symbol)
+                        .font(.caption)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
                 }
 
-                Divider()
+                Rectangle().fill(PortuTheme.dashboardStroke).frame(height: 1)
 
-                // Category
                 LabeledContent("Category") {
                     CapsuleBadge(asset.category.rawValue.capitalized)
                 }
 
-                // Verification
                 LabeledContent("Verified") {
                     Image(systemName: asset.isVerified ? "checkmark.seal.fill" : "xmark.seal")
-                        .foregroundStyle(asset.isVerified ? .green : .secondary)
+                        .foregroundStyle(asset.isVerified ? PortuTheme.dashboardSuccess : PortuTheme.dashboardSecondaryText)
                 }
 
-                // CoinGecko ID
                 if let cgId = asset.coinGeckoId {
                     LabeledContent("CoinGecko") {
-                        Text(cgId).font(.caption).foregroundStyle(.secondary)
+                        Text(cgId).font(.caption).foregroundStyle(PortuTheme.dashboardSecondaryText)
                     }
                 }
 
-                Divider()
+                Rectangle().fill(PortuTheme.dashboardStroke).frame(height: 1)
 
-                // Explorer links note
                 Text("Explorer links are per-position (varies by network), not per-asset.")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
             }
             .padding()
+        }
+        .font(.caption)
+        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+        .background(PortuTheme.dashboardPanelBackground)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(PortuTheme.dashboardStroke)
+                .frame(width: 1)
         }
     }
 }

--- a/Sources/Portu/Features/AssetDetail/AssetPositionsTable.swift
+++ b/Sources/Portu/Features/AssetDetail/AssetPositionsTable.swift
@@ -17,10 +17,12 @@ struct AssetPositionsTable: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Positions").font(.headline)
+            Text("Positions")
+                .font(DashboardStyle.sectionTitleFont)
+                .foregroundStyle(PortuTheme.dashboardText)
 
             Table(rows) {
-                TableColumn("Account") { row in Text(row.accountName) }
+                TableColumn("Account") { row in Text(row.accountName).foregroundStyle(PortuTheme.dashboardText) }
                     .width(min: 80, ideal: 120)
                 TableColumn("Platform") { row in Text(row.platformName) }
                     .width(min: 80, ideal: 100)
@@ -32,13 +34,16 @@ struct AssetPositionsTable: View {
                     .width(min: 60, ideal: 80)
                 TableColumn("Amount") { row in
                     Text(row.amount, format: .number.precision(.fractionLength(2 ... 8)))
+                        .font(DashboardStyle.monoTableFont)
                 }
                 .width(min: 80, ideal: 100)
                 TableColumn("USD Balance") { row in
                     Text(row.usdBalance, format: .currency(code: "USD"))
+                        .font(DashboardStyle.monoTableFont)
                 }
                 .width(min: 80, ideal: 100)
             }
+            .dashboardTable()
         }
     }
 }

--- a/Sources/Portu/Features/AssetDetail/AssetPriceChart.swift
+++ b/Sources/Portu/Features/AssetDetail/AssetPriceChart.swift
@@ -1,6 +1,7 @@
 import Charts
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -54,6 +55,7 @@ struct AssetPriceChart: View {
                     }
                     .pickerStyle(.segmented)
                     .frame(width: 250)
+                    .dashboardControl()
 
                 Spacer()
 
@@ -66,6 +68,7 @@ struct AssetPriceChart: View {
                     }
                     .pickerStyle(.segmented)
                     .frame(width: 250)
+                    .dashboardControl()
             }
 
             switch store.assetDetail.chartMode {
@@ -87,11 +90,13 @@ struct AssetPriceChart: View {
                 ContentUnavailableView(
                     "Price History", systemImage: "chart.line.uptrend.xyaxis",
                     description: Text("Historical price chart — requires CoinGecko market_chart API integration"))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
                     .frame(height: 250)
             } else {
                 ContentUnavailableView(
                     "No Price Data", systemImage: "chart.line.uptrend.xyaxis",
                     description: Text("Asset has no CoinGecko ID for price history"))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
                     .frame(height: 250)
             }
         }
@@ -105,6 +110,7 @@ struct AssetPriceChart: View {
                 ContentUnavailableView(
                     "No Value Data", systemImage: "chart.line.uptrend.xyaxis",
                     description: Text("Sync your accounts to see value history"))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
                     .frame(height: 250)
             } else {
                 let isBorrowOnly = aggregated.allSatisfy { $0.grossUSD == 0 && $0.borrowUSD > 0 }
@@ -115,7 +121,7 @@ struct AssetPriceChart: View {
                         LineMark(
                             x: .value("Date", point.date),
                             y: .value("Value", net))
-                            .foregroundStyle(net < 0 ? .red : Color.accentColor)
+                            .foregroundStyle(net < 0 ? PortuTheme.dashboardWarning : PortuTheme.dashboardGold)
 
                         AreaMark(
                             x: .value("Date", point.date),
@@ -137,7 +143,7 @@ struct AssetPriceChart: View {
                 if isBorrowOnly {
                     Text("Debt history — this asset is only borrowed")
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(PortuTheme.dashboardGold)
                 }
             }
         }
@@ -151,13 +157,14 @@ struct AssetPriceChart: View {
                 ContentUnavailableView(
                     "No Amount Data", systemImage: "chart.line.uptrend.xyaxis",
                     description: Text("Sync your accounts to see amount history"))
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
                     .frame(height: 250)
             } else {
                 Chart {
                     ForEach(aggregated) { point in
                         let net = point.grossAmount - point.borrowAmount
                         LineMark(x: .value("Date", point.date), y: .value("Amount", net))
-                            .foregroundStyle(net < 0 ? .red : Color.accentColor)
+                            .foregroundStyle(net < 0 ? PortuTheme.dashboardWarning : PortuTheme.dashboardGold)
                     }
                 }
                 .frame(height: 250)

--- a/Sources/Portu/Features/Exposure/ExposureView.swift
+++ b/Sources/Portu/Features/Exposure/ExposureView.swift
@@ -27,7 +27,9 @@ struct ExposureView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+                DashboardPageHeader("Portfolio Exposure")
+
                 HStack(spacing: 12) {
                     summaryCard("Spot Total", value: summary.totalSpot)
                     summaryCard("Derivatives", value: 0, subtitle: "Coming soon")
@@ -42,23 +44,26 @@ struct ExposureView: View {
                     }
                     .pickerStyle(.segmented)
                     .frame(width: 250)
+                    .dashboardControl()
 
                 if store.exposure.showByAsset {
                     assetTable
+                        .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
                 } else {
                     categoryTable
+                        .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
                 }
             }
-            .padding()
+            .padding(DashboardStyle.pagePadding)
         }
-        .navigationTitle("Exposure")
+        .dashboardPage()
     }
 
     // MARK: - Tables
 
     private var categoryTable: some View {
         Table(byCategory) {
-            TableColumn("Category") { row in Text(row.name).fontWeight(.medium) }
+            TableColumn("Category") { row in Text(row.name).fontWeight(.medium).foregroundStyle(PortuTheme.dashboardText) }
                 .width(min: 100, ideal: 140)
             TableColumn("Spot Assets") { row in currencyCell(row.spotAssets) }
                 .width(min: 80, ideal: 120)
@@ -66,19 +71,22 @@ struct ExposureView: View {
                 .width(min: 80, ideal: 120)
             TableColumn("Spot Net") { row in signedCell(row.spotNet) }
                 .width(min: 80, ideal: 120)
-            TableColumn("Derivatives") { _ in Text("\u{2014}").foregroundStyle(.tertiary) }
+            TableColumn("Derivatives") { _ in Text("\u{2014}").foregroundStyle(PortuTheme.dashboardTertiaryText) }
                 .width(min: 60, ideal: 80)
             TableColumn("Net Exposure") { row in currencyCell(row.netExposure).fontWeight(.medium) }
                 .width(min: 80, ideal: 120)
         }
+        .dashboardTable()
     }
 
     private var assetTable: some View {
         Table(byAsset) {
-            TableColumn("Asset") { row in Text(row.symbol).fontWeight(.medium) }
+            TableColumn("Asset") { row in Text(row.symbol).fontWeight(.medium).foregroundStyle(PortuTheme.dashboardText) }
                 .width(min: 60, ideal: 80)
             TableColumn("Category") { row in
-                Text(row.category.rawValue.capitalized).font(.caption)
+                Text(row.category.rawValue.capitalized)
+                    .font(.caption)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
             }
             .width(min: 80, ideal: 100)
             TableColumn("Spot Assets") { row in currencyCell(row.spotAssets) }
@@ -86,34 +94,39 @@ struct ExposureView: View {
             TableColumn("Spot Net") { row in signedCell(row.spotNet) }
             TableColumn("Net Exposure") { row in currencyCell(row.netExposure).fontWeight(.medium) }
         }
+        .dashboardTable()
     }
 
     private func currencyCell(_ value: Decimal) -> Text {
         Text(value, format: .currency(code: "USD"))
+            .font(DashboardStyle.monoTableFont)
     }
 
     private func liabilityCell(_ value: Decimal) -> some View {
-        currencyCell(value).foregroundStyle(value > 0 ? .red : .secondary)
+        currencyCell(value).foregroundStyle(value > 0 ? PortuTheme.dashboardWarning : PortuTheme.dashboardSecondaryText)
     }
 
     private func signedCell(_ value: Decimal) -> some View {
-        currencyCell(value).foregroundStyle(value < 0 ? .red : .primary)
+        currencyCell(value).foregroundStyle(value < 0 ? PortuTheme.dashboardWarning : PortuTheme.dashboardText)
     }
 
     // MARK: - Helpers
 
     private func summaryCard(_ title: String, value: Decimal, subtitle: String? = nil) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption).foregroundStyle(.secondary)
+            Text(title)
+                .font(DashboardStyle.labelFont)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
             Text(value, format: .currency(code: "USD"))
-                .font(.title3.weight(.semibold))
+                .font(.system(size: 18, weight: .semibold, design: .monospaced))
+                .foregroundStyle(PortuTheme.dashboardText)
             if let subtitle {
-                Text(subtitle).font(.caption2).foregroundStyle(.tertiary)
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
             }
         }
-        .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .dashboardCard()
     }
 }

--- a/Sources/Portu/Features/Overview/InspectorPanel.swift
+++ b/Sources/Portu/Features/Overview/InspectorPanel.swift
@@ -1,5 +1,6 @@
 // Sources/Portu/Features/Overview/InspectorPanel.swift
 import ComposableArchitecture
+import PortuUI
 import SwiftUI
 
 struct InspectorPanel: View {
@@ -7,14 +8,26 @@ struct InspectorPanel: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: 18) {
                 TopAssetsDonut(store: store)
-                Divider()
+                inspectorDivider
                 PortfolioHealthPanel(store: store)
-                Divider()
+                inspectorDivider
                 PriceWatchlist()
             }
-            .padding()
+            .padding(18)
         }
+        .background(PortuTheme.dashboardPanelBackground)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(PortuTheme.dashboardStroke)
+                .frame(width: 1)
+        }
+    }
+
+    private var inspectorDivider: some View {
+        Rectangle()
+            .fill(PortuTheme.dashboardStroke)
+            .frame(height: 1)
     }
 }

--- a/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
+++ b/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
@@ -23,13 +23,25 @@ struct OverviewPositionTabs: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Picker("Tab", selection: $selectedTab) {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 20) {
                 ForEach(OverviewTab.allCases, id: \.self) { tab in
-                    Text(tab.rawValue).tag(tab)
+                    Button {
+                        selectedTab = tab
+                    } label: {
+                        Text(tab.rawValue)
+                            .font(.system(size: 14, weight: selectedTab == tab ? .semibold : .regular))
+                            .foregroundStyle(selectedTab == tab ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                            .padding(.vertical, 4)
+                            .overlay(alignment: .bottom) {
+                                Rectangle()
+                                    .fill(selectedTab == tab ? PortuTheme.dashboardGold : .clear)
+                                    .frame(height: 1)
+                            }
+                    }
+                    .buttonStyle(.plain)
                 }
             }
-            .pickerStyle(.segmented)
 
             switch selectedTab {
             case .keyChanges:
@@ -81,32 +93,56 @@ struct OverviewPositionTabs: View {
     // MARK: - Token table (flat rows)
 
     private func tokenTable(tokens: [(PositionToken, Position)]) -> some View {
+        Group {
+            if tokens.isEmpty {
+                ContentUnavailableView("No assets in this view", systemImage: "tablecells")
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .frame(minHeight: 220)
+                    .frame(maxWidth: .infinity)
+                    .background(PortuTheme.dashboardPanelBackground)
+            } else {
+                tokenRowsTable(tokens: tokens)
+            }
+        }
+    }
+
+    private func tokenRowsTable(tokens: [(PositionToken, Position)]) -> some View {
         Table(of: TokenRowData.self) {
             TableColumn("Asset") { row in
                 Text(row.symbol).fontWeight(.medium)
+                    .foregroundStyle(PortuTheme.dashboardText)
             }
             .width(min: 60, ideal: 80)
 
             TableColumn("Network / Account") { row in
                 VStack(alignment: .leading) {
-                    if let chain = row.chain { Text(chain.rawValue.capitalized).font(.caption) }
-                    Text(row.accountName).font(.caption2).foregroundStyle(.secondary)
+                    if let chain = row.chain {
+                        Text(chain.rawValue.capitalized)
+                            .font(.caption)
+                            .foregroundStyle(PortuTheme.dashboardText)
+                    }
+                    Text(row.accountName)
+                        .font(.caption2)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
                 }
             }
             .width(min: 80, ideal: 120)
 
             TableColumn("Amount") { row in
                 Text(row.amount, format: .number.precision(.fractionLength(2 ... 6)))
+                    .font(DashboardStyle.monoTableFont)
             }
             .width(min: 80, ideal: 100)
 
             TableColumn("Price") { row in
                 Text(row.price, format: .currency(code: "USD"))
+                    .font(DashboardStyle.monoTableFont)
             }
             .width(min: 60, ideal: 80)
 
             TableColumn("Value") { row in
                 Text(row.value, format: .currency(code: "USD"))
+                    .font(DashboardStyle.monoTableFont)
             }
             .width(min: 80, ideal: 100)
         } rows: {
@@ -114,6 +150,8 @@ struct OverviewPositionTabs: View {
                 TableRow(row)
             }
         }
+        .dashboardTable()
+        .frame(minHeight: 260)
     }
 
     // MARK: - Borrowing view (grouped by protocol)
@@ -128,13 +166,13 @@ struct OverviewPositionTabs: View {
                 "No Borrowing",
                 systemImage: "arrow.down.circle",
                 description: Text("No active borrow positions"))
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
         } else {
             ForEach(borrowPositions, id: \.id) { pos in
                 VStack(alignment: .leading, spacing: 4) {
-                    // Section header
                     HStack {
                         Text(pos.protocolName ?? "Unknown Protocol")
-                            .font(.headline)
+                            .font(DashboardStyle.sectionTitleFont)
                         if let chain = pos.chain {
                             CapsuleBadge(chain.rawValue.capitalized)
                         }
@@ -158,12 +196,10 @@ struct OverviewPositionTabs: View {
                             Text(tokenValue(token), format: .currency(code: "USD"))
                                 .frame(width: 100, alignment: .trailing)
                         }
-                        .font(.body)
+                        .font(DashboardStyle.tableFont)
                     }
                 }
-                .padding()
-                .background(.quaternary.opacity(0.3))
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
             }
         }
     }

--- a/Sources/Portu/Features/Overview/OverviewSummaryCards.swift
+++ b/Sources/Portu/Features/Overview/OverviewSummaryCards.swift
@@ -59,7 +59,7 @@ struct OverviewSummaryCards: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .top, spacing: PortuTheme.dashboardContentSpacing) {
             summaryCard(title: "Idle", items: idleBreakdown)
             summaryCard(title: "Deployed", items: deployedBreakdown)
             summaryCard(title: "Futures", items: []) // Future work
@@ -69,27 +69,32 @@ struct OverviewSummaryCards: View {
     private func summaryCard(title: String, items: [(String, Decimal)]) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
-                .font(.headline)
+                .font(DashboardStyle.sectionTitleFont)
+                .foregroundStyle(PortuTheme.dashboardText)
             let total = items.reduce(Decimal.zero) { $0 + $1.1 }
             Text(total, format: .currency(code: "USD"))
-                .font(.title3.weight(.semibold))
+                .font(.system(size: 18, weight: .semibold, design: .monospaced))
+                .foregroundStyle(PortuTheme.dashboardText)
 
             if items.isEmpty {
                 Text("Coming soon")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
             } else {
                 ForEach(items, id: \.0) { label, value in
                     HStack {
-                        Text(label).font(.caption).foregroundStyle(.secondary)
+                        Text(label)
+                            .font(.caption)
+                            .foregroundStyle(PortuTheme.dashboardSecondaryText)
                         Spacer()
-                        Text(value, format: .currency(code: "USD")).font(.caption)
+                        Text(value, format: .currency(code: "USD"))
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(PortuTheme.dashboardText)
                     }
                 }
             }
         }
-        .padding()
-        .background(.quaternary.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .frame(maxWidth: .infinity, minHeight: 116, alignment: .topLeading)
+        .dashboardCard()
     }
 }

--- a/Sources/Portu/Features/Overview/OverviewTopBar.swift
+++ b/Sources/Portu/Features/Overview/OverviewTopBar.swift
@@ -61,7 +61,6 @@ struct OverviewTopBar: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 4) {
-                    Text(change24h < 0 ? "-" : "+")
                     Text(change24h, format: .currency(code: "USD"))
                     Spacer()
                     Text("$ change 24h")

--- a/Sources/Portu/Features/Overview/OverviewTopBar.swift
+++ b/Sources/Portu/Features/Overview/OverviewTopBar.swift
@@ -8,8 +8,6 @@ struct OverviewTopBar: View {
     @Environment(AppState.self) private var appState
     @Query private var positions: [Position]
 
-    let onSync: () -> Void
-
     /// Only positions from active accounts
     private var activePositions: [Position] {
         positions.filter { $0.account?.isActive == true }
@@ -49,44 +47,39 @@ struct OverviewTopBar: View {
     }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 16) {
-            // Total value
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Portfolio Value")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Portfolio value")
+                    .font(DashboardStyle.labelFont)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
                 Text(totalValue, format: .currency(code: "USD"))
-                    .font(.system(.title, design: .rounded, weight: .semibold))
+                    .font(DashboardStyle.heroValueFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.65)
             }
 
-            // 24h change
-            VStack(alignment: .leading, spacing: 2) {
-                Text("24h Change")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 4) {
-                    Image(systemName: change24h >= 0 ? "arrow.up.right" : "arrow.down.right")
-                        .foregroundStyle(PortuTheme.changeColor(for: change24h))
+                    Text(change24h < 0 ? "-" : "+")
                     Text(change24h, format: .currency(code: "USD"))
-                        .foregroundStyle(PortuTheme.changeColor(for: change24h))
-                    Text("(\(changePct, format: .percent.precision(.fractionLength(2))))")
-                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("$ change 24h")
+                        .foregroundStyle(PortuTheme.dashboardTertiaryText)
                 }
-                .font(.headline)
-            }
+                .foregroundStyle(PortuTheme.changeColor(for: change24h))
 
-            Spacer()
-
-            // Last synced + Sync button
-            if case .syncing = appState.syncStatus {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Button(action: onSync) {
-                    Label("Sync", systemImage: "arrow.triangle.2.circlepath")
+                HStack(spacing: 4) {
+                    Image(systemName: changePct >= 0 ? "arrowtriangle.up.fill" : "arrowtriangle.down.fill")
+                        .font(.caption2)
+                    Text(changePct, format: .percent.precision(.fractionLength(2)))
+                    Spacer()
+                    Text("% change 24h")
+                        .foregroundStyle(PortuTheme.dashboardTertiaryText)
                 }
+                .foregroundStyle(PortuTheme.changeColor(for: changePct))
             }
+            .font(.system(size: 13, weight: .medium, design: .monospaced))
         }
-        .padding()
     }
 }

--- a/Sources/Portu/Features/Overview/OverviewView.swift
+++ b/Sources/Portu/Features/Overview/OverviewView.swift
@@ -15,9 +15,15 @@ struct OverviewView: View {
                 VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
                     DashboardPageHeader("Overview") {
                         HStack(spacing: 10) {
-                            Text("Updated \(store.lastPriceUpdate ?? .now, format: .relative(presentation: .named))")
-                                .font(.caption)
-                                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                            if let lastPriceUpdate = store.lastPriceUpdate {
+                                Text("Updated \(lastPriceUpdate, format: .relative(presentation: .named))")
+                                    .font(.caption)
+                                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                            } else {
+                                Text("Not updated yet")
+                                    .font(.caption)
+                                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                            }
 
                             if case .syncing = appState.syncStatus {
                                 ProgressView()

--- a/Sources/Portu/Features/Overview/OverviewView.swift
+++ b/Sources/Portu/Features/Overview/OverviewView.swift
@@ -1,6 +1,7 @@
 // Sources/Portu/Features/Overview/OverviewView.swift
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -10,28 +11,57 @@ struct OverviewView: View {
 
     var body: some View {
         HSplitView {
-            // Main content (left, flex: 3)
             ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    OverviewTopBar {
-                        appState.onSyncRequested?()
+                VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+                    DashboardPageHeader("Overview") {
+                        HStack(spacing: 10) {
+                            Text("Updated \(store.lastPriceUpdate ?? .now, format: .relative(presentation: .named))")
+                                .font(.caption)
+                                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+
+                            if case .syncing = appState.syncStatus {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .tint(PortuTheme.dashboardGold)
+                            } else {
+                                Button {
+                                    appState.onSyncRequested?()
+                                } label: {
+                                    Label("Sync", systemImage: "arrow.triangle.2.circlepath")
+                                }
+                                .dashboardControl()
+                            }
+                        }
                     }
 
-                    PortfolioValueChart()
+                    DashboardCard {
+                        HStack(alignment: .top, spacing: 20) {
+                            OverviewTopBar()
+                                .frame(width: 250, alignment: .leading)
+
+                            PortfolioValueChart()
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
 
                     OverviewSummaryCards()
 
                     OverviewPositionTabs()
+                        .dashboardCard()
                 }
-                .padding()
+                .padding(DashboardStyle.pagePadding)
             }
             .frame(minWidth: 500)
             .layoutPriority(3)
+            .background(PortuTheme.dashboardBackground)
 
-            // Inspector panel (right, flex: 1, collapsible)
             InspectorPanel(store: store)
-                .frame(minWidth: 250, idealWidth: 300, maxWidth: 350)
+                .frame(
+                    minWidth: PortuTheme.dashboardInspectorWidth,
+                    idealWidth: PortuTheme.dashboardInspectorWidth,
+                    maxWidth: 360)
                 .layoutPriority(1)
         }
+        .dashboardPage()
     }
 }

--- a/Sources/Portu/Features/Overview/PortfolioHealthPanel.swift
+++ b/Sources/Portu/Features/Overview/PortfolioHealthPanel.swift
@@ -38,7 +38,8 @@ struct PortfolioHealthPanel: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Portfolio Health")
-                    .font(.headline)
+                    .font(DashboardStyle.sectionTitleFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
                 Spacer()
                 riskBadge
             }
@@ -57,7 +58,7 @@ struct PortfolioHealthPanel: View {
                 }
                 .buttonStyle(.plain)
                 .font(.caption)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(PortuTheme.dashboardGold)
             }
         }
     }
@@ -84,8 +85,11 @@ struct PortfolioHealthPanel: View {
 
     private func metricItem(_ label: String, _ value: String) -> some View {
         VStack(spacing: 2) {
-            Text(value).fontWeight(.medium)
-            Text(label).foregroundStyle(.secondary)
+            Text(value)
+                .fontWeight(.semibold)
+                .foregroundStyle(PortuTheme.dashboardText)
+            Text(label)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
         }
     }
 
@@ -98,6 +102,7 @@ struct PortfolioHealthPanel: View {
                         .font(.caption2)
                     Text("\(risk.symbol) is \(risk.percentage.formatted(.percent.precision(.fractionLength(0)))) of portfolio")
                         .font(.caption)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
                 }
             }
         }
@@ -109,16 +114,17 @@ struct PortfolioHealthPanel: View {
                 HStack {
                     Text(weight.symbol)
                         .font(.caption.weight(.medium))
+                        .foregroundStyle(PortuTheme.dashboardText)
                         .frame(width: 50, alignment: .leading)
                     GeometryReader { geo in
                         RoundedRectangle(cornerRadius: 2)
-                            .fill(Color.accentColor.opacity(0.3))
+                            .fill(PortuTheme.dashboardGoldMuted)
                             .frame(width: max(4, geo.size.width * CGFloat(truncating: weight.percentage as NSDecimalNumber)))
                     }
                     .frame(height: 8)
                     Text(weight.percentage.formatted(.percent.precision(.fractionLength(1))))
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
                         .frame(width: 40, alignment: .trailing)
                 }
             }

--- a/Sources/Portu/Features/Overview/PortfolioValueChart.swift
+++ b/Sources/Portu/Features/Overview/PortfolioValueChart.swift
@@ -1,6 +1,7 @@
 // Sources/Portu/Features/Overview/PortfolioValueChart.swift
 import Charts
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -16,8 +17,7 @@ struct PortfolioValueChart: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            // Time range picker
+        VStack(alignment: .leading, spacing: 10) {
             Picker("Range", selection: $selectedRange) {
                 ForEach([ChartTimeRange.oneWeek, .oneMonth, .threeMonths, .oneYear, .ytd], id: \.self) { range in
                     Text(range.rawValue).tag(range)
@@ -25,13 +25,15 @@ struct PortfolioValueChart: View {
             }
             .pickerStyle(.segmented)
             .frame(maxWidth: 300)
+            .dashboardControl()
 
             if filteredSnapshots.isEmpty {
                 ContentUnavailableView(
                     "No Data",
                     systemImage: "chart.line.uptrend.xyaxis",
                     description: Text("Sync your accounts to see portfolio history"))
-                    .frame(height: 200)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .frame(height: 190)
             } else {
                 Chart(filteredSnapshots, id: \.id) { snapshot in
                     AreaMark(
@@ -46,21 +48,23 @@ struct PortfolioValueChart: View {
                     LineMark(
                         x: .value("Date", snapshot.timestamp),
                         y: .value("Value", snapshot.totalValue))
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(PortuTheme.dashboardGold)
 
-                    // Partial snapshot indicator
                     if snapshot.isPartial {
                         PointMark(
                             x: .value("Date", snapshot.timestamp),
                             y: .value("Value", snapshot.totalValue))
                             .symbolSize(20)
-                            .foregroundStyle(.orange.opacity(0.6))
+                            .foregroundStyle(PortuTheme.dashboardWarning.opacity(0.8))
                     }
                 }
                 .chartYAxis {
                     AxisMarks(format: .currency(code: "USD").precision(.fractionLength(0)))
                 }
-                .frame(height: 250)
+                .chartXAxis {
+                    AxisMarks()
+                }
+                .frame(height: 190)
             }
         }
     }

--- a/Sources/Portu/Features/Overview/PriceWatchlist.swift
+++ b/Sources/Portu/Features/Overview/PriceWatchlist.swift
@@ -23,18 +23,21 @@ struct PriceWatchlist: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Prices")
-                .font(.headline)
+                .font(DashboardStyle.sectionTitleFont)
+                .foregroundStyle(PortuTheme.dashboardText)
 
             ForEach(watchlistAssets, id: \.id) { asset in
                 HStack {
                     Text(asset.symbol)
-                        .fontWeight(.medium)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(PortuTheme.dashboardText)
                     Spacer()
 
                     if let cgId = asset.coinGeckoId, let price = appState.prices[cgId] {
                         VStack(alignment: .trailing) {
                             Text(price, format: .currency(code: "USD"))
-                                .font(.body)
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle(PortuTheme.dashboardText)
                             if let change = appState.priceChanges24h[cgId] {
                                 HStack(spacing: 2) {
                                     Image(systemName: change >= 0 ? "arrow.up.right" : "arrow.down.right")
@@ -45,10 +48,13 @@ struct PriceWatchlist: View {
                             }
                         }
                     } else {
-                        Text("\u{2014}").foregroundStyle(.tertiary)
+                        Text("\u{2014}")
+                            .foregroundStyle(PortuTheme.dashboardTertiaryText)
                     }
                 }
-                Divider()
+                Rectangle()
+                    .fill(PortuTheme.dashboardStroke)
+                    .frame(height: 1)
             }
         }
     }

--- a/Sources/Portu/Features/Overview/TopAssetsDonut.swift
+++ b/Sources/Portu/Features/Overview/TopAssetsDonut.swift
@@ -2,6 +2,7 @@
 import Charts
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -54,21 +55,25 @@ struct TopAssetsDonut: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Top Assets")
-                    .font(.headline)
+                    .font(DashboardStyle.sectionTitleFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
                 Spacer()
                 Picker("Group", selection: $groupByCategory) {
                     Text("Category").tag(true)
                     Text("Asset").tag(false)
                 }
                 .pickerStyle(.segmented)
-                .frame(width: 160)
+                .frame(width: 136)
+                .dashboardControl()
             }
 
             if slices.isEmpty {
-                Text("No data").foregroundStyle(.secondary)
+                Text("No data")
+                    .font(.caption)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
             } else {
                 Chart(slices) { slice in
                     SectorMark(
@@ -79,18 +84,22 @@ struct TopAssetsDonut: View {
                         .annotation(position: .overlay) {
                             Text(slice.label)
                                 .font(.caption2)
-                                .foregroundStyle(.white)
+                                .foregroundStyle(PortuTheme.dashboardText)
                         }
                 }
-                .frame(height: 180)
+                .frame(height: 168)
 
                 // Legend
                 ForEach(slices) { slice in
                     HStack(spacing: 6) {
                         Circle().fill(slice.color).frame(width: 8, height: 8)
-                        Text(slice.label).font(.caption)
+                        Text(slice.label)
+                            .font(.caption)
+                            .foregroundStyle(PortuTheme.dashboardText)
                         Spacer()
-                        Text(slice.value, format: .currency(code: "USD")).font(.caption)
+                        Text(slice.value, format: .currency(code: "USD"))
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(PortuTheme.dashboardSecondaryText)
                     }
                 }
             }
@@ -99,6 +108,8 @@ struct TopAssetsDonut: View {
                 store.send(.sectionSelected(.allAssets))
             }
             .font(.caption)
+            .foregroundStyle(PortuTheme.dashboardGold)
+            .buttonStyle(.plain)
         }
     }
 
@@ -107,7 +118,16 @@ struct TopAssetsDonut: View {
     }
 
     private func chartColor(index: Int) -> Color {
-        let colors: [Color] = [.blue, .orange, .green, .purple, .pink, .yellow, .cyan, .red]
+        let colors: [Color] = [
+            Color(red: 0.360, green: 0.610, blue: 0.700),
+            Color(red: 0.930, green: 0.800, blue: 0.280),
+            Color(red: 0.400, green: 0.800, blue: 0.730),
+            Color(red: 0.760, green: 0.300, blue: 0.250),
+            Color(red: 0.830, green: 0.600, blue: 0.230),
+            Color(red: 0.900, green: 0.900, blue: 0.840),
+            Color(red: 0.480, green: 0.420, blue: 0.720),
+            Color(red: 0.650, green: 0.450, blue: 0.320)
+        ]
         return colors[index % colors.count]
     }
 }

--- a/Sources/Portu/Features/Performance/AssetsChartMode.swift
+++ b/Sources/Portu/Features/Performance/AssetsChartMode.swift
@@ -1,6 +1,7 @@
 import Charts
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -43,7 +44,8 @@ struct AssetsChartMode: View {
                 ContentUnavailableView(
                     "No Asset Data", systemImage: "chart.bar.xaxis",
                     description: Text("Sync to see asset category breakdown"))
-                    .frame(height: 300)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .frame(height: 320)
             } else {
                 Chart(chartData) { point in
                     AreaMark(
@@ -55,8 +57,7 @@ struct AssetsChartMode: View {
                 .chartYAxis {
                     AxisMarks(format: .currency(code: "USD").precision(.fractionLength(0)))
                 }
-                .frame(height: 300)
-                .padding()
+                .frame(height: 320)
             }
 
             HStack(spacing: 8) {
@@ -70,14 +71,14 @@ struct AssetsChartMode: View {
                             .padding(.vertical, 4)
                             .background(
                                 store.performance.disabledCategories.contains(cat)
-                                    ? AnyShapeStyle(.quaternary)
-                                    : AnyShapeStyle(Color.accentColor.opacity(0.2)))
+                                    ? AnyShapeStyle(PortuTheme.dashboardMutedPanelBackground)
+                                    : AnyShapeStyle(PortuTheme.dashboardGoldMuted))
                             .clipShape(Capsule())
                     }
                     .buttonStyle(.plain)
+                    .foregroundStyle(PortuTheme.dashboardText)
                 }
             }
-            .padding(.horizontal)
         }
     }
 }

--- a/Sources/Portu/Features/Performance/PerformanceBottomPanel.swift
+++ b/Sources/Portu/Features/Performance/PerformanceBottomPanel.swift
@@ -1,4 +1,5 @@
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -24,31 +25,37 @@ struct PerformanceBottomPanel: View {
     var body: some View {
         HStack(alignment: .top, spacing: 20) {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Asset Categories").font(.headline)
+                Text("Asset categories")
+                    .font(DashboardStyle.sectionTitleFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
                 ForEach(categoryChanges) { change in
                     HStack {
                         Text(change.name).frame(width: 100, alignment: .leading)
                         Text(change.startValue, format: .currency(code: "USD")).frame(width: 100)
-                        Text("\u{2192}").foregroundStyle(.secondary)
+                        Text("\u{2192}").foregroundStyle(PortuTheme.dashboardSecondaryText)
                         Text(change.endValue, format: .currency(code: "USD")).frame(width: 100)
                         Text(change.percentChange, format: .percent.precision(.fractionLength(1)))
-                            .foregroundStyle(change.percentChange >= 0 ? .green : .red)
+                            .foregroundStyle(change.percentChange >= 0 ? PortuTheme.dashboardSuccess : PortuTheme.dashboardWarning)
                             .frame(width: 60)
                     }
                     .font(.caption)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
                 }
             }
 
-            Divider()
+            Rectangle()
+                .fill(PortuTheme.dashboardStroke)
+                .frame(width: 1)
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("Asset Prices").font(.headline)
+                Text("Asset prices")
+                    .font(DashboardStyle.sectionTitleFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
                 Text("Top assets with period price change")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
             }
         }
-        .padding()
-        .frame(height: 200)
+        .frame(minHeight: 180, alignment: .topLeading)
     }
 }

--- a/Sources/Portu/Features/Performance/PerformanceView.swift
+++ b/Sources/Portu/Features/Performance/PerformanceView.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -9,67 +10,76 @@ struct PerformanceView: View {
     @Query private var accounts: [Account]
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Picker("Account", selection: Binding(
-                    get: { store.performance.selectedAccountId },
-                    set: { store.send(.performance(.accountSelected($0))) })) {
-                        Text("All Accounts").tag(nil as UUID?)
-                        ForEach(accounts.filter(\.isActive), id: \.id) { account in
-                            Text(account.name).tag(account.id as UUID?)
-                        }
+        ScrollView {
+            VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+                DashboardPageHeader("Performance")
+
+                controlStrip
+
+                DashboardCard(horizontalPadding: 18, verticalPadding: 16) {
+                    switch store.performance.chartMode {
+                    case .value:
+                        ValueChartMode(
+                            accountId: store.performance.selectedAccountId,
+                            startDate: store.performance.selectedRange.startDate)
+                    case .assets:
+                        AssetsChartMode(
+                            accountId: store.performance.selectedAccountId,
+                            startDate: store.performance.selectedRange.startDate,
+                            store: store)
+                    case .pnl:
+                        PnLChartMode(
+                            accountId: store.performance.selectedAccountId,
+                            startDate: store.performance.selectedRange.startDate,
+                            store: store)
                     }
-                    .frame(width: 200)
+                }
 
-                Spacer()
-
-                Picker("Range", selection: Binding(
-                    get: { store.performance.selectedRange },
-                    set: { store.send(.performance(.timeRangeChanged($0))) })) {
-                        ForEach(ChartTimeRange.allCases, id: \.self) { r in
-                            Text(r.rawValue).tag(r)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 300)
-
-                Spacer()
-
-                Picker("Mode", selection: Binding(
-                    get: { store.performance.chartMode },
-                    set: { store.send(.performance(.chartModeChanged($0))) })) {
-                        ForEach(PerformanceChartMode.allCases, id: \.self) { m in
-                            Text(m.rawValue).tag(m)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 200)
-            }
-            .padding()
-
-            switch store.performance.chartMode {
-            case .value:
-                ValueChartMode(
+                PerformanceBottomPanel(
                     accountId: store.performance.selectedAccountId,
                     startDate: store.performance.selectedRange.startDate)
-            case .assets:
-                AssetsChartMode(
-                    accountId: store.performance.selectedAccountId,
-                    startDate: store.performance.selectedRange.startDate,
-                    store: store)
-            case .pnl:
-                PnLChartMode(
-                    accountId: store.performance.selectedAccountId,
-                    startDate: store.performance.selectedRange.startDate,
-                    store: store)
+                    .dashboardCard(horizontalPadding: 18, verticalPadding: 16)
             }
-
-            Divider()
-
-            PerformanceBottomPanel(
-                accountId: store.performance.selectedAccountId,
-                startDate: store.performance.selectedRange.startDate)
+            .padding(DashboardStyle.pagePadding)
         }
-        .navigationTitle("Performance")
+        .dashboardPage()
+    }
+
+    private var controlStrip: some View {
+        HStack(spacing: 10) {
+            Picker("Account", selection: Binding(
+                get: { store.performance.selectedAccountId },
+                set: { store.send(.performance(.accountSelected($0))) })) {
+                    Text("All Accounts").tag(nil as UUID?)
+                    ForEach(accounts.filter(\.isActive), id: \.id) { account in
+                        Text(account.name).tag(account.id as UUID?)
+                    }
+                }
+                .frame(width: 220)
+
+            Picker("Range", selection: Binding(
+                get: { store.performance.selectedRange },
+                set: { store.send(.performance(.timeRangeChanged($0))) })) {
+                    ForEach(ChartTimeRange.allCases, id: \.self) { r in
+                        Text(r.rawValue).tag(r)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 300)
+
+            Picker("Mode", selection: Binding(
+                get: { store.performance.chartMode },
+                set: { store.send(.performance(.chartModeChanged($0))) })) {
+                    ForEach(PerformanceChartMode.allCases, id: \.self) { m in
+                        Text(m.rawValue).tag(m)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 200)
+
+            Spacer(minLength: 0)
+        }
+        .dashboardControl()
+        .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
     }
 }

--- a/Sources/Portu/Features/Performance/PnLChartMode.swift
+++ b/Sources/Portu/Features/Performance/PnLChartMode.swift
@@ -1,6 +1,7 @@
 import Charts
 import ComposableArchitecture
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -31,33 +32,35 @@ struct PnLChartMode: View {
                 ContentUnavailableView(
                     "Insufficient Data", systemImage: "chart.bar",
                     description: Text("Need at least 2 days of data for PnL"))
-                    .frame(height: 300)
+                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .frame(height: 320)
             } else {
                 Chart(bars) { bar in
                     BarMark(
                         x: .value("Date", bar.date, unit: .day),
                         y: .value("PnL", bar.pnl))
-                        .foregroundStyle(bar.pnl >= 0 ? Color.green : Color.red)
+                        .foregroundStyle(bar.pnl >= 0 ? PortuTheme.dashboardSuccess : PortuTheme.dashboardWarning)
 
                     if store.performance.showCumulative {
                         LineMark(
                             x: .value("Date", bar.date, unit: .day),
                             y: .value("Cumulative", bar.cumulative))
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(PortuTheme.dashboardGold)
                             .lineStyle(StrokeStyle(lineWidth: 2))
                     }
                 }
                 .chartYAxis {
                     AxisMarks(format: .currency(code: "USD").precision(.fractionLength(0)))
                 }
-                .frame(height: 300)
-                .padding()
+                .frame(height: 320)
             }
 
             Toggle("Show Cumulative", isOn: Binding(
                 get: { store.performance.showCumulative },
                 set: { _ in store.send(.performance(.showCumulativeToggled)) }))
-                .padding(.horizontal)
+                .font(.caption)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .dashboardControl()
         }
     }
 }

--- a/Sources/Portu/Features/Performance/ValueChartMode.swift
+++ b/Sources/Portu/Features/Performance/ValueChartMode.swift
@@ -1,5 +1,6 @@
 import Charts
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -31,25 +32,25 @@ struct ValueChartMode: View {
                 "No Performance Data",
                 systemImage: "chart.line.uptrend.xyaxis",
                 description: Text("Sync your accounts to track portfolio performance"))
-                .frame(height: 300)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .frame(height: 320)
         } else {
             Chart {
                 ForEach(dataPoints, id: \.0) { date, value, isPartial in
                     AreaMark(x: .value("Date", date), y: .value("Value", value))
                         .foregroundStyle(
                             .linearGradient(
-                                colors: [Color.accentColor.opacity(0.3), .clear],
+                                colors: [PortuTheme.dashboardGold.opacity(0.35), .clear],
                                 startPoint: .top, endPoint: .bottom))
                     LineMark(x: .value("Date", date), y: .value("Value", value))
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(PortuTheme.dashboardGold)
                         .lineStyle(isPartial ? StrokeStyle(lineWidth: 2, dash: [5, 3]) : StrokeStyle(lineWidth: 2))
                 }
             }
             .chartYAxis {
                 AxisMarks(format: .currency(code: "USD").precision(.fractionLength(0)))
             }
-            .frame(height: 300)
-            .padding()
+            .frame(height: 320)
         }
     }
 }

--- a/Sources/Portu/Features/Positions/AllPositionsView.swift
+++ b/Sources/Portu/Features/Positions/AllPositionsView.swift
@@ -1,5 +1,6 @@
 // Sources/Portu/Features/Positions/AllPositionsView.swift
 import PortuCore
+import PortuUI
 import SwiftData
 import SwiftUI
 
@@ -30,9 +31,17 @@ struct AllPositionsView: View {
 
     var body: some View {
         HSplitView {
-            // Main content
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 16) {
+                LazyVStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+                    DashboardPageHeader("All Positions") {
+                        Button {
+                            showAddSheet = true
+                        } label: {
+                            Label("Add Position", systemImage: "plus")
+                        }
+                        .dashboardControl()
+                    }
+
                     ForEach(groupedByType, id: \.0) { type, positions in
                         Section {
                             ForEach(positions, id: \.id) { pos in
@@ -41,38 +50,33 @@ struct AllPositionsView: View {
                         } header: {
                             HStack {
                                 Text(typeSectionTitle(type))
-                                    .font(.title3.weight(.semibold))
+                                    .font(DashboardStyle.sectionTitleFont)
+                                    .foregroundStyle(PortuTheme.dashboardText)
                                 Spacer()
                                 let total = positions.reduce(Decimal.zero) { $0 + $1.netUSDValue }
                                 Text(total, format: .currency(code: "USD"))
-                                    .foregroundStyle(.secondary)
+                                    .font(.system(size: 13, design: .monospaced))
+                                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
                             }
-                            .padding(.horizontal)
+                            .padding(.top, 4)
                         }
                     }
                 }
-                .padding()
+                .padding(DashboardStyle.pagePadding)
             }
             .frame(minWidth: 500)
-            .toolbar {
-                ToolbarItem {
-                    Button("Add Position", systemImage: "plus") {
-                        showAddSheet = true
-                    }
-                }
-            }
             .sheet(isPresented: $showAddSheet) {
                 AddPositionSheet()
+                    .environment(\.colorScheme, .dark)
             }
 
-            // Filter sidebar
             PositionFilterSidebar(
                 positions: positions,
                 selectedType: $filterType,
                 selectedProtocol: $filterProtocol)
                 .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
         }
-        .navigationTitle("All Positions")
+        .dashboardPage()
     }
 
     private func typeSectionTitle(_ type: PositionType) -> String {

--- a/Sources/Portu/Features/Positions/PositionFilterSidebar.swift
+++ b/Sources/Portu/Features/Positions/PositionFilterSidebar.swift
@@ -1,5 +1,6 @@
 // Sources/Portu/Features/Positions/PositionFilterSidebar.swift
 import PortuCore
+import PortuUI
 import SwiftUI
 
 struct PositionFilterSidebar: View {
@@ -37,36 +38,44 @@ struct PositionFilterSidebar: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 Text("Filter")
-                    .font(.headline)
+                    .font(DashboardStyle.sectionTitleFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
 
-                // Type filter
-                Section("Position Type") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Position Type")
+                        .font(DashboardStyle.labelFont)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
                     ForEach(typeFilters, id: \.1) { type, label, total in
                         Button {
                             selectedType = type
                         } label: {
                             HStack {
                                 Text(label)
-                                    .foregroundStyle(selectedType == type ? .primary : .secondary)
+                                    .foregroundStyle(selectedType == type ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
                                 Spacer()
                                 Text(total, format: .currency(code: "USD"))
                                     .font(.caption)
-                                    .foregroundStyle(.tertiary)
+                                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
                             }
+                            .padding(.vertical, 3)
                         }
                         .buttonStyle(.plain)
                     }
                 }
 
-                Divider()
+                Rectangle()
+                    .fill(PortuTheme.dashboardStroke)
+                    .frame(height: 1)
 
-                // Protocol filter (uses protocolId to match AllPositionsView filtering)
-                Section("Protocol") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Protocol")
+                        .font(DashboardStyle.labelFont)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
                     Button {
                         selectedProtocol = .all
                     } label: {
                         Text("All Protocols")
-                            .foregroundStyle(selectedProtocol == .all ? .primary : .secondary)
+                            .foregroundStyle(selectedProtocol == .all ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
                     }
                     .buttonStyle(.plain)
 
@@ -77,18 +86,25 @@ struct PositionFilterSidebar: View {
                         } label: {
                             HStack {
                                 Text(filter.name)
-                                    .foregroundStyle(selectedProtocol == filterValue ? .primary : .secondary)
+                                    .foregroundStyle(selectedProtocol == filterValue ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
                                 Spacer()
                                 Text(filter.value, format: .currency(code: "USD"))
                                     .font(.caption)
-                                    .foregroundStyle(.tertiary)
+                                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
                             }
+                            .padding(.vertical, 3)
                         }
                         .buttonStyle(.plain)
                     }
                 }
             }
             .padding()
+        }
+        .background(PortuTheme.dashboardPanelBackground)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(PortuTheme.dashboardStroke)
+                .frame(width: 1)
         }
     }
 }

--- a/Sources/Portu/Features/Positions/PositionGroupView.swift
+++ b/Sources/Portu/Features/Positions/PositionGroupView.swift
@@ -28,11 +28,10 @@ struct PositionGroupView: View {
                         .foregroundStyle(hf < 1.2 ? .red : hf < 1.5 ? .orange : .green)
                 }
 
-                // Net value (signed) — computed from live prices to match token rows
-                let headerTotal = position.tokens.reduce(Decimal.zero) { sum, token in
-                    let value = tokenValue(token)
-                    return token.role.isBorrow ? sum - value : sum + value
-                }
+                // Net value (signed), computed from live prices to match token rows.
+                let headerTotal = PositionGroupValue.headerTotal(
+                    for: position.tokens,
+                    livePrices: appState.prices)
                 Text(headerTotal, format: .currency(code: "USD"))
                     .font(.system(size: 13, weight: .semibold, design: .monospaced))
                     .foregroundStyle(PortuTheme.changeColor(for: headerTotal))
@@ -67,5 +66,15 @@ struct PositionGroupView: View {
 
     private func tokenValue(_ token: PositionToken) -> Decimal {
         token.resolvedUSDValue(prices: appState.prices)
+    }
+}
+
+enum PositionGroupValue {
+    static func headerTotal(
+        for tokens: [PositionToken],
+        livePrices: [String: Decimal]) -> Decimal {
+        tokens.reduce(Decimal.zero) { total, token in
+            total + AssetValueFormatter.signedValue(for: token, livePrices: livePrices)
+        }
     }
 }

--- a/Sources/Portu/Features/Positions/PositionGroupView.swift
+++ b/Sources/Portu/Features/Positions/PositionGroupView.swift
@@ -8,13 +8,12 @@ struct PositionGroupView: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            // Header: protocol name, chain, health factor
+        VStack(alignment: .leading, spacing: 8) {
             HStack {
                 if let name = position.protocolName {
-                    Text(name).font(.headline)
+                    Text(name).font(DashboardStyle.sectionTitleFont)
                 } else {
-                    Text(position.positionType.rawValue.capitalized).font(.headline)
+                    Text(position.positionType.rawValue.capitalized).font(DashboardStyle.sectionTitleFont)
                 }
 
                 if let chain = position.chain {
@@ -35,11 +34,10 @@ struct PositionGroupView: View {
                     return token.role.isBorrow ? sum - value : sum + value
                 }
                 Text(headerTotal, format: .currency(code: "USD"))
-                    .font(.headline)
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
                     .foregroundStyle(PortuTheme.changeColor(for: headerTotal))
             }
 
-            // Token rows
             ForEach(position.tokens, id: \.id) { token in
                 HStack {
                     Text(token.role.displayLabel)
@@ -47,23 +45,23 @@ struct PositionGroupView: View {
                         .foregroundStyle(token.role.displayColor)
 
                     Text(token.asset?.symbol ?? "???")
-                        .fontWeight(.medium)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(PortuTheme.dashboardText)
 
                     Spacer()
 
                     Text(token.amount, format: .number.precision(.fractionLength(2 ... 6)))
-                        .foregroundStyle(.secondary)
+                        .font(DashboardStyle.monoTableFont)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
 
-                    // Always positive display
                     let value = tokenValue(token)
                     Text(value, format: .currency(code: "USD"))
+                        .font(DashboardStyle.monoTableFont)
                         .frame(width: 100, alignment: .trailing)
                 }
             }
         }
-        .padding()
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .dashboardCard(horizontalPadding: 12, verticalPadding: 10)
     }
 
     private func tokenValue(_ token: PositionToken) -> Decimal {

--- a/Sources/Portu/Features/Positions/PositionGroupView.swift
+++ b/Sources/Portu/Features/Positions/PositionGroupView.swift
@@ -57,6 +57,7 @@ struct PositionGroupView: View {
                     let value = tokenValue(token)
                     Text(value, format: .currency(code: "USD"))
                         .font(DashboardStyle.monoTableFont)
+                        .foregroundStyle(PortuTheme.dashboardText)
                         .frame(width: 100, alignment: .trailing)
                 }
             }

--- a/Sources/Portu/Features/Shared/DashboardStyle.swift
+++ b/Sources/Portu/Features/Shared/DashboardStyle.swift
@@ -1,0 +1,184 @@
+import PortuUI
+import SwiftUI
+
+enum DashboardStyle {
+    static let pagePadding: CGFloat = 16
+    static let panelPadding: CGFloat = 14
+    static let compactPadding: CGFloat = 10
+
+    static let pageTitleFont = Font.system(size: 18, weight: .semibold)
+    static let heroValueFont = Font.system(size: 34, weight: .medium, design: .monospaced)
+    static let sectionTitleFont = Font.system(size: 14, weight: .semibold)
+    static let labelFont = Font.system(size: 11, weight: .medium)
+    static let valueFont = Font.system(size: 13, weight: .semibold)
+    static let tableFont = Font.system(size: 12)
+    static let monoTableFont = Font.system(size: 12, design: .monospaced)
+}
+
+struct DashboardPageHeader<Actions: View>: View {
+    let title: String
+    let subtitle: String?
+    let actions: Actions
+
+    init(
+        _ title: String,
+        subtitle: String? = nil,
+        @ViewBuilder actions: () -> Actions) {
+        self.title = title
+        self.subtitle = subtitle
+        self.actions = actions()
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(DashboardStyle.pageTitleFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                }
+            }
+
+            Spacer(minLength: 12)
+            actions
+        }
+    }
+}
+
+extension DashboardPageHeader where Actions == EmptyView {
+    init(_ title: String, subtitle: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.actions = EmptyView()
+    }
+}
+
+struct DashboardCard<Content: View>: View {
+    let horizontalPadding: CGFloat
+    let verticalPadding: CGFloat
+    private let content: Content
+
+    init(
+        horizontalPadding: CGFloat = DashboardStyle.panelPadding,
+        verticalPadding: CGFloat = DashboardStyle.panelPadding,
+        @ViewBuilder content: () -> Content) {
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: PortuTheme.dashboardPanelCornerRadius, style: .continuous)
+                    .fill(PortuTheme.dashboardPanelBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: PortuTheme.dashboardPanelCornerRadius, style: .continuous)
+                    .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+}
+
+struct DashboardMetricBlock: View {
+    let title: String
+    let value: String
+    var subtitle: String?
+    var valueColor: Color = PortuTheme.dashboardText
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(DashboardStyle.labelFont)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .textCase(.uppercase)
+            Text(value)
+                .font(DashboardStyle.valueFont)
+                .foregroundStyle(valueColor)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
+            }
+        }
+    }
+}
+
+struct DashboardSectionHeader<Trailing: View>: View {
+    let title: String
+    let trailing: Trailing
+
+    init(_ title: String, @ViewBuilder trailing: () -> Trailing = { EmptyView() }) {
+        self.title = title
+        self.trailing = trailing()
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(DashboardStyle.sectionTitleFont)
+                .foregroundStyle(PortuTheme.dashboardText)
+            Spacer(minLength: 8)
+            trailing
+        }
+    }
+}
+
+struct DashboardSearchField: View {
+    let placeholder: String
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.caption)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(.caption)
+                .foregroundStyle(PortuTheme.dashboardText)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(PortuTheme.dashboardPanelElevatedBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+}
+
+extension View {
+    func dashboardPage() -> some View {
+        background(PortuTheme.dashboardBackground)
+            .foregroundStyle(PortuTheme.dashboardText)
+            .environment(\.colorScheme, .dark)
+    }
+
+    func dashboardCard(
+        horizontalPadding: CGFloat = DashboardStyle.panelPadding,
+        verticalPadding: CGFloat = DashboardStyle.panelPadding) -> some View {
+        DashboardCard(
+            horizontalPadding: horizontalPadding,
+            verticalPadding: verticalPadding) {
+                self
+            }
+    }
+
+    func dashboardControl() -> some View {
+        controlSize(.small)
+            .tint(PortuTheme.dashboardGold)
+    }
+
+    func dashboardTable() -> some View {
+        font(DashboardStyle.tableFont)
+            .controlSize(.small)
+            .tint(PortuTheme.dashboardGold)
+            .environment(\.defaultMinListRowHeight, PortuTheme.dashboardTableRowHeight)
+            .background(PortuTheme.dashboardPanelBackground)
+    }
+}

--- a/Sources/Portu/Features/Sidebar/SidebarView.swift
+++ b/Sources/Portu/Features/Sidebar/SidebarView.swift
@@ -1,19 +1,79 @@
 import ComposableArchitecture
 import PortuCore
+import PortuUI
+import SwiftData
 import SwiftUI
 
 struct SidebarView: View {
     let store: StoreOf<AppFeature>
 
-    var body: some View {
-        VStack(spacing: 0) {
-            List(selection: selectedSection) {
-                ForEach(SidebarLayout.navigationSections) { section in
-                    SidebarNavigationSection(section: section)
+    @Environment(AppState.self) private var appState
+    @Query private var positions: [Position]
+    @State private var searchText = ""
+
+    private var activePositions: [Position] {
+        positions.filter { $0.account?.isActive == true }
+    }
+
+    private var totalValue: Decimal {
+        activePositions.reduce(Decimal.zero) { $0 + $1.netUSDValue }
+    }
+
+    private var change24h: Decimal {
+        var total: Decimal = 0
+        for position in activePositions {
+            for token in position.tokens {
+                guard
+                    let asset = token.asset,
+                    let coinGeckoId = asset.coinGeckoId,
+                    let price = appState.prices[coinGeckoId],
+                    let changePct = appState.priceChanges24h[coinGeckoId] else { continue }
+
+                let contribution = token.amount * price * changePct
+                if token.role.isPositive {
+                    total += contribution
+                } else if token.role.isBorrow {
+                    total -= contribution
                 }
             }
-            .listStyle(.sidebar)
-            .navigationTitle("Portu")
+        }
+        return total
+    }
+
+    private var filteredSections: [SidebarLayoutSection] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return SidebarLayout.navigationSections }
+
+        return SidebarLayout.navigationSections.compactMap { section in
+            let items = section.items.filter { $0.title.localizedCaseInsensitiveContains(query) }
+            guard !items.isEmpty else { return nil }
+            return SidebarLayoutSection(title: section.title, items: items, isDisabled: section.isDisabled)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    SidebarPortfolioHeader(totalValue: totalValue, change24h: change24h)
+
+                    DashboardSearchField(placeholder: "Search", text: $searchText)
+
+                    VStack(alignment: .leading, spacing: 14) {
+                        ForEach(filteredSections) { section in
+                            SidebarNavigationSection(
+                                section: section,
+                                selectedSection: store.sidebarSelection,
+                                isSettingsSelected: store.isSettingsPresented) { item in
+                                    select(item)
+                                }
+                        }
+                    }
+                }
+                .padding(.horizontal, 8)
+                .padding(.top, 12)
+                .padding(.bottom, 16)
+            }
 
             SidebarFooter(
                 items: SidebarLayout.footerItems,
@@ -21,46 +81,135 @@ struct SidebarView: View {
                     store.send(.settingsSelected)
                 }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(PortuTheme.dashboardSidebarBackground)
     }
 
-    private var selectedSection: Binding<SidebarSection?> {
-        Binding(
-            get: { store.sidebarSelection },
-            set: { if let section = $0 { store.send(.sectionSelected(section)) } })
+    private func select(_ item: SidebarItem) {
+        switch item {
+        case let .section(section):
+            store.send(.sectionSelected(section))
+        case .settings:
+            store.send(.settingsSelected)
+        case .strategies:
+            break
+        }
+    }
+}
+
+private struct SidebarPortfolioHeader: View {
+    let totalValue: Decimal
+    let change24h: Decimal
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(Color(red: 0.910, green: 0.850, blue: 0.680))
+                Text("P")
+                    .font(.system(size: 22, weight: .black, design: .rounded))
+                    .foregroundStyle(PortuTheme.dashboardBackground)
+            }
+            .frame(width: 34, height: 34)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(totalValue, format: .currency(code: "USD").precision(.fractionLength(0)))
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                HStack(spacing: 4) {
+                    Text(change24h, format: .currency(code: "USD").precision(.fractionLength(0)))
+                    Text("24h")
+                }
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(change24h < 0 ? PortuTheme.dashboardWarning : PortuTheme.dashboardSuccess)
+            }
+        }
+        .padding(.horizontal, 4)
     }
 }
 
 private struct SidebarNavigationSection: View {
     let section: SidebarLayoutSection
+    let selectedSection: SidebarSection?
+    let isSettingsSelected: Bool
+    let select: (SidebarItem) -> Void
 
     var body: some View {
-        Section {
-            ForEach(section.items) { item in
-                SidebarNavigationRow(item: item)
-            }
-        } header: {
+        VStack(alignment: .leading, spacing: 4) {
             if let title = section.title {
                 Text(title)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
+                    .padding(.horizontal, 8)
+            }
+
+            ForEach(section.items) { item in
+                Button {
+                    select(item)
+                } label: {
+                    SidebarNavigationRow(
+                        item: item,
+                        isSelected: isSelected(item),
+                        isDisabled: section.isDisabled)
+                }
+                .buttonStyle(.plain)
+                .disabled(section.isDisabled)
             }
         }
-        .disabled(section.isDisabled)
+    }
+
+    private func isSelected(_ item: SidebarItem) -> Bool {
+        switch item {
+        case let .section(section):
+            selectedSection == section && !isSettingsSelected
+        case .settings:
+            isSettingsSelected
+        case .strategies:
+            false
+        }
     }
 }
 
 private struct SidebarNavigationRow: View {
     let item: SidebarItem
+    let isSelected: Bool
+    let isDisabled: Bool
 
     var body: some View {
-        switch item {
-        case let .section(section):
-            Label(section.title, systemImage: section.systemImage)
-                .tag(section)
-        case .strategies:
-            Label("Strategies", systemImage: "lightbulb")
-                .foregroundStyle(.tertiary)
-        case .settings:
-            EmptyView()
+        HStack(spacing: 8) {
+            Image(systemName: item.systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 16)
+                .foregroundStyle(iconColor)
+
+            Text(item.title)
+                .font(.system(size: 13, weight: isSelected ? .semibold : .regular))
+                .lineLimit(1)
+
+            Spacer(minLength: 0)
         }
+        .foregroundStyle(textColor)
+        .padding(.horizontal, 8)
+        .frame(height: 30)
+        .background(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(isSelected ? PortuTheme.dashboardMutedPanelBackground : .clear))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .stroke(isSelected ? PortuTheme.dashboardMutedStroke : .clear, lineWidth: 1))
+        .contentShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+    }
+
+    private var iconColor: Color {
+        if isDisabled { return PortuTheme.dashboardTertiaryText }
+        return isSelected ? PortuTheme.dashboardGold : PortuTheme.dashboardSecondaryText
+    }
+
+    private var textColor: Color {
+        if isDisabled { return PortuTheme.dashboardTertiaryText }
+        return isSelected ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText
     }
 }
 
@@ -71,7 +220,9 @@ private struct SidebarFooter: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Divider()
+            Rectangle()
+                .fill(PortuTheme.dashboardStroke)
+                .frame(height: 1)
 
             ForEach(items) { item in
                 switch item {
@@ -79,24 +230,36 @@ private struct SidebarFooter: View {
                     Button {
                         settingsAction()
                     } label: {
-                        Label("Settings", systemImage: "gear")
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .contentShape(Rectangle())
-                            .foregroundStyle(isSettingsSelected ? Color.accentColor : Color.primary)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 5)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .fill(isSettingsSelected ? Color.accentColor.opacity(0.16) : .clear))
+                        SidebarNavigationRow(
+                            item: item,
+                            isSelected: isSettingsSelected,
+                            isDisabled: false)
                     }
                     .buttonStyle(.plain)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
+                    .padding(8)
                 case .section, .strategies:
                     EmptyView()
                 }
             }
         }
-        .background(.bar)
+        .background(PortuTheme.dashboardSidebarBackground)
+    }
+}
+
+private extension SidebarItem {
+    var title: String {
+        switch self {
+        case let .section(section): section.title
+        case .strategies: "Strategies"
+        case .settings: "Settings"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case let .section(section): section.systemImage
+        case .strategies: "lightbulb"
+        case .settings: "gearshape"
+        }
     }
 }

--- a/Tests/PortuTests/AddAccountSheetReviewTests.swift
+++ b/Tests/PortuTests/AddAccountSheetReviewTests.swift
@@ -1,0 +1,24 @@
+@testable import Portu
+import PortuCore
+import Testing
+
+struct AddAccountExchangeSecretsTests {
+    @Test func `passphrase is persisted only for Coinbase`() {
+        #expect(AddAccountExchangeSecrets.persistedPassphrase("phrase", for: .coinbase) == "phrase")
+        #expect(AddAccountExchangeSecrets.persistedPassphrase("phrase", for: .kraken) == nil)
+        #expect(AddAccountExchangeSecrets.persistedPassphrase("phrase", for: .binance) == nil)
+        #expect(AddAccountExchangeSecrets.persistedPassphrase("", for: .coinbase) == nil)
+    }
+
+    @Test func `switching away from Coinbase clears passphrase`() {
+        #expect(AddAccountExchangeSecrets.passphraseAfterSelecting(.coinbase, currentPassphrase: "phrase") == "phrase")
+        #expect(AddAccountExchangeSecrets.passphraseAfterSelecting(.kraken, currentPassphrase: "phrase").isEmpty)
+        #expect(AddAccountExchangeSecrets.passphraseAfterSelecting(.binance, currentPassphrase: "phrase").isEmpty)
+    }
+}
+
+struct AddAccountAccessibilityTests {
+    @Test func `close icon button has explicit accessible label`() {
+        #expect(AddAccountAccessibility.closeButtonLabel == "Close")
+    }
+}

--- a/Tests/PortuTests/AddAccountSupportChipTests.swift
+++ b/Tests/PortuTests/AddAccountSupportChipTests.swift
@@ -1,0 +1,19 @@
+@testable import Portu
+import PortuUI
+import Testing
+
+@MainActor
+struct AddAccountSupportChipTests {
+    @Test func `model identity is stable for equivalent chips`() {
+        let first = AddAccountSupportChip.Model(
+            title: "Ethereum",
+            systemImage: "link",
+            tint: PortuTheme.dashboardGold)
+        let second = AddAccountSupportChip.Model(
+            title: "Ethereum",
+            systemImage: "link",
+            tint: PortuTheme.dashboardGold)
+
+        #expect(first.id == second.id)
+    }
+}

--- a/Tests/PortuTests/PositionGroupValueTests.swift
+++ b/Tests/PortuTests/PositionGroupValueTests.swift
@@ -1,0 +1,22 @@
+@testable import Portu
+import PortuCore
+import Testing
+
+struct PositionGroupValueTests {
+    @Test func `header total excludes rewards and signs borrows`() {
+        let asset = Asset(
+            symbol: "ETH",
+            name: "Ethereum",
+            coinGeckoId: "ethereum",
+            category: .major)
+        let tokens = [
+            PositionToken(role: .supply, amount: 2, usdValue: 6000, asset: asset),
+            PositionToken(role: .borrow, amount: 1, usdValue: 3000, asset: asset),
+            PositionToken(role: .reward, amount: 10, usdValue: 500, asset: asset)
+        ]
+
+        let total = PositionGroupValue.headerTotal(for: tokens, livePrices: ["ethereum": 3100])
+
+        #expect(total == 3100)
+    }
+}

--- a/Tests/PortuTests/ViewRenderSmokeTests.swift
+++ b/Tests/PortuTests/ViewRenderSmokeTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import Foundation
 @testable import Portu

--- a/Tests/PortuTests/ViewRenderSmokeTests.swift
+++ b/Tests/PortuTests/ViewRenderSmokeTests.swift
@@ -1,0 +1,262 @@
+import ComposableArchitecture
+import Foundation
+@testable import Portu
+import PortuCore
+import SwiftData
+import SwiftUI
+import Testing
+
+@MainActor
+struct ViewRenderSmokeTests {
+    private static var retainedWindows: [NSWindow] = []
+
+    @Test(arguments: [
+        SidebarSection.overview,
+        .exposure,
+        .performance,
+        .allAssets,
+        .allPositions,
+        .accounts
+    ])
+    func `dashboard section renders without crashing`(_ section: SidebarSection) throws {
+        let container = try makeContainer()
+        let store = makeStore(section: section)
+        let appState = AppState()
+        appState.bridge(from: store)
+
+        let view = ContentView(store: store)
+            .modelContainer(container)
+            .environment(appState)
+            .frame(width: 1400, height: 900)
+
+        render(view)
+    }
+
+    @Test(arguments: AssetTab.allCases)
+    func `all assets tabs render without crashing`(_ tab: AssetTab) throws {
+        let container = try makeContainer()
+        var state = populatedState(section: .allAssets)
+        state.allAssets.selectedTab = tab
+        let store = makeStore(state: state)
+        let appState = AppState()
+        appState.bridge(from: store)
+
+        let view = ContentView(store: store)
+            .modelContainer(container)
+            .environment(appState)
+            .frame(width: 1400, height: 900)
+
+        render(view)
+    }
+
+    @Test func `asset detail renders without crashing`() throws {
+        let container = try makeContainer()
+        let asset = try #require(try container.mainContext.fetch(FetchDescriptor<Asset>()).first)
+        let store = makeStore(section: .allAssets)
+
+        let view = AssetDetailView(assetId: asset.id, store: store)
+            .modelContainer(container)
+            .frame(width: 1400, height: 900)
+
+        render(view)
+    }
+
+    @Test func `settings route renders without crashing`() throws {
+        let container = try makeContainer()
+        var state = populatedState(section: .overview)
+        state.isSettingsPresented = true
+        let store = makeStore(state: state)
+        let appState = AppState()
+        appState.bridge(from: store)
+
+        let view = ContentView(store: store)
+            .modelContainer(container)
+            .environment(appState)
+            .frame(width: 1400, height: 900)
+
+        render(view)
+    }
+
+    @Test func `add account sheet renders without crashing`() throws {
+        let container = try makeContainer()
+
+        let view = AddAccountSheet()
+            .modelContainer(container)
+            .environment(\.colorScheme, .dark)
+            .frame(width: 920, height: 760)
+
+        render(view)
+    }
+
+    private func makeStore(section: SidebarSection) -> StoreOf<AppFeature> {
+        makeStore(state: populatedState(section: section))
+    }
+
+    private func makeStore(state: AppFeature.State) -> StoreOf<AppFeature> {
+        Store(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine.sync = { SyncResult(failedAccounts: []) }
+            $0.priceService.fetchPrices = { _ in PriceUpdate(prices: [:], changes24h: [:]) }
+            $0.priceService.invalidateCache = {}
+        }
+    }
+
+    private func populatedState(section: SidebarSection) -> AppFeature.State {
+        var state = AppFeature.State(selectedSection: section)
+        state.prices = ["ethereum": 3050, "usd-coin": 1]
+        state.priceChanges24h = ["ethereum": 0.021, "usd-coin": 0]
+        state.lastPriceUpdate = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        return state
+    }
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Account.self,
+            WalletAddress.self,
+            Position.self,
+            PositionToken.self,
+            Asset.self,
+            PortfolioSnapshot.self,
+            AccountSnapshot.self,
+            AssetSnapshot.self
+        ])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        try seedSampleData(in: container)
+        return container
+    }
+
+    private func seedSampleData(in container: ModelContainer) throws {
+        let context = container.mainContext
+        let ids = SampleIDs()
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let assets = makeSampleAssets(ids: ids)
+        let account = makeSampleAccount(id: ids.account, now: now, assets: assets)
+
+        context.insert(assets.eth)
+        context.insert(assets.usdc)
+        context.insert(account)
+        insertSnapshots(context: context, ids: ids, now: now)
+
+        try context.save()
+    }
+
+    private func makeSampleAssets(ids: SampleIDs) -> (eth: Asset, usdc: Asset) {
+        let eth = Asset(
+            id: ids.eth,
+            symbol: "ETH",
+            name: "Ethereum",
+            coinGeckoId: "ethereum",
+            category: .major,
+            isVerified: true)
+        let usdc = Asset(
+            id: ids.usdc,
+            symbol: "USDC",
+            name: "USD Coin",
+            coinGeckoId: "usd-coin",
+            category: .stablecoin,
+            isVerified: true)
+        return (eth, usdc)
+    }
+
+    private func makeSampleAccount(
+        id: UUID,
+        now: Date,
+        assets: (eth: Asset, usdc: Asset)) -> Account {
+        let account = Account(
+            id: id,
+            name: "Primary Wallet",
+            kind: .wallet,
+            dataSource: .zapper,
+            lastSyncedAt: now)
+        let ethToken = PositionToken(role: .balance, amount: 2, usdValue: 6000, asset: assets.eth)
+        let usdcToken = PositionToken(role: .supply, amount: 4000, usdValue: 4000, asset: assets.usdc)
+        let borrowToken = PositionToken(role: .borrow, amount: 500, usdValue: 500, asset: assets.usdc)
+
+        account.positions = [
+            Position(
+                positionType: .idle,
+                chain: .ethereum,
+                netUSDValue: 6000,
+                tokens: [ethToken],
+                account: account,
+                syncedAt: now),
+            Position(
+                positionType: .lending,
+                chain: .ethereum,
+                protocolId: "aave-v3",
+                protocolName: "Aave V3",
+                healthFactor: 2.4,
+                netUSDValue: 3500,
+                tokens: [usdcToken, borrowToken],
+                account: account,
+                syncedAt: now)
+        ]
+        return account
+    }
+
+    private func insertSnapshots(context: ModelContext, ids: SampleIDs, now: Date) {
+        for day in 0 ..< 5 {
+            let timestamp = now.addingTimeInterval(Double(day - 4) * 86400)
+            let total = Decimal(8600 + day * 240)
+            context.insert(PortfolioSnapshot(
+                syncBatchId: ids.batch,
+                timestamp: timestamp,
+                totalValue: total,
+                idleValue: total * Decimal(60) / Decimal(100),
+                deployedValue: total * Decimal(40) / Decimal(100),
+                debtValue: 500,
+                isPartial: false))
+            context.insert(AccountSnapshot(
+                syncBatchId: ids.batch,
+                timestamp: timestamp,
+                accountId: ids.account,
+                totalValue: total,
+                isFresh: true))
+            context.insert(AssetSnapshot(
+                syncBatchId: ids.batch,
+                timestamp: timestamp,
+                accountId: ids.account,
+                assetId: ids.eth,
+                symbol: "ETH",
+                category: .major,
+                amount: 2,
+                usdValue: 6000))
+            context.insert(AssetSnapshot(
+                syncBatchId: ids.batch,
+                timestamp: timestamp,
+                accountId: ids.account,
+                assetId: ids.usdc,
+                symbol: "USDC",
+                category: .stablecoin,
+                amount: 4000,
+                usdValue: 4000,
+                borrowAmount: 500,
+                borrowUsdValue: 500))
+        }
+    }
+
+    private struct SampleIDs {
+        let account = UUID(uuidString: "00000000-0000-0000-0000-0000000000A1")!
+        let eth = UUID(uuidString: "00000000-0000-0000-0000-0000000000E1")!
+        let usdc = UUID(uuidString: "00000000-0000-0000-0000-0000000000C1")!
+        let batch = UUID(uuidString: "00000000-0000-0000-0000-0000000000B1")!
+    }
+
+    private func render(_ view: some View) {
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.frame = CGRect(x: 0, y: 0, width: 1400, height: 900)
+
+        let window = NSWindow(
+            contentRect: hostingView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false)
+        window.contentView = hostingView
+        window.layoutIfNeeded()
+        hostingView.layoutSubtreeIfNeeded()
+        hostingView.displayIfNeeded()
+        Self.retainedWindows.append(window)
+    }
+}

--- a/Tests/PortuTests/ViewRenderSmokeTests.swift
+++ b/Tests/PortuTests/ViewRenderSmokeTests.swift
@@ -8,6 +8,7 @@ import Testing
 
 @MainActor
 struct ViewRenderSmokeTests {
+    private static let maxRetainedWindows = 16
     private static var retainedWindows: [NSWindow] = []
 
     @Test(arguments: [
@@ -253,10 +254,15 @@ struct ViewRenderSmokeTests {
             styleMask: [.borderless],
             backing: .buffered,
             defer: false)
+
         window.contentView = hostingView
         window.layoutIfNeeded()
         hostingView.layoutSubtreeIfNeeded()
         hostingView.displayIfNeeded()
+
         Self.retainedWindows.append(window)
+        if Self.retainedWindows.count > Self.maxRetainedWindows {
+            Self.retainedWindows.removeFirst(Self.retainedWindows.count - Self.maxRetainedWindows)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Redesign the main Portu dashboard views with the compact dark panel treatment, shared dashboard styling, and tighter view chrome inspired by the reference screens.
- Redesign the Add Account sheet, including the chain/manual/exchange tabs, support panels, smaller popup margins, and more compact input controls.
- Add SwiftUI render smoke tests for dashboard sections, all-assets tabs, asset detail, settings route, and the Add Account sheet to catch crash-prone view paths.

## Verification
- `./script/build_and_run.sh --verify`
- Focused render smoke tests: `xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test -only-testing:PortuTests/ViewRenderSmokeTests`
- Full suite: `xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test` (277 tests in 45 suites)
- Visual check of the redesigned app and Add Account sheet, including compact chain-account layout without the visible scrollbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New dashboard UI components and page layout (consistent headers, cards, controls, tables)
  * Sidebar now includes a searchable portfolio sidebar and rebuilt navigation

* **Style**
  * Unified dashboard theme (colors, typography, spacings) applied across app, charts, tables, and status bar
  * Many views restyled for improved visual hierarchy and consistency

* **Bug Fixes**
  * Add Account flow: per-tab save validation, error alert on failure, and exchange notes persisted on save
<!-- end of auto-generated comment: release notes by coderabbit.ai -->