### PR TITLE
[codex] Redesign overview dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 
 
 .screens/
+mockups/
 pnevma.toml
 .pnevma/
 .superpowers/

--- a/Sources/Portu/App/MainWindowPlacement.swift
+++ b/Sources/Portu/App/MainWindowPlacement.swift
@@ -1,0 +1,23 @@
+import CoreGraphics
+
+enum MainWindowPlacement {
+    private static let displayScale: CGFloat = 0.9
+    private static let minimumSize = CGSize(width: 900, height: 600)
+    private static let maximumSize = CGSize(width: 1440, height: 960)
+
+    static func launchSize(for visibleDisplaySize: CGSize) -> CGSize {
+        CGSize(
+            width: clamped(
+                visibleDisplaySize.width * displayScale,
+                minimum: minimumSize.width,
+                maximum: maximumSize.width),
+            height: clamped(
+                visibleDisplaySize.height * displayScale,
+                minimum: minimumSize.height,
+                maximum: maximumSize.height))
+    }
+
+    private static func clamped(_ value: CGFloat, minimum: CGFloat, maximum: CGFloat) -> CGFloat {
+        min(max(value, minimum), maximum)
+    }
+}

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -82,6 +82,10 @@ struct PortuApp: App {
             ContentView(store: store)
                 .environment(appState)
         }
+        .defaultWindowPlacement { _, context in
+            let launchSize = MainWindowPlacement.launchSize(for: context.defaultDisplay.visibleRect.size)
+            return WindowPlacement(size: launchSize)
+        }
         .modelContainer(container)
         .commands {
             CommandGroup(replacing: .appSettings) {

--- a/Sources/Portu/Features/Overview/InspectorPanel.swift
+++ b/Sources/Portu/Features/Overview/InspectorPanel.swift
@@ -5,13 +5,12 @@ import SwiftUI
 
 struct InspectorPanel: View {
     let store: StoreOf<AppFeature>
+    var showsLeadingDivider = true
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 TopAssetsDonut(store: store)
-                inspectorDivider
-                PortfolioHealthPanel(store: store)
                 inspectorDivider
                 PriceWatchlist()
             }
@@ -19,9 +18,11 @@ struct InspectorPanel: View {
         }
         .background(PortuTheme.dashboardPanelBackground)
         .overlay(alignment: .leading) {
-            Rectangle()
-                .fill(PortuTheme.dashboardStroke)
-                .frame(width: 1)
+            if showsLeadingDivider {
+                Rectangle()
+                    .fill(PortuTheme.dashboardStroke)
+                    .frame(width: 1)
+            }
         }
     }
 

--- a/Sources/Portu/Features/Overview/OverviewFeature.swift
+++ b/Sources/Portu/Features/Overview/OverviewFeature.swift
@@ -131,12 +131,21 @@ enum OverviewWatchlistStore {
         return result
     }
 
+    static func normalizedID(_ id: String?) -> String? {
+        guard let id else { return nil }
+        let normalized = normalize(id)
+        return normalized.isEmpty ? nil : normalized
+    }
+
     static func normalize(_ id: String) -> String {
         id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 
 enum OverviewFeature {
+    private static let assetResidualSliceID = "asset-residual"
+    private static let categoryResidualSliceID = "category-residual"
+
     private struct AssetAggregate {
         let assetId: UUID
         var symbol: String
@@ -159,12 +168,12 @@ enum OverviewFeature {
         let aggregates = sortedAssetAggregates(from: tokens, prices: prices)
         let visibleCount = max(limit, 0)
         var sliceInputs = aggregates.prefix(visibleCount).map {
-            SliceInput(id: $0.coinGeckoId ?? $0.assetId.uuidString, label: $0.symbol, value: $0.value)
+            SliceInput(id: $0.assetId.uuidString, label: $0.symbol, value: $0.value)
         }
 
         let otherValue = aggregates.dropFirst(visibleCount).reduce(Decimal.zero) { $0 + $1.value }
         if otherValue > 0 {
-            sliceInputs.append(SliceInput(id: "other", label: "other", value: otherValue))
+            sliceInputs.append(SliceInput(id: assetResidualSliceID, label: "other", value: otherValue))
         }
 
         return makeSlices(from: sliceInputs)
@@ -190,14 +199,14 @@ enum OverviewFeature {
 
         let visibleCount = max(limit, 0)
         var inputs = sortedValues
-            .prefix(max(limit, 0))
+            .prefix(visibleCount)
             .map { category, value in
                 SliceInput(id: category.rawValue, label: category.rawValue.capitalized, value: value)
             }
 
         let otherValue = sortedValues.dropFirst(visibleCount).reduce(Decimal.zero) { $0 + $1.value }
         if otherValue > 0 {
-            inputs.append(SliceInput(id: "other", label: "other", value: otherValue))
+            inputs.append(SliceInput(id: categoryResidualSliceID, label: "other", value: otherValue))
         }
 
         return makeSlices(from: inputs)
@@ -208,8 +217,7 @@ enum OverviewFeature {
         var candidates: [String: OverviewAssetCandidate] = [:]
 
         for asset in assets {
-            let coinGeckoId = OverviewWatchlistStore.normalize(asset.coinGeckoId)
-            guard !coinGeckoId.isEmpty else { continue }
+            guard let coinGeckoId = OverviewWatchlistStore.normalizedID(asset.coinGeckoId) else { continue }
 
             if let existing = candidates[coinGeckoId] {
                 candidates[coinGeckoId] = preferredAssetCandidate(asset, over: existing) ? asset : existing
@@ -219,6 +227,34 @@ enum OverviewFeature {
         }
 
         return candidates
+    }
+
+    static func watchlistSuggestions(
+        assets: [OverviewAssetCandidate],
+        watchlistIDs: [String],
+        query: String,
+        limit: Int = 5) -> [OverviewAssetCandidate] {
+        let searchQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !searchQuery.isEmpty else { return [] }
+
+        let existing = Set(OverviewWatchlistStore.normalizedUniqueIDs(watchlistIDs))
+        return assetCandidatesByCoinGeckoId(from: assets)
+            .filter { coinGeckoId, asset in
+                !existing.contains(coinGeckoId)
+                    && (asset.symbol.localizedCaseInsensitiveContains(searchQuery)
+                        || asset.name.localizedCaseInsensitiveContains(searchQuery)
+                        || coinGeckoId.localizedCaseInsensitiveContains(searchQuery)
+                        || asset.coinGeckoId.localizedCaseInsensitiveContains(searchQuery))
+            }
+            .map(\.value)
+            .sorted {
+                if $0.symbol == $1.symbol {
+                    return $0.name < $1.name
+                }
+                return $0.symbol < $1.symbol
+            }
+            .prefix(max(limit, 0))
+            .map(\.self)
     }
 
     static func priceRows(
@@ -251,12 +287,12 @@ enum OverviewFeature {
         var seen: Set<String> = []
 
         for aggregate in sortedAssetAggregates(from: tokens, prices: prices).prefix(max(portfolioLimit, 0)) {
-            let rowID = aggregate.coinGeckoId?.lowercased() ?? aggregate.assetId.uuidString
+            let coinGeckoId = OverviewWatchlistStore.normalizedID(aggregate.coinGeckoId)
+            let rowID = coinGeckoId ?? aggregate.assetId.uuidString
             guard !seen.contains(rowID) else {
                 continue
             }
             seen.insert(rowID)
-            let coinGeckoId = aggregate.coinGeckoId?.lowercased()
             rows.append(OverviewPriceRowData(
                 id: rowID,
                 assetId: aggregate.assetId,
@@ -269,17 +305,28 @@ enum OverviewFeature {
         }
 
         for coinGeckoId in watchlist where !seen.contains(coinGeckoId) {
-            guard let asset = assetsByCoinGeckoId[coinGeckoId] else { continue }
             seen.insert(coinGeckoId)
-            rows.append(OverviewPriceRowData(
-                id: coinGeckoId,
-                assetId: asset.id,
-                symbol: asset.symbol,
-                name: asset.name,
-                coinGeckoId: coinGeckoId,
-                price: prices[coinGeckoId],
-                change24h: changes24h[coinGeckoId],
-                isWatchlisted: true))
+            if let asset = assetsByCoinGeckoId[coinGeckoId] {
+                rows.append(OverviewPriceRowData(
+                    id: coinGeckoId,
+                    assetId: asset.id,
+                    symbol: asset.symbol,
+                    name: asset.name,
+                    coinGeckoId: coinGeckoId,
+                    price: prices[coinGeckoId],
+                    change24h: changes24h[coinGeckoId],
+                    isWatchlisted: true))
+            } else {
+                rows.append(OverviewPriceRowData(
+                    id: coinGeckoId,
+                    assetId: nil,
+                    symbol: coinGeckoId,
+                    name: coinGeckoId,
+                    coinGeckoId: coinGeckoId,
+                    price: prices[coinGeckoId],
+                    change24h: changes24h[coinGeckoId],
+                    isWatchlisted: true))
+            }
         }
 
         return rows
@@ -326,10 +373,10 @@ enum OverviewFeature {
                 symbol: token.symbol,
                 name: token.name,
                 category: token.category,
-                coinGeckoId: token.coinGeckoId,
+                coinGeckoId: OverviewWatchlistStore.normalizedID(token.coinGeckoId),
                 value: 0,
                 amount: 0)
-            aggregate.coinGeckoId = aggregate.coinGeckoId ?? token.coinGeckoId
+            aggregate.coinGeckoId = aggregate.coinGeckoId ?? OverviewWatchlistStore.normalizedID(token.coinGeckoId)
             aggregate.value += resolvedValue(for: token, prices: prices)
             if token.amount > 0 {
                 aggregate.amount += token.amount
@@ -341,7 +388,17 @@ enum OverviewFeature {
             .filter { $0.value > 0 }
             .sorted {
                 if $0.value == $1.value {
-                    return $0.symbol.localizedStandardCompare($1.symbol) == .orderedAscending
+                    let symbolOrder = $0.symbol.localizedStandardCompare($1.symbol)
+                    if symbolOrder != .orderedSame {
+                        return symbolOrder == .orderedAscending
+                    }
+
+                    let nameOrder = $0.name.localizedStandardCompare($1.name)
+                    if nameOrder != .orderedSame {
+                        return nameOrder == .orderedAscending
+                    }
+
+                    return $0.assetId.uuidString < $1.assetId.uuidString
                 }
                 return $0.value > $1.value
             }
@@ -359,7 +416,7 @@ enum OverviewFeature {
     private static func resolvedValue(
         for token: TokenEntry,
         prices: [String: Decimal]) -> Decimal {
-        if let coinGeckoId = token.coinGeckoId?.lowercased(), let price = prices[coinGeckoId] {
+        if let coinGeckoId = OverviewWatchlistStore.normalizedID(token.coinGeckoId), let price = prices[coinGeckoId] {
             return token.amount * price
         }
         return token.usdValue

--- a/Sources/Portu/Features/Overview/OverviewFeature.swift
+++ b/Sources/Portu/Features/Overview/OverviewFeature.swift
@@ -284,15 +284,19 @@ enum OverviewFeature {
         let watchlistSet = Set(watchlist)
 
         var rows: [OverviewPriceRowData] = []
-        var seen: Set<String> = []
+        var seenRowIDs: Set<String> = []
+        var portfolioCoinGeckoIDs: Set<String> = []
 
         for aggregate in sortedAssetAggregates(from: tokens, prices: prices).prefix(max(portfolioLimit, 0)) {
             let coinGeckoId = OverviewWatchlistStore.normalizedID(aggregate.coinGeckoId)
-            let rowID = coinGeckoId ?? aggregate.assetId.uuidString
-            guard !seen.contains(rowID) else {
+            let rowID = aggregate.assetId.uuidString
+            guard !seenRowIDs.contains(rowID) else {
                 continue
             }
-            seen.insert(rowID)
+            seenRowIDs.insert(rowID)
+            if let coinGeckoId {
+                portfolioCoinGeckoIDs.insert(coinGeckoId)
+            }
             rows.append(OverviewPriceRowData(
                 id: rowID,
                 assetId: aggregate.assetId,
@@ -304,8 +308,8 @@ enum OverviewFeature {
                 isWatchlisted: coinGeckoId.map { watchlistSet.contains($0) } ?? false))
         }
 
-        for coinGeckoId in watchlist where !seen.contains(coinGeckoId) {
-            seen.insert(coinGeckoId)
+        for coinGeckoId in watchlist where !portfolioCoinGeckoIDs.contains(coinGeckoId) && !seenRowIDs.contains(coinGeckoId) {
+            seenRowIDs.insert(coinGeckoId)
             if let asset = assetsByCoinGeckoId[coinGeckoId] {
                 rows.append(OverviewPriceRowData(
                     id: coinGeckoId,

--- a/Sources/Portu/Features/Overview/OverviewFeature.swift
+++ b/Sources/Portu/Features/Overview/OverviewFeature.swift
@@ -43,6 +43,7 @@ struct OverviewPriceRowData: Equatable, Identifiable {
 
 enum OverviewPriceDisplay {
     static let assetLabelMaxLength = 6
+    private static let priceLocale = Locale(identifier: "en_US_POSIX")
 
     static func assetLabel(_ symbol: String) -> String {
         let trimmed = symbol.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -54,21 +55,31 @@ enum OverviewPriceDisplay {
     }
 
     private static func formattedNumber(_ price: Decimal) -> String {
-        let number = NSDecimalNumber(decimal: price)
-        let absoluteValue = abs(number.doubleValue)
-        let formatter = NumberFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.numberStyle = .decimal
-        formatter.usesGroupingSeparator = true
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = maximumFractionDigits(for: absoluteValue)
-        return formatter.string(from: number) ?? number.stringValue
+        let number = NSDecimalNumber(decimal: price).doubleValue
+        return number.formatted(.number
+            .locale(priceLocale)
+            .grouping(.automatic)
+            .precision(.fractionLength(0 ... maximumFractionDigits(for: abs(number)))))
     }
 
     private static func maximumFractionDigits(for absoluteValue: Double) -> Int {
         if absoluteValue >= 1000 { return 0 }
         if absoluteValue >= 1 { return 4 }
-        return 5
+        if absoluteValue >= 0.0001 { return 6 }
+        return 8
+    }
+}
+
+enum OverviewPriceCountdown {
+    static func secondsRemaining(
+        lastPriceUpdate: Date?,
+        refreshInterval: TimeInterval,
+        now: Date) -> Int {
+        let fallback = max(0, Int(refreshInterval.rounded(.up)))
+        guard let lastPriceUpdate else { return fallback }
+
+        let nextUpdate = lastPriceUpdate.addingTimeInterval(refreshInterval)
+        return max(0, Int(ceil(nextUpdate.timeIntervalSince(now))))
     }
 }
 
@@ -120,7 +131,7 @@ enum OverviewWatchlistStore {
         return result
     }
 
-    private static func normalize(_ id: String) -> String {
+    static func normalize(_ id: String) -> String {
         id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
@@ -168,7 +179,7 @@ enum OverviewFeature {
             values[token.category, default: 0] += resolvedValue(for: token, prices: prices)
         }
 
-        let inputs = values
+        let sortedValues = values
             .filter { $0.value > 0 }
             .sorted {
                 if $0.value == $1.value {
@@ -176,12 +187,38 @@ enum OverviewFeature {
                 }
                 return $0.value > $1.value
             }
+
+        let visibleCount = max(limit, 0)
+        var inputs = sortedValues
             .prefix(max(limit, 0))
             .map { category, value in
                 SliceInput(id: category.rawValue, label: category.rawValue.capitalized, value: value)
             }
 
-        return makeSlices(from: Array(inputs))
+        let otherValue = sortedValues.dropFirst(visibleCount).reduce(Decimal.zero) { $0 + $1.value }
+        if otherValue > 0 {
+            inputs.append(SliceInput(id: "other", label: "other", value: otherValue))
+        }
+
+        return makeSlices(from: inputs)
+    }
+
+    static func assetCandidatesByCoinGeckoId(
+        from assets: [OverviewAssetCandidate]) -> [String: OverviewAssetCandidate] {
+        var candidates: [String: OverviewAssetCandidate] = [:]
+
+        for asset in assets {
+            let coinGeckoId = OverviewWatchlistStore.normalize(asset.coinGeckoId)
+            guard !coinGeckoId.isEmpty else { continue }
+
+            if let existing = candidates[coinGeckoId] {
+                candidates[coinGeckoId] = preferredAssetCandidate(asset, over: existing) ? asset : existing
+            } else {
+                candidates[coinGeckoId] = asset
+            }
+        }
+
+        return candidates
     }
 
     static func priceRows(
@@ -191,20 +228,24 @@ enum OverviewFeature {
         changes24h: [String: Decimal],
         watchlistIDs: [String],
         portfolioLimit: Int = 10) -> [OverviewPriceRowData] {
+        priceRows(
+            tokens: tokens,
+            assetsByCoinGeckoId: assetCandidatesByCoinGeckoId(from: assets),
+            prices: prices,
+            changes24h: changes24h,
+            watchlistIDs: watchlistIDs,
+            portfolioLimit: portfolioLimit)
+    }
+
+    static func priceRows(
+        tokens: [TokenEntry],
+        assetsByCoinGeckoId: [String: OverviewAssetCandidate],
+        prices: [String: Decimal],
+        changes24h: [String: Decimal],
+        watchlistIDs: [String],
+        portfolioLimit: Int = 10) -> [OverviewPriceRowData] {
         let watchlist = OverviewWatchlistStore.normalizedUniqueIDs(watchlistIDs)
         let watchlistSet = Set(watchlist)
-        let candidatesByCoinGeckoId = Dictionary(
-            grouping: assets,
-            by: { $0.coinGeckoId.lowercased() })
-            .compactMapValues { candidates in
-                candidates.min {
-                    if $0.symbol == $1.symbol {
-                        $0.name < $1.name
-                    } else {
-                        $0.symbol < $1.symbol
-                    }
-                }
-            }
 
         var rows: [OverviewPriceRowData] = []
         var seen: Set<String> = []
@@ -228,7 +269,7 @@ enum OverviewFeature {
         }
 
         for coinGeckoId in watchlist where !seen.contains(coinGeckoId) {
-            guard let asset = candidatesByCoinGeckoId[coinGeckoId] else { continue }
+            guard let asset = assetsByCoinGeckoId[coinGeckoId] else { continue }
             seen.insert(coinGeckoId)
             rows.append(OverviewPriceRowData(
                 id: coinGeckoId,
@@ -247,11 +288,13 @@ enum OverviewFeature {
     static func pricePollingIDs(
         tokens: [TokenEntry],
         watchlistIDs: [String]) -> [String] {
-        var ids = sortedAssetAggregates(from: tokens, prices: [:])
-            .compactMap { $0.coinGeckoId?.lowercased() }
+        var ids = tokens.compactMap { token -> String? in
+            guard token.role.isPositive, token.amount > 0 else { return nil }
+            return token.coinGeckoId
+        }
 
         ids.append(contentsOf: watchlistIDs)
-        return OverviewWatchlistStore.normalizedUniqueIDs(ids)
+        return OverviewWatchlistStore.normalizedUniqueIDs(ids).sorted()
     }
 
     private struct SliceInput {
@@ -302,6 +345,15 @@ enum OverviewFeature {
                 }
                 return $0.value > $1.value
             }
+    }
+
+    private static func preferredAssetCandidate(
+        _ candidate: OverviewAssetCandidate,
+        over existing: OverviewAssetCandidate) -> Bool {
+        if candidate.symbol == existing.symbol {
+            return candidate.name < existing.name
+        }
+        return candidate.symbol < existing.symbol
     }
 
     private static func resolvedValue(

--- a/Sources/Portu/Features/Overview/OverviewFeature.swift
+++ b/Sources/Portu/Features/Overview/OverviewFeature.swift
@@ -1,0 +1,332 @@
+import Foundation
+import PortuCore
+
+struct OverviewAssetCandidate: Equatable, Identifiable {
+    let id: UUID
+    let symbol: String
+    let name: String
+    let category: AssetCategory
+    let coinGeckoId: String
+
+    @MainActor
+    static func fromAssets(_ assets: [Asset]) -> [OverviewAssetCandidate] {
+        assets.compactMap { asset in
+            guard let coinGeckoId = asset.coinGeckoId else { return nil }
+            return OverviewAssetCandidate(
+                id: asset.id,
+                symbol: asset.symbol,
+                name: asset.name,
+                category: asset.category,
+                coinGeckoId: coinGeckoId)
+        }
+    }
+}
+
+struct OverviewAssetSlice: Equatable, Identifiable {
+    let id: String
+    let label: String
+    let value: Decimal
+    let displayPercent: Int
+    let colorIndex: Int
+}
+
+struct OverviewPriceRowData: Equatable, Identifiable {
+    let id: String
+    let assetId: UUID?
+    let symbol: String
+    let name: String
+    let coinGeckoId: String?
+    let price: Decimal?
+    let change24h: Decimal?
+    let isWatchlisted: Bool
+}
+
+enum OverviewPriceDisplay {
+    static let assetLabelMaxLength = 6
+
+    static func assetLabel(_ symbol: String) -> String {
+        let trimmed = symbol.trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(trimmed.prefix(assetLabelMaxLength))
+    }
+
+    static func price(_ price: Decimal) -> String {
+        "$ \(formattedNumber(price))"
+    }
+
+    private static func formattedNumber(_ price: Decimal) -> String {
+        let number = NSDecimalNumber(decimal: price)
+        let absoluteValue = abs(number.doubleValue)
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = maximumFractionDigits(for: absoluteValue)
+        return formatter.string(from: number) ?? number.stringValue
+    }
+
+    private static func maximumFractionDigits(for absoluteValue: Double) -> Int {
+        if absoluteValue >= 1000 { return 0 }
+        if absoluteValue >= 1 { return 4 }
+        return 5
+    }
+}
+
+enum OverviewWatchlistStore {
+    static let key = "OverviewWatchlistCoinGeckoIDs"
+
+    static func decode(_ rawValue: String) -> [String] {
+        guard
+            let data = rawValue.data(using: .utf8),
+            let ids = try? JSONDecoder().decode([String].self, from: data)
+        else {
+            return []
+        }
+
+        return normalizedUniqueIDs(ids)
+    }
+
+    static func encode(_ ids: [String]) -> String {
+        let normalized = normalizedUniqueIDs(ids)
+        guard
+            let data = try? JSONEncoder().encode(normalized),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return "[]"
+        }
+        return string
+    }
+
+    static func add(_ id: String, to ids: [String]) -> [String] {
+        normalizedUniqueIDs(ids + [id])
+    }
+
+    static func remove(_ id: String, from ids: [String]) -> [String] {
+        let target = normalize(id)
+        return normalizedUniqueIDs(ids).filter { $0 != target }
+    }
+
+    static func normalizedUniqueIDs(_ ids: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+
+        for id in ids {
+            let normalized = normalize(id)
+            guard !normalized.isEmpty, !seen.contains(normalized) else { continue }
+            seen.insert(normalized)
+            result.append(normalized)
+        }
+
+        return result
+    }
+
+    private static func normalize(_ id: String) -> String {
+        id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+enum OverviewFeature {
+    private struct AssetAggregate {
+        let assetId: UUID
+        var symbol: String
+        var name: String
+        var category: AssetCategory
+        var coinGeckoId: String?
+        var value: Decimal
+        var amount: Decimal
+
+        var fallbackPrice: Decimal? {
+            guard amount > 0 else { return nil }
+            return value / amount
+        }
+    }
+
+    static func topAssetSlices(
+        from tokens: [TokenEntry],
+        prices: [String: Decimal],
+        limit: Int = 5) -> [OverviewAssetSlice] {
+        let aggregates = sortedAssetAggregates(from: tokens, prices: prices)
+        let visibleCount = max(limit, 0)
+        var sliceInputs = aggregates.prefix(visibleCount).map {
+            SliceInput(id: $0.coinGeckoId ?? $0.assetId.uuidString, label: $0.symbol, value: $0.value)
+        }
+
+        let otherValue = aggregates.dropFirst(visibleCount).reduce(Decimal.zero) { $0 + $1.value }
+        if otherValue > 0 {
+            sliceInputs.append(SliceInput(id: "other", label: "other", value: otherValue))
+        }
+
+        return makeSlices(from: sliceInputs)
+    }
+
+    static func categorySlices(
+        from tokens: [TokenEntry],
+        prices: [String: Decimal],
+        limit: Int = 6) -> [OverviewAssetSlice] {
+        var values: [AssetCategory: Decimal] = [:]
+        for token in tokens where token.role.isPositive {
+            values[token.category, default: 0] += resolvedValue(for: token, prices: prices)
+        }
+
+        let inputs = values
+            .filter { $0.value > 0 }
+            .sorted {
+                if $0.value == $1.value {
+                    return $0.key.rawValue < $1.key.rawValue
+                }
+                return $0.value > $1.value
+            }
+            .prefix(max(limit, 0))
+            .map { category, value in
+                SliceInput(id: category.rawValue, label: category.rawValue.capitalized, value: value)
+            }
+
+        return makeSlices(from: Array(inputs))
+    }
+
+    static func priceRows(
+        tokens: [TokenEntry],
+        assets: [OverviewAssetCandidate],
+        prices: [String: Decimal],
+        changes24h: [String: Decimal],
+        watchlistIDs: [String],
+        portfolioLimit: Int = 10) -> [OverviewPriceRowData] {
+        let watchlist = OverviewWatchlistStore.normalizedUniqueIDs(watchlistIDs)
+        let watchlistSet = Set(watchlist)
+        let candidatesByCoinGeckoId = Dictionary(
+            grouping: assets,
+            by: { $0.coinGeckoId.lowercased() })
+            .compactMapValues { candidates in
+                candidates.min {
+                    if $0.symbol == $1.symbol {
+                        $0.name < $1.name
+                    } else {
+                        $0.symbol < $1.symbol
+                    }
+                }
+            }
+
+        var rows: [OverviewPriceRowData] = []
+        var seen: Set<String> = []
+
+        for aggregate in sortedAssetAggregates(from: tokens, prices: prices).prefix(max(portfolioLimit, 0)) {
+            let rowID = aggregate.coinGeckoId?.lowercased() ?? aggregate.assetId.uuidString
+            guard !seen.contains(rowID) else {
+                continue
+            }
+            seen.insert(rowID)
+            let coinGeckoId = aggregate.coinGeckoId?.lowercased()
+            rows.append(OverviewPriceRowData(
+                id: rowID,
+                assetId: aggregate.assetId,
+                symbol: aggregate.symbol,
+                name: aggregate.name,
+                coinGeckoId: coinGeckoId,
+                price: coinGeckoId.flatMap { prices[$0] } ?? aggregate.fallbackPrice,
+                change24h: coinGeckoId.flatMap { changes24h[$0] },
+                isWatchlisted: coinGeckoId.map { watchlistSet.contains($0) } ?? false))
+        }
+
+        for coinGeckoId in watchlist where !seen.contains(coinGeckoId) {
+            guard let asset = candidatesByCoinGeckoId[coinGeckoId] else { continue }
+            seen.insert(coinGeckoId)
+            rows.append(OverviewPriceRowData(
+                id: coinGeckoId,
+                assetId: asset.id,
+                symbol: asset.symbol,
+                name: asset.name,
+                coinGeckoId: coinGeckoId,
+                price: prices[coinGeckoId],
+                change24h: changes24h[coinGeckoId],
+                isWatchlisted: true))
+        }
+
+        return rows
+    }
+
+    static func pricePollingIDs(
+        tokens: [TokenEntry],
+        watchlistIDs: [String]) -> [String] {
+        var ids = sortedAssetAggregates(from: tokens, prices: [:])
+            .compactMap { $0.coinGeckoId?.lowercased() }
+
+        ids.append(contentsOf: watchlistIDs)
+        return OverviewWatchlistStore.normalizedUniqueIDs(ids)
+    }
+
+    private struct SliceInput {
+        let id: String
+        let label: String
+        let value: Decimal
+    }
+
+    private static func makeSlices(from inputs: [SliceInput]) -> [OverviewAssetSlice] {
+        let percentages = displayPercentages(for: inputs.map(\.value))
+        return zip(inputs.indices, inputs).map { index, input in
+            OverviewAssetSlice(
+                id: input.id,
+                label: input.label,
+                value: input.value,
+                displayPercent: percentages[index],
+                colorIndex: index)
+        }
+    }
+
+    private static func sortedAssetAggregates(
+        from tokens: [TokenEntry],
+        prices: [String: Decimal]) -> [AssetAggregate] {
+        var aggregates: [UUID: AssetAggregate] = [:]
+
+        for token in tokens where token.role.isPositive {
+            var aggregate = aggregates[token.assetId] ?? AssetAggregate(
+                assetId: token.assetId,
+                symbol: token.symbol,
+                name: token.name,
+                category: token.category,
+                coinGeckoId: token.coinGeckoId,
+                value: 0,
+                amount: 0)
+            aggregate.coinGeckoId = aggregate.coinGeckoId ?? token.coinGeckoId
+            aggregate.value += resolvedValue(for: token, prices: prices)
+            if token.amount > 0 {
+                aggregate.amount += token.amount
+            }
+            aggregates[token.assetId] = aggregate
+        }
+
+        return aggregates.values
+            .filter { $0.value > 0 }
+            .sorted {
+                if $0.value == $1.value {
+                    return $0.symbol.localizedStandardCompare($1.symbol) == .orderedAscending
+                }
+                return $0.value > $1.value
+            }
+    }
+
+    private static func resolvedValue(
+        for token: TokenEntry,
+        prices: [String: Decimal]) -> Decimal {
+        if let coinGeckoId = token.coinGeckoId?.lowercased(), let price = prices[coinGeckoId] {
+            return token.amount * price
+        }
+        return token.usdValue
+    }
+
+    private static func displayPercentages(for values: [Decimal]) -> [Int] {
+        let total = values.reduce(Decimal.zero, +)
+        guard total > 0 else { return Array(repeating: 0, count: values.count) }
+
+        var percentages = values.map { value in
+            let ratio = NSDecimalNumber(decimal: value / total).doubleValue
+            return Int((ratio * 100).rounded())
+        }
+
+        let residual = 100 - percentages.reduce(0, +)
+        if residual != 0, let residualIndex = values.indices.max(by: { values[$0] < values[$1] }) {
+            percentages[residualIndex] += residual
+        }
+
+        return percentages
+    }
+}

--- a/Sources/Portu/Features/Overview/OverviewPositionHelpers.swift
+++ b/Sources/Portu/Features/Overview/OverviewPositionHelpers.swift
@@ -1,0 +1,66 @@
+import PortuCore
+import PortuUI
+import SwiftUI
+
+enum OverviewPositionPricing {
+    static func price(
+        coinGeckoId: String?,
+        amount: Decimal,
+        usdValue: Decimal,
+        prices: [String: Decimal]) -> Decimal {
+        normalizedPrice(coinGeckoId: coinGeckoId, prices: prices)
+            ?? (amount > 0 ? usdValue / amount : 0)
+    }
+
+    static func tokenValue(
+        coinGeckoId: String?,
+        amount: Decimal,
+        usdValue: Decimal,
+        prices: [String: Decimal]) -> Decimal {
+        normalizedPrice(coinGeckoId: coinGeckoId, prices: prices).map { amount * $0 }
+            ?? usdValue
+    }
+
+    static func change24h(
+        coinGeckoId: String?,
+        amount: Decimal,
+        prices: [String: Decimal],
+        changes24h: [String: Decimal]) -> Decimal {
+        guard
+            let coinGeckoId = OverviewWatchlistStore.normalizedID(coinGeckoId),
+            let price = prices[coinGeckoId],
+            let changePercent = changes24h[coinGeckoId]
+        else {
+            return 0
+        }
+        return amount * price * changePercent
+    }
+
+    private static func normalizedPrice(
+        coinGeckoId: String?,
+        prices: [String: Decimal]) -> Decimal? {
+        OverviewWatchlistStore.normalizedID(coinGeckoId).flatMap { prices[$0] }
+    }
+}
+
+enum OverviewPositionChangeTone: Equatable {
+    case favorable
+    case unfavorable
+
+    static func tone(for role: TokenRole, change: Decimal) -> OverviewPositionChangeTone {
+        if role.isBorrow {
+            return change <= 0 ? .favorable : .unfavorable
+        }
+        return change >= 0 ? .favorable : .unfavorable
+    }
+
+    @MainActor
+    var color: Color {
+        switch self {
+        case .favorable:
+            PortuTheme.dashboardSuccess
+        case .unfavorable:
+            PortuTheme.dashboardWarning
+        }
+    }
+}

--- a/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
+++ b/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
@@ -1,4 +1,3 @@
-// Sources/Portu/Features/Overview/OverviewPositionTabs.swift
 import PortuCore
 import PortuUI
 import SwiftData
@@ -10,7 +9,6 @@ struct OverviewPositionTabs: View {
 
     @State private var selectedTab: OverviewTab = .keyChanges
 
-    /// Only positions from active accounts
     private var positions: [Position] {
         allPositions.filter { $0.account?.isActive == true }
     }
@@ -20,54 +18,83 @@ struct OverviewPositionTabs: View {
         case idleStables = "Idle Stables"
         case idleMajors = "Idle Majors"
         case borrowing = "Borrowing"
+        case futures = "Futures"
+        case options = "Options"
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 20) {
-                ForEach(OverviewTab.allCases, id: \.self) { tab in
-                    Button {
-                        selectedTab = tab
-                    } label: {
-                        Text(tab.rawValue)
-                            .font(.system(size: 14, weight: selectedTab == tab ? .semibold : .regular))
-                            .foregroundStyle(selectedTab == tab ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
-                            .padding(.vertical, 4)
-                            .overlay(alignment: .bottom) {
-                                Rectangle()
-                                    .fill(selectedTab == tab ? PortuTheme.dashboardGold : .clear)
-                                    .frame(height: 1)
-                            }
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 24) {
+                    ForEach(OverviewTab.allCases, id: \.self) { tab in
+                        tabButton(tab)
                     }
-                    .buttonStyle(.plain)
                 }
+                .padding(.horizontal, 14)
+                .padding(.top, 12)
             }
 
-            switch selectedTab {
-            case .keyChanges:
-                tokenTable(tokens: keyChangeTokens)
-            case .idleStables:
-                tokenTable(tokens: idleStableTokens)
-            case .idleMajors:
-                tokenTable(tokens: idleMajorTokens)
-            case .borrowing:
-                borrowingView
+            Rectangle()
+                .fill(PortuTheme.dashboardStroke)
+                .frame(height: 1)
+                .padding(.top, 7)
+
+            VStack(alignment: .leading, spacing: 12) {
+                switch selectedTab {
+                case .keyChanges:
+                    positionCards(tokens: keyChangeTokens, emptyTitle: "No key changes")
+                case .idleStables:
+                    positionCards(tokens: idleStableTokens, emptyTitle: "No idle stables")
+                case .idleMajors:
+                    positionCards(tokens: idleMajorTokens, emptyTitle: "No idle majors")
+                case .borrowing:
+                    borrowingView
+                case .futures, .options:
+                    emptyState("No deployed positions")
+                }
             }
+            .padding(14)
         }
+    }
+
+    private func tabButton(_ tab: OverviewTab) -> some View {
+        Button {
+            selectedTab = tab
+        } label: {
+            Text(tab.rawValue)
+                .font(.system(size: 14, weight: selectedTab == tab ? .semibold : .regular))
+                .foregroundStyle(selectedTab == tab ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                .lineLimit(1)
+                .padding(.vertical, 4)
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(selectedTab == tab ? PortuTheme.dashboardGold : .clear)
+                        .frame(height: 1)
+                }
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Token filtering
 
     private var allActiveTokens: [(PositionToken, Position)] {
-        positions.flatMap { pos in pos.tokens.map { ($0, pos) } }
+        positions.flatMap { position in
+            position.tokens.map { ($0, position) }
+        }
     }
 
     private var keyChangeTokens: [(PositionToken, Position)] {
-        // Tokens with largest 24h USD change (absolute value), excluding those without 24h data
         allActiveTokens
             .filter(\.0.role.isPositive)
             .filter { tokenChange24h($0.0) != 0 }
-            .sorted { abs(tokenChange24h($0.0)) > abs(tokenChange24h($1.0)) }
+            .sorted {
+                let lhs = abs(tokenChange24h($0.0))
+                let rhs = abs(tokenChange24h($1.0))
+                if lhs == rhs {
+                    return ($0.0.asset?.symbol ?? "") < ($1.0.asset?.symbol ?? "")
+                }
+                return lhs > rhs
+            }
             .prefix(20)
             .map { ($0.0, $0.1) }
     }
@@ -84,155 +111,328 @@ struct OverviewPositionTabs: View {
 
     private func tokenChange24h(_ token: PositionToken) -> Decimal {
         guard
-            let cgId = token.asset?.coinGeckoId,
-            let price = appState.prices[cgId],
-            let changePct = appState.priceChanges24h[cgId] else { return 0 }
-        return token.amount * price * changePct
+            let coinGeckoId = token.asset?.coinGeckoId,
+            let price = appState.prices[coinGeckoId],
+            let changePercent = appState.priceChanges24h[coinGeckoId]
+        else {
+            return 0
+        }
+        return token.amount * price * changePercent
     }
 
-    // MARK: - Token table (flat rows)
+    // MARK: - Position cards
 
-    private func tokenTable(tokens: [(PositionToken, Position)]) -> some View {
+    private func positionCards(
+        tokens: [(PositionToken, Position)],
+        emptyTitle: String) -> some View {
         Group {
             if tokens.isEmpty {
-                ContentUnavailableView("No assets in this view", systemImage: "tablecells")
-                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
-                    .frame(minHeight: 220)
-                    .frame(maxWidth: .infinity)
-                    .background(PortuTheme.dashboardPanelBackground)
+                emptyState(emptyTitle)
             } else {
-                tokenRowsTable(tokens: tokens)
-            }
-        }
-    }
-
-    private func tokenRowsTable(tokens: [(PositionToken, Position)]) -> some View {
-        Table(of: TokenRowData.self) {
-            TableColumn("Asset") { row in
-                Text(row.symbol).fontWeight(.medium)
-                    .foregroundStyle(PortuTheme.dashboardText)
-            }
-            .width(min: 60, ideal: 80)
-
-            TableColumn("Network / Account") { row in
-                VStack(alignment: .leading) {
-                    if let chain = row.chain {
-                        Text(chain.rawValue.capitalized)
-                            .font(.caption)
-                            .foregroundStyle(PortuTheme.dashboardText)
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(groupedTokens(tokens)) { group in
+                        OverviewPositionGroupCard(
+                            group: group,
+                            price: price,
+                            tokenValue: tokenValue,
+                            tokenChange24h: tokenChange24h)
                     }
-                    Text(row.accountName)
-                        .font(.caption2)
-                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
                 }
             }
-            .width(min: 80, ideal: 120)
-
-            TableColumn("Amount") { row in
-                Text(row.amount, format: .number.precision(.fractionLength(2 ... 6)))
-                    .font(DashboardStyle.monoTableFont)
-            }
-            .width(min: 80, ideal: 100)
-
-            TableColumn("Price") { row in
-                Text(row.price, format: .currency(code: "USD"))
-                    .font(DashboardStyle.monoTableFont)
-            }
-            .width(min: 60, ideal: 80)
-
-            TableColumn("Value") { row in
-                Text(row.value, format: .currency(code: "USD"))
-                    .font(DashboardStyle.monoTableFont)
-            }
-            .width(min: 80, ideal: 100)
-        } rows: {
-            ForEach(tokens.map { makeTokenRowData($0.0, position: $0.1) }, id: \.id) { row in
-                TableRow(row)
-            }
         }
-        .dashboardTable()
-        .frame(minHeight: 260)
     }
 
-    // MARK: - Borrowing view (grouped by protocol)
+    private func emptyState(_ title: String) -> some View {
+        Text(title)
+            .font(.caption)
+            .foregroundStyle(PortuTheme.dashboardTertiaryText)
+            .lineLimit(1)
+            .frame(maxWidth: .infinity, minHeight: 180, alignment: .center)
+    }
+
+    private func groupedTokens(_ tokens: [(PositionToken, Position)]) -> [OverviewPositionGroupData] {
+        var order: [UUID] = []
+        var grouped: [UUID: (position: Position, tokens: [PositionToken])] = [:]
+
+        for (token, position) in tokens {
+            if grouped[position.id] == nil {
+                order.append(position.id)
+                grouped[position.id] = (position, [])
+            }
+            grouped[position.id]?.tokens.append(token)
+        }
+
+        return order.compactMap { id in
+            guard let group = grouped[id] else { return nil }
+            return OverviewPositionGroupData(
+                id: id,
+                position: group.position,
+                tokens: group.tokens)
+        }
+    }
+
+    // MARK: - Borrowing
 
     @ViewBuilder
     private var borrowingView: some View {
-        let borrowPositions = positions.filter { pos in
-            pos.tokens.contains { $0.role.isBorrow }
+        let borrowPositions = positions.filter { position in
+            position.tokens.contains { $0.role.isBorrow }
         }
-        if borrowPositions.isEmpty {
-            ContentUnavailableView(
-                "No Borrowing",
-                systemImage: "arrow.down.circle",
-                description: Text("No active borrow positions"))
-                .foregroundStyle(PortuTheme.dashboardSecondaryText)
-        } else {
-            ForEach(borrowPositions, id: \.id) { pos in
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(pos.protocolName ?? "Unknown Protocol")
-                            .font(DashboardStyle.sectionTitleFont)
-                        if let chain = pos.chain {
-                            CapsuleBadge(chain.rawValue.capitalized)
-                        }
-                        Spacer()
-                        if let hf = pos.healthFactor {
-                            Text("HF: \(hf, specifier: "%.2f")")
-                                .font(.caption)
-                                .foregroundStyle(hf < 1.2 ? .red : hf < 1.5 ? .orange : .green)
-                        }
-                    }
 
-                    // Token rows
-                    ForEach(pos.tokens, id: \.id) { token in
-                        HStack {
-                            Text(token.role.displayLabel)
-                                .font(.caption)
-                                .foregroundStyle(token.role.displayColor)
-                            Text(token.asset?.symbol ?? "???")
-                            Spacer()
-                            Text(token.amount, format: .number.precision(.fractionLength(2 ... 6)))
-                            Text(tokenValue(token), format: .currency(code: "USD"))
-                                .frame(width: 100, alignment: .trailing)
-                        }
-                        .font(DashboardStyle.tableFont)
-                    }
+        if borrowPositions.isEmpty {
+            emptyState("No borrowing")
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(borrowPositions, id: \.id) { position in
+                    OverviewPositionGroupCard(
+                        group: OverviewPositionGroupData(
+                            id: position.id,
+                            position: position,
+                            tokens: position.tokens.filter(\.role.isBorrow)),
+                        price: price,
+                        tokenValue: tokenValue,
+                        tokenChange24h: tokenChange24h)
                 }
-                .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
             }
         }
     }
 
     // MARK: - Helpers
 
-    private struct TokenRowData: Identifiable {
-        let id: UUID
-        let symbol: String
-        let chain: Chain?
-        let accountName: String
-        let amount: Decimal
-        let price: Decimal
-        let value: Decimal
-    }
-
-    private func makeTokenRowData(_ token: PositionToken, position: Position) -> TokenRowData {
-        let price = token.asset?.coinGeckoId.flatMap { appState.prices[$0] }
+    private func price(_ token: PositionToken) -> Decimal {
+        token.asset?.coinGeckoId.flatMap { appState.prices[$0] }
             ?? (token.amount > 0 ? token.usdValue / token.amount : 0)
-        let value = token.asset?.coinGeckoId.flatMap { appState.prices[$0] }.map { token.amount * $0 }
-            ?? token.usdValue
-
-        return TokenRowData(
-            id: token.id,
-            symbol: token.asset?.symbol ?? "???",
-            chain: position.chain,
-            accountName: position.account?.name ?? "",
-            amount: token.amount,
-            price: price,
-            value: value)
     }
 
     private func tokenValue(_ token: PositionToken) -> Decimal {
-        token.resolvedUSDValue(prices: appState.prices)
+        token.asset?.coinGeckoId.flatMap { appState.prices[$0] }.map { token.amount * $0 }
+            ?? token.usdValue
+    }
+}
+
+private struct OverviewPositionGroupData: Identifiable {
+    let id: UUID
+    let position: Position
+    let tokens: [PositionToken]
+}
+
+private struct OverviewPositionGroupCard: View {
+    let group: OverviewPositionGroupData
+    let price: (PositionToken) -> Decimal
+    let tokenValue: (PositionToken) -> Decimal
+    let tokenChange24h: (PositionToken) -> Decimal
+
+    private var groupValue: Decimal {
+        group.tokens.reduce(Decimal.zero) { partial, token in
+            let value = tokenValue(token)
+            return token.role.isBorrow ? partial - value : partial + value
+        }
+    }
+
+    private var groupChange: Decimal {
+        group.tokens.reduce(Decimal.zero) { partial, token in
+            let change = tokenChange24h(token)
+            return token.role.isBorrow ? partial - change : partial + change
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            groupHeader
+
+            VStack(spacing: 0) {
+                columnHeader
+
+                ForEach(group.tokens, id: \.id) { token in
+                    OverviewPositionTokenRow(
+                        token: token,
+                        position: group.position,
+                        price: price(token),
+                        value: tokenValue(token),
+                        change24h: tokenChange24h(token))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(PortuTheme.dashboardPanelElevatedBackground.opacity(0.65)))
+        }
+    }
+
+    private var groupHeader: some View {
+        HStack(spacing: 10) {
+            Image(systemName: iconName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(PortuTheme.dashboardGold)
+                .frame(width: 18)
+
+            Text(groupTitle)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(PortuTheme.dashboardText)
+                .lineLimit(1)
+
+            Spacer(minLength: 10)
+
+            Text(groupValue, format: .currency(code: "USD").precision(.fractionLength(0)))
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(PortuTheme.dashboardText)
+                .lineLimit(1)
+
+            Text(groupChange, format: .currency(code: "USD").precision(.fractionLength(0)))
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundStyle(groupChange >= 0 ? PortuTheme.dashboardSuccess : PortuTheme.dashboardWarning)
+                .lineLimit(1)
+        }
+        .padding(.bottom, 8)
+    }
+
+    private var columnHeader: some View {
+        HStack(spacing: 12) {
+            Text("Position")
+                .frame(width: 250, alignment: .leading)
+            Text("Asset")
+                .frame(width: 90, alignment: .leading)
+            Text("Asset Price (24h)")
+                .frame(width: 140, alignment: .trailing)
+            Text("Asset Amount (24h)")
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .font(.system(size: 11))
+        .foregroundStyle(PortuTheme.dashboardTertiaryText)
+        .lineLimit(1)
+        .padding(.bottom, 8)
+    }
+
+    private var groupTitle: String {
+        group.position.protocolName ?? group.position.account?.name ?? "Wallet"
+    }
+
+    private var iconName: String {
+        switch group.position.positionType {
+        case .idle: "wallet.pass"
+        case .lending: "building.columns"
+        case .staking: "diamond"
+        case .farming, .liquidityPool: "leaf"
+        case .vesting: "clock"
+        case .other: "square.grid.2x2"
+        }
+    }
+}
+
+private struct OverviewPositionTokenRow: View {
+    let token: PositionToken
+    let position: Position
+    let price: Decimal
+    let value: Decimal
+    let change24h: Decimal
+
+    var body: some View {
+        HStack(spacing: 12) {
+            positionContext
+                .frame(width: 250, alignment: .leading)
+
+            HStack(spacing: 7) {
+                assetDot
+                Text(token.asset?.symbol ?? "???")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
+            }
+            .frame(width: 90, alignment: .leading)
+
+            HStack(spacing: 8) {
+                Text(price, format: .currency(code: "USD").precision(.fractionLength(0 ... 5)))
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
+
+                Text(change24h, format: .currency(code: "USD").precision(.fractionLength(0)))
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(change24h >= 0 ? PortuTheme.dashboardSuccess : PortuTheme.dashboardWarning)
+                    .lineLimit(1)
+            }
+            .frame(width: 140, alignment: .trailing)
+
+            HStack(spacing: 8) {
+                Text(token.amount, format: .number.precision(.fractionLength(2 ... 6)))
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
+
+                if token.role.isBorrow {
+                    Text("Close")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(PortuTheme.dashboardWarning)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(PortuTheme.dashboardWarning.opacity(0.12)))
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .stroke(PortuTheme.dashboardWarning.opacity(0.55), lineWidth: 1))
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .frame(minHeight: 42)
+    }
+
+    private var positionContext: some View {
+        HStack(spacing: 8) {
+            Text(positionLabel)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(roleColor)
+                .lineLimit(1)
+
+            if let chain = position.chain {
+                HStack(spacing: 5) {
+                    Image(systemName: "circle.fill")
+                        .font(.system(size: 6))
+                    Text(chain.rawValue.capitalized)
+                        .font(.system(size: 12))
+                }
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .lineLimit(1)
+            }
+
+            Text(token.role.rawValue)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .lineLimit(1)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(PortuTheme.dashboardGoldMuted.opacity(0.35)))
+        }
+    }
+
+    private var assetDot: some View {
+        ZStack {
+            Circle()
+                .fill(PortuTheme.dashboardGoldMuted)
+            Text(String((token.asset?.symbol ?? "?").prefix(1)))
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(PortuTheme.dashboardText)
+        }
+        .frame(width: 16, height: 16)
+    }
+
+    private var positionLabel: String {
+        switch position.positionType {
+        case .idle: "Idle on"
+        case .lending: "Lending on"
+        case .staking: "Staked on"
+        case .farming, .liquidityPool: "Yield on"
+        case .vesting: "Vesting on"
+        case .other: "Position on"
+        }
+    }
+
+    private var roleColor: Color {
+        token.role.isBorrow ? PortuTheme.dashboardWarning : PortuTheme.dashboardText
     }
 }

--- a/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
+++ b/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
@@ -114,14 +114,11 @@ struct OverviewPositionTabs: View {
     }
 
     private func tokenChange24h(_ token: PositionToken) -> Decimal {
-        guard
-            let coinGeckoId = token.asset?.coinGeckoId,
-            let price = appState.prices[coinGeckoId],
-            let changePercent = appState.priceChanges24h[coinGeckoId]
-        else {
-            return 0
-        }
-        return token.amount * price * changePercent
+        OverviewPositionPricing.change24h(
+            coinGeckoId: token.asset?.coinGeckoId,
+            amount: token.amount,
+            prices: appState.prices,
+            changes24h: appState.priceChanges24h)
     }
 
     // MARK: - Position cards
@@ -204,13 +201,19 @@ struct OverviewPositionTabs: View {
     // MARK: - Helpers
 
     private func price(_ token: PositionToken) -> Decimal {
-        token.asset?.coinGeckoId.flatMap { appState.prices[$0] }
-            ?? (token.amount > 0 ? token.usdValue / token.amount : 0)
+        OverviewPositionPricing.price(
+            coinGeckoId: token.asset?.coinGeckoId,
+            amount: token.amount,
+            usdValue: token.usdValue,
+            prices: appState.prices)
     }
 
     private func tokenValue(_ token: PositionToken) -> Decimal {
-        token.asset?.coinGeckoId.flatMap { appState.prices[$0] }.map { token.amount * $0 }
-            ?? token.usdValue
+        OverviewPositionPricing.tokenValue(
+            coinGeckoId: token.asset?.coinGeckoId,
+            amount: token.amount,
+            usdValue: token.usdValue,
+            prices: appState.prices)
     }
 }
 
@@ -359,7 +362,7 @@ private struct OverviewPositionTokenRow: View {
 
                 Text(change24h, format: .currency(code: "USD").precision(.fractionLength(0)))
                     .font(.system(size: 12, design: .monospaced))
-                    .foregroundStyle(change24h >= 0 ? PortuTheme.dashboardSuccess : PortuTheme.dashboardWarning)
+                    .foregroundStyle(OverviewPositionChangeTone.tone(for: token.role, change: change24h).color)
                     .lineLimit(1)
             }
             .frame(width: 140, alignment: .trailing)

--- a/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
+++ b/Sources/Portu/Features/Overview/OverviewPositionTabs.swift
@@ -86,17 +86,21 @@ struct OverviewPositionTabs: View {
     private var keyChangeTokens: [(PositionToken, Position)] {
         allActiveTokens
             .filter(\.0.role.isPositive)
-            .filter { tokenChange24h($0.0) != 0 }
+            .compactMap { token, position -> TokenChangeCandidate? in
+                let change = tokenChange24h(token)
+                guard change != 0 else { return nil }
+                return TokenChangeCandidate(token: token, position: position, change: change)
+            }
             .sorted {
-                let lhs = abs(tokenChange24h($0.0))
-                let rhs = abs(tokenChange24h($1.0))
+                let lhs = abs($0.change)
+                let rhs = abs($1.change)
                 if lhs == rhs {
-                    return ($0.0.asset?.symbol ?? "") < ($1.0.asset?.symbol ?? "")
+                    return ($0.token.asset?.symbol ?? "") < ($1.token.asset?.symbol ?? "")
                 }
                 return lhs > rhs
             }
             .prefix(20)
-            .map { ($0.0, $0.1) }
+            .map { ($0.token, $0.position) }
     }
 
     private var idleStableTokens: [(PositionToken, Position)] {
@@ -216,6 +220,12 @@ private struct OverviewPositionGroupData: Identifiable {
     let tokens: [PositionToken]
 }
 
+private struct TokenChangeCandidate {
+    let token: PositionToken
+    let position: Position
+    let change: Decimal
+}
+
 private struct OverviewPositionGroupCard: View {
     let group: OverviewPositionGroupData
     let price: (PositionToken) -> Decimal
@@ -293,9 +303,9 @@ private struct OverviewPositionGroupCard: View {
                 .frame(width: 250, alignment: .leading)
             Text("Asset")
                 .frame(width: 90, alignment: .leading)
-            Text("Asset Price (24h)")
+            Text("Price / 24h")
                 .frame(width: 140, alignment: .trailing)
-            Text("Asset Amount (24h)")
+            Text("Amount")
                 .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .font(.system(size: 11))

--- a/Sources/Portu/Features/Overview/OverviewSummaryCards.swift
+++ b/Sources/Portu/Features/Overview/OverviewSummaryCards.swift
@@ -30,7 +30,7 @@ struct OverviewSummaryCards: View {
         return [
             ("Stablecoins & Fiat", stablesFiat),
             ("Majors", majors),
-            ("Tokens & Memes", tokens)
+            ("Tokens & Memecoins", tokens)
         ]
     }
 
@@ -71,30 +71,33 @@ struct OverviewSummaryCards: View {
             Text(title)
                 .font(DashboardStyle.sectionTitleFont)
                 .foregroundStyle(PortuTheme.dashboardText)
-            let total = items.reduce(Decimal.zero) { $0 + $1.1 }
-            Text(total, format: .currency(code: "USD"))
-                .font(.system(size: 18, weight: .semibold, design: .monospaced))
-                .foregroundStyle(PortuTheme.dashboardText)
+                .lineLimit(1)
 
             if items.isEmpty {
-                Text("Coming soon")
+                Text("No deployed positions")
                     .font(.caption)
                     .foregroundStyle(PortuTheme.dashboardTertiaryText)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             } else {
                 ForEach(items, id: \.0) { label, value in
-                    HStack {
+                    HStack(spacing: 8) {
                         Text(label)
                             .font(.caption)
                             .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
                         Spacer()
                         Text(value, format: .currency(code: "USD"))
                             .font(.system(size: 12, design: .monospaced))
                             .foregroundStyle(PortuTheme.dashboardText)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
                     }
                 }
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 116, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
         .dashboardCard()
     }
 }

--- a/Sources/Portu/Features/Overview/OverviewSummaryCards.swift
+++ b/Sources/Portu/Features/Overview/OverviewSummaryCards.swift
@@ -74,7 +74,7 @@ struct OverviewSummaryCards: View {
                 .lineLimit(1)
 
             if items.isEmpty {
-                Text("No deployed positions")
+                Text(OverviewSummaryCardText.emptyState(for: title))
                     .font(.caption)
                     .foregroundStyle(PortuTheme.dashboardTertiaryText)
                     .lineLimit(1)
@@ -99,5 +99,11 @@ struct OverviewSummaryCards: View {
         }
         .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
         .dashboardCard()
+    }
+}
+
+enum OverviewSummaryCardText {
+    static func emptyState(for title: String) -> String {
+        title == "Futures" ? "Coming soon" : "No deployed positions"
     }
 }

--- a/Sources/Portu/Features/Overview/OverviewTopBar.swift
+++ b/Sources/Portu/Features/Overview/OverviewTopBar.swift
@@ -47,24 +47,21 @@ struct OverviewTopBar: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Portfolio value")
-                    .font(DashboardStyle.labelFont)
-                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
-                Text(totalValue, format: .currency(code: "USD"))
-                    .font(DashboardStyle.heroValueFont)
-                    .foregroundStyle(PortuTheme.dashboardText)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.65)
-            }
+        VStack(alignment: .leading, spacing: 18) {
+            Text(totalValue, format: .currency(code: "USD").precision(.fractionLength(0)))
+                .font(DashboardStyle.heroValueFont)
+                .foregroundStyle(PortuTheme.dashboardText)
+                .lineLimit(1)
+                .minimumScaleFactor(0.65)
 
             VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 4) {
                     Text(change24h, format: .currency(code: "USD"))
+                        .lineLimit(1)
                     Spacer()
                     Text("$ change 24h")
                         .foregroundStyle(PortuTheme.dashboardTertiaryText)
+                        .lineLimit(1)
                 }
                 .foregroundStyle(PortuTheme.changeColor(for: change24h))
 
@@ -72,9 +69,11 @@ struct OverviewTopBar: View {
                     Image(systemName: changePct >= 0 ? "arrowtriangle.up.fill" : "arrowtriangle.down.fill")
                         .font(.caption2)
                     Text(changePct, format: .percent.precision(.fractionLength(2)))
+                        .lineLimit(1)
                     Spacer()
                     Text("% change 24h")
                         .foregroundStyle(PortuTheme.dashboardTertiaryText)
+                        .lineLimit(1)
                 }
                 .foregroundStyle(PortuTheme.changeColor(for: changePct))
             }

--- a/Sources/Portu/Features/Overview/OverviewView.swift
+++ b/Sources/Portu/Features/Overview/OverviewView.swift
@@ -39,7 +39,7 @@ struct OverviewView: View {
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                         InspectorPanel(store: store)
-                            .frame(width: PortuTheme.dashboardInspectorWidth + 22)
+                            .frame(width: PortuTheme.dashboardInspectorWidth + OverviewLayout.inspectorRailWidthAdjustment)
                     }
                 } else {
                     compactScrollColumn
@@ -134,6 +134,10 @@ struct OverviewView: View {
                 .dashboardCard(horizontalPadding: 0, verticalPadding: 0)
         }
     }
+}
+
+enum OverviewLayout {
+    static let inspectorRailWidthAdjustment: CGFloat = 22
 }
 
 enum OverviewSyncButtonStyleMetrics {

--- a/Sources/Portu/Features/Overview/OverviewView.swift
+++ b/Sources/Portu/Features/Overview/OverviewView.swift
@@ -8,66 +8,195 @@ import SwiftUI
 struct OverviewView: View {
     let store: StoreOf<AppFeature>
     @Environment(AppState.self) private var appState
+    @Query private var allTokens: [PositionToken]
+    @AppStorage(OverviewWatchlistStore.key) private var watchlistRaw = "[]"
+
+    private var tokenEntries: [TokenEntry] {
+        TokenEntry.fromActiveTokens(allTokens)
+    }
+
+    private var watchlistIDs: [String] {
+        OverviewWatchlistStore.decode(watchlistRaw)
+    }
+
+    private var pricePollingIDs: [String] {
+        OverviewFeature.pricePollingIDs(tokens: tokenEntries, watchlistIDs: watchlistIDs)
+    }
 
     var body: some View {
-        HSplitView {
-            ScrollView {
-                VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
-                    DashboardPageHeader("Overview") {
-                        HStack(spacing: 10) {
-                            if let lastPriceUpdate = store.lastPriceUpdate {
-                                Text("Updated \(lastPriceUpdate, format: .relative(presentation: .named))")
-                                    .font(.caption)
-                                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
-                            } else {
-                                Text("Not updated yet")
-                                    .font(.caption)
-                                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
-                            }
+        GeometryReader { proxy in
+            let isWide = proxy.size.width >= 1080
 
-                            if case .syncing = appState.syncStatus {
-                                ProgressView()
-                                    .controlSize(.small)
-                                    .tint(PortuTheme.dashboardGold)
-                            } else {
-                                Button {
-                                    appState.onSyncRequested?()
-                                } label: {
-                                    Label("Sync", systemImage: "arrow.triangle.2.circlepath")
-                                }
-                                .dashboardControl()
-                            }
-                        }
+            VStack(alignment: .leading, spacing: 0) {
+                pageHeader
+                    .padding(.horizontal, DashboardStyle.pagePadding)
+                    .padding(.top, DashboardStyle.pagePadding)
+                    .padding(.bottom, 10)
+
+                if isWide {
+                    HStack(alignment: .top, spacing: 0) {
+                        mainScrollColumn
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                        InspectorPanel(store: store)
+                            .frame(width: PortuTheme.dashboardInspectorWidth + 22)
                     }
-
-                    DashboardCard {
-                        HStack(alignment: .top, spacing: 20) {
-                            OverviewTopBar()
-                                .frame(width: 250, alignment: .leading)
-
-                            PortfolioValueChart()
-                                .frame(maxWidth: .infinity)
-                        }
-                    }
-
-                    OverviewSummaryCards()
-
-                    OverviewPositionTabs()
-                        .dashboardCard()
+                } else {
+                    compactScrollColumn
                 }
-                .padding(DashboardStyle.pagePadding)
             }
-            .frame(minWidth: 500)
-            .layoutPriority(3)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(PortuTheme.dashboardBackground)
-
-            InspectorPanel(store: store)
-                .frame(
-                    minWidth: PortuTheme.dashboardInspectorWidth,
-                    idealWidth: PortuTheme.dashboardInspectorWidth,
-                    maxWidth: 360)
-                .layoutPriority(1)
         }
         .dashboardPage()
+        .task(id: pricePollingIDs) {
+            if pricePollingIDs.isEmpty {
+                store.send(.stopPricePolling)
+            } else {
+                store.send(.startPricePolling(pricePollingIDs))
+            }
+        }
+        .onDisappear {
+            store.send(.stopPricePolling)
+        }
+    }
+
+    private var pageHeader: some View {
+        DashboardPageHeader("Overview") {
+            HStack(spacing: 12) {
+                if let lastPriceUpdate = store.lastPriceUpdate {
+                    Text("Updated \(lastPriceUpdate, format: .relative(presentation: .named))")
+                        .font(.caption)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                        .lineLimit(1)
+                } else {
+                    Text("Not updated yet")
+                        .font(.caption)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                        .lineLimit(1)
+                }
+
+                if case .syncing = appState.syncStatus {
+                    Button {} label: {
+                        OverviewSyncButtonLabel(isSyncing: true)
+                    }
+                    .buttonStyle(OverviewSyncButtonStyle())
+                    .disabled(true)
+                } else {
+                    Button {
+                        appState.onSyncRequested?()
+                    } label: {
+                        OverviewSyncButtonLabel(isSyncing: false)
+                    }
+                    .buttonStyle(OverviewSyncButtonStyle())
+                }
+            }
+        }
+    }
+
+    private var mainScrollColumn: some View {
+        ScrollView {
+            overviewMainContent
+                .padding(.horizontal, DashboardStyle.pagePadding)
+                .padding(.bottom, DashboardStyle.pagePadding)
+        }
+        .background(PortuTheme.dashboardBackground)
+    }
+
+    private var compactScrollColumn: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+                overviewMainContent
+                InspectorPanel(store: store, showsLeadingDivider: false)
+                    .dashboardCard(horizontalPadding: 0, verticalPadding: 0)
+            }
+            .padding(.horizontal, DashboardStyle.pagePadding)
+            .padding(.bottom, DashboardStyle.pagePadding)
+        }
+        .background(PortuTheme.dashboardBackground)
+    }
+
+    private var overviewMainContent: some View {
+        VStack(alignment: .leading, spacing: PortuTheme.dashboardContentSpacing) {
+            DashboardCard {
+                HStack(alignment: .top, spacing: 22) {
+                    OverviewTopBar()
+                        .frame(width: 260, alignment: .leading)
+
+                    PortfolioValueChart()
+                        .frame(maxWidth: .infinity)
+                }
+            }
+
+            OverviewSummaryCards()
+
+            OverviewPositionTabs()
+                .dashboardCard(horizontalPadding: 0, verticalPadding: 0)
+        }
+    }
+}
+
+enum OverviewSyncButtonStyleMetrics {
+    static let iconName = "arrow.triangle.2.circlepath"
+    static let height: CGFloat = 30
+    static let cornerRadius: CGFloat = 6
+    static let horizontalPadding: CGFloat = 11
+    static let labelSpacing: CGFloat = 7
+}
+
+private struct OverviewSyncButtonLabel: View {
+    let isSyncing: Bool
+
+    var body: some View {
+        HStack(spacing: OverviewSyncButtonStyleMetrics.labelSpacing) {
+            Text("Sync")
+            if isSyncing {
+                ProgressView()
+                    .controlSize(.small)
+                    .scaleEffect(0.62)
+                    .frame(width: 12, height: 12)
+                    .tint(PortuTheme.dashboardGold)
+            } else {
+                Image(systemName: OverviewSyncButtonStyleMetrics.iconName)
+                    .font(.system(size: 11, weight: .bold))
+            }
+        }
+        .lineLimit(1)
+    }
+}
+
+private struct OverviewSyncButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(isEnabled ? PortuTheme.dashboardText : PortuTheme.dashboardTertiaryText)
+            .padding(.horizontal, OverviewSyncButtonStyleMetrics.horizontalPadding)
+            .frame(height: OverviewSyncButtonStyleMetrics.height)
+            .background(
+                RoundedRectangle(cornerRadius: OverviewSyncButtonStyleMetrics.cornerRadius, style: .continuous)
+                    .fill(backgroundColor(isPressed: configuration.isPressed)))
+            .overlay(
+                RoundedRectangle(cornerRadius: OverviewSyncButtonStyleMetrics.cornerRadius, style: .continuous)
+                    .stroke(borderColor(isPressed: configuration.isPressed), lineWidth: 1))
+            .contentShape(
+                RoundedRectangle(cornerRadius: OverviewSyncButtonStyleMetrics.cornerRadius, style: .continuous))
+            .opacity(isEnabled ? 1 : 0.72)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+
+    private func backgroundColor(isPressed: Bool) -> Color {
+        if isPressed {
+            return PortuTheme.dashboardGoldMuted.opacity(0.52)
+        }
+        return PortuTheme.dashboardGoldMuted.opacity(0.34)
+    }
+
+    private func borderColor(isPressed: Bool) -> Color {
+        if isPressed {
+            return PortuTheme.dashboardGold.opacity(0.58)
+        }
+        return PortuTheme.dashboardGold.opacity(0.34)
     }
 }

--- a/Sources/Portu/Features/Overview/PortfolioValueChart.swift
+++ b/Sources/Portu/Features/Overview/PortfolioValueChart.swift
@@ -9,31 +9,20 @@ struct PortfolioValueChart: View {
     @Query(sort: \PortfolioSnapshot.timestamp)
     private var snapshots: [PortfolioSnapshot]
 
-    @State private var selectedRange: ChartTimeRange = .oneMonth
-
     private var filteredSnapshots: [PortfolioSnapshot] {
-        let start = selectedRange.startDate
+        let start = ChartTimeRange.oneMonth.startDate
         return snapshots.filter { $0.timestamp >= start }
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Picker("Range", selection: $selectedRange) {
-                ForEach([ChartTimeRange.oneWeek, .oneMonth, .threeMonths, .oneYear, .ytd], id: \.self) { range in
-                    Text(range.rawValue).tag(range)
-                }
-            }
-            .pickerStyle(.segmented)
-            .frame(maxWidth: 300)
-            .dashboardControl()
-
+        VStack(alignment: .leading, spacing: 0) {
             if filteredSnapshots.isEmpty {
                 ContentUnavailableView(
                     "No Data",
                     systemImage: "chart.line.uptrend.xyaxis",
                     description: Text("Sync your accounts to see portfolio history"))
                     .foregroundStyle(PortuTheme.dashboardSecondaryText)
-                    .frame(height: 190)
+                    .frame(height: 172)
             } else {
                 Chart(filteredSnapshots, id: \.id) { snapshot in
                     AreaMark(
@@ -64,7 +53,7 @@ struct PortfolioValueChart: View {
                 .chartXAxis {
                     AxisMarks()
                 }
-                .frame(height: 190)
+                .frame(height: 172)
             }
         }
     }

--- a/Sources/Portu/Features/Overview/PriceWatchlist.swift
+++ b/Sources/Portu/Features/Overview/PriceWatchlist.swift
@@ -167,7 +167,7 @@ struct PriceWatchlist: View {
 
     private var priceHeader: some View {
         HStack(spacing: 6) {
-            Text("Top Portfolio Assets")
+            Text(PriceWatchlistText.priceHeaderTitle)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text("Price")
                 .frame(width: 104, alignment: .trailing)
@@ -195,6 +195,10 @@ struct PriceWatchlist: View {
         watchlistRaw = OverviewWatchlistStore.encode(
             OverviewWatchlistStore.remove(coinGeckoId, from: watchlistIDs))
     }
+}
+
+enum PriceWatchlistText {
+    static let priceHeaderTitle = "Portfolio + Watchlist"
 }
 
 private struct PriceCountdownText: View {

--- a/Sources/Portu/Features/Overview/PriceWatchlist.swift
+++ b/Sources/Portu/Features/Overview/PriceWatchlist.swift
@@ -37,27 +37,10 @@ struct PriceWatchlist: View {
     }
 
     private var matchingAssets: [OverviewAssetCandidate] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return [] }
-        let existing = Set(watchlistIDs)
-
-        return assetCandidates
-            .filter { asset in
-                let coinGeckoId = OverviewWatchlistStore.normalize(asset.coinGeckoId)
-                return !existing.contains(coinGeckoId)
-                    && !coinGeckoId.isEmpty
-                    && (asset.symbol.localizedCaseInsensitiveContains(query)
-                        || asset.name.localizedCaseInsensitiveContains(query)
-                        || asset.coinGeckoId.localizedCaseInsensitiveContains(query))
-            }
-            .sorted {
-                if $0.symbol == $1.symbol {
-                    return $0.name < $1.name
-                }
-                return $0.symbol < $1.symbol
-            }
-            .prefix(5)
-            .map(\.self)
+        OverviewFeature.watchlistSuggestions(
+            assets: assetCandidates,
+            watchlistIDs: watchlistIDs,
+            query: searchText)
     }
 
     var body: some View {

--- a/Sources/Portu/Features/Overview/PriceWatchlist.swift
+++ b/Sources/Portu/Features/Overview/PriceWatchlist.swift
@@ -10,7 +10,6 @@ struct PriceWatchlist: View {
     @Query private var tokens: [PositionToken]
     @AppStorage(OverviewWatchlistStore.key) private var watchlistRaw = "[]"
     @State private var searchText = ""
-    @State private var secondsRemaining = Int(PricePollingSettings.defaultRefreshIntervalSeconds)
 
     private var tokenEntries: [TokenEntry] {
         TokenEntry.fromActiveTokens(tokens)
@@ -20,6 +19,10 @@ struct PriceWatchlist: View {
         OverviewAssetCandidate.fromAssets(assets)
     }
 
+    private var assetCandidatesByCoinGeckoId: [String: OverviewAssetCandidate] {
+        OverviewFeature.assetCandidatesByCoinGeckoId(from: assetCandidates)
+    }
+
     private var watchlistIDs: [String] {
         OverviewWatchlistStore.decode(watchlistRaw)
     }
@@ -27,7 +30,7 @@ struct PriceWatchlist: View {
     private var rows: [OverviewPriceRowData] {
         OverviewFeature.priceRows(
             tokens: tokenEntries,
-            assets: assetCandidates,
+            assetsByCoinGeckoId: assetCandidatesByCoinGeckoId,
             prices: appState.prices,
             changes24h: appState.priceChanges24h,
             watchlistIDs: watchlistIDs)
@@ -40,7 +43,9 @@ struct PriceWatchlist: View {
 
         return assetCandidates
             .filter { asset in
-                !existing.contains(asset.coinGeckoId)
+                let coinGeckoId = OverviewWatchlistStore.normalize(asset.coinGeckoId)
+                return !existing.contains(coinGeckoId)
+                    && !coinGeckoId.isEmpty
                     && (asset.symbol.localizedCaseInsensitiveContains(query)
                         || asset.name.localizedCaseInsensitiveContains(query)
                         || asset.coinGeckoId.localizedCaseInsensitiveContains(query))
@@ -67,10 +72,9 @@ struct PriceWatchlist: View {
                 Spacer()
             }
 
-            Text("Updating in \(secondsRemaining)s")
-                .font(.caption)
-                .foregroundStyle(PortuTheme.dashboardSecondaryText)
-                .lineLimit(1)
+            PriceCountdownText(
+                lastPriceUpdate: appState.lastPriceUpdate,
+                refreshInterval: PricePollingSettings.refreshIntervalSeconds())
 
             watchlistSearchField
 
@@ -99,19 +103,6 @@ struct PriceWatchlist: View {
                             .fill(PortuTheme.dashboardStroke.opacity(0.75))
                             .frame(height: 1)
                     }
-                }
-            }
-        }
-        .task(id: appState.lastPriceUpdate) {
-            resetCountdown()
-            while !Task.isCancelled {
-                do {
-                    try await Task.sleep(for: .seconds(1))
-                } catch {
-                    return
-                }
-                if secondsRemaining > 0 {
-                    secondsRemaining -= 1
                 }
             }
         }
@@ -221,9 +212,26 @@ struct PriceWatchlist: View {
         watchlistRaw = OverviewWatchlistStore.encode(
             OverviewWatchlistStore.remove(coinGeckoId, from: watchlistIDs))
     }
+}
 
-    private func resetCountdown() {
-        secondsRemaining = Int(PricePollingSettings.refreshIntervalSeconds())
+private struct PriceCountdownText: View {
+    let lastPriceUpdate: Date?
+    let refreshInterval: TimeInterval
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            Text("Updating in \(secondsRemaining(at: context.date))s")
+                .font(.caption)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .lineLimit(1)
+        }
+    }
+
+    private func secondsRemaining(at date: Date) -> Int {
+        OverviewPriceCountdown.secondsRemaining(
+            lastPriceUpdate: lastPriceUpdate,
+            refreshInterval: refreshInterval,
+            now: date)
     }
 }
 

--- a/Sources/Portu/Features/Overview/PriceWatchlist.swift
+++ b/Sources/Portu/Features/Overview/PriceWatchlist.swift
@@ -7,55 +7,311 @@ import SwiftUI
 struct PriceWatchlist: View {
     @Environment(AppState.self) private var appState
     @Query private var assets: [Asset]
+    @Query private var tokens: [PositionToken]
+    @AppStorage(OverviewWatchlistStore.key) private var watchlistRaw = "[]"
+    @State private var searchText = ""
+    @State private var secondsRemaining = Int(PricePollingSettings.defaultRefreshIntervalSeconds)
 
-    /// Top assets by current price (those with coinGeckoId for live pricing)
-    private var watchlistAssets: [Asset] {
-        assets
-            .compactMap { asset -> (Asset, Decimal)? in
-                guard let cgId = asset.coinGeckoId else { return nil }
-                return (asset, appState.prices[cgId] ?? 0)
+    private var tokenEntries: [TokenEntry] {
+        TokenEntry.fromActiveTokens(tokens)
+    }
+
+    private var assetCandidates: [OverviewAssetCandidate] {
+        OverviewAssetCandidate.fromAssets(assets)
+    }
+
+    private var watchlistIDs: [String] {
+        OverviewWatchlistStore.decode(watchlistRaw)
+    }
+
+    private var rows: [OverviewPriceRowData] {
+        OverviewFeature.priceRows(
+            tokens: tokenEntries,
+            assets: assetCandidates,
+            prices: appState.prices,
+            changes24h: appState.priceChanges24h,
+            watchlistIDs: watchlistIDs)
+    }
+
+    private var matchingAssets: [OverviewAssetCandidate] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return [] }
+        let existing = Set(watchlistIDs)
+
+        return assetCandidates
+            .filter { asset in
+                !existing.contains(asset.coinGeckoId)
+                    && (asset.symbol.localizedCaseInsensitiveContains(query)
+                        || asset.name.localizedCaseInsensitiveContains(query)
+                        || asset.coinGeckoId.localizedCaseInsensitiveContains(query))
             }
-            .sorted { $0.1 > $1.1 }
-            .prefix(10)
-            .map(\.0)
+            .sorted {
+                if $0.symbol == $1.symbol {
+                    return $0.name < $1.name
+                }
+                return $0.symbol < $1.symbol
+            }
+            .prefix(5)
+            .map(\.self)
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Prices")
-                .font(DashboardStyle.sectionTitleFont)
-                .foregroundStyle(PortuTheme.dashboardText)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Prices")
+                    .font(DashboardStyle.sectionTitleFont)
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
 
-            ForEach(watchlistAssets, id: \.id) { asset in
-                HStack {
-                    Text(asset.symbol)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(PortuTheme.dashboardText)
-                    Spacer()
+                livePill
+                Spacer()
+            }
 
-                    if let cgId = asset.coinGeckoId, let price = appState.prices[cgId] {
-                        VStack(alignment: .trailing) {
-                            Text(price, format: .currency(code: "USD"))
-                                .font(.system(size: 12, design: .monospaced))
-                                .foregroundStyle(PortuTheme.dashboardText)
-                            if let change = appState.priceChanges24h[cgId] {
-                                HStack(spacing: 2) {
-                                    Image(systemName: change >= 0 ? "arrow.up.right" : "arrow.down.right")
-                                    Text(change, format: .percent.precision(.fractionLength(2)))
-                                }
-                                .font(.caption)
-                                .foregroundStyle(PortuTheme.changeColor(for: change))
-                            }
-                        }
-                    } else {
-                        Text("\u{2014}")
-                            .foregroundStyle(PortuTheme.dashboardTertiaryText)
-                    }
-                }
+            Text("Updating in \(secondsRemaining)s")
+                .font(.caption)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                .lineLimit(1)
+
+            watchlistSearchField
+
+            if !matchingAssets.isEmpty {
+                suggestionList
+            }
+
+            VStack(spacing: 0) {
+                priceHeader
+
                 Rectangle()
                     .fill(PortuTheme.dashboardStroke)
                     .frame(height: 1)
+
+                if rows.isEmpty {
+                    Text("No priced assets")
+                        .font(.caption)
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, minHeight: 96, alignment: .center)
+                } else {
+                    ForEach(rows) { row in
+                        PriceWatchlistRow(row: row, remove: removeFromWatchlist)
+
+                        Rectangle()
+                            .fill(PortuTheme.dashboardStroke.opacity(0.75))
+                            .frame(height: 1)
+                    }
+                }
             }
+        }
+        .task(id: appState.lastPriceUpdate) {
+            resetCountdown()
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+                if secondsRemaining > 0 {
+                    secondsRemaining -= 1
+                }
+            }
+        }
+    }
+
+    private var livePill: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 9, weight: .semibold))
+            Text("Live")
+                .font(.system(size: 10, weight: .semibold))
+        }
+        .foregroundStyle(PortuTheme.dashboardSuccess)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(
+            Capsule(style: .continuous)
+                .fill(PortuTheme.dashboardSuccess.opacity(0.12)))
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(PortuTheme.dashboardSuccess.opacity(0.6), lineWidth: 1))
+    }
+
+    private var watchlistSearchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.caption)
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+            TextField("Add to your watchlist...", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(PortuTheme.dashboardText)
+                .lineLimit(1)
+                .onSubmit(addFirstMatch)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 32)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(PortuTheme.dashboardPanelElevatedBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+
+    private var suggestionList: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(matchingAssets) { asset in
+                Button {
+                    addToWatchlist(asset.coinGeckoId)
+                } label: {
+                    HStack(spacing: 8) {
+                        Text(asset.symbol)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(PortuTheme.dashboardText)
+                            .lineLimit(1)
+
+                        Text(asset.name)
+                            .font(.caption)
+                            .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                            .lineLimit(1)
+
+                        Spacer(minLength: 8)
+
+                        Image(systemName: "plus")
+                            .font(.caption)
+                            .foregroundStyle(PortuTheme.dashboardGold)
+                    }
+                    .padding(.horizontal, 9)
+                    .frame(height: 28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(PortuTheme.dashboardMutedPanelBackground))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var priceHeader: some View {
+        HStack(spacing: 6) {
+            Text("Top Portfolio Assets")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Price")
+                .frame(width: 104, alignment: .trailing)
+            Text("24h")
+                .frame(width: 52, alignment: .trailing)
+        }
+        .font(.caption)
+        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+        .lineLimit(1)
+        .padding(.bottom, 8)
+    }
+
+    private func addFirstMatch() {
+        guard let first = matchingAssets.first else { return }
+        addToWatchlist(first.coinGeckoId)
+    }
+
+    private func addToWatchlist(_ coinGeckoId: String) {
+        watchlistRaw = OverviewWatchlistStore.encode(
+            OverviewWatchlistStore.add(coinGeckoId, to: watchlistIDs))
+        searchText = ""
+    }
+
+    private func removeFromWatchlist(_ coinGeckoId: String) {
+        watchlistRaw = OverviewWatchlistStore.encode(
+            OverviewWatchlistStore.remove(coinGeckoId, from: watchlistIDs))
+    }
+
+    private func resetCountdown() {
+        secondsRemaining = Int(PricePollingSettings.refreshIntervalSeconds())
+    }
+}
+
+private struct PriceWatchlistRow: View {
+    let row: OverviewPriceRowData
+    let remove: (String) -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            HStack(spacing: 7) {
+                assetDot
+                Text(OverviewPriceDisplay.assetLabel(row.symbol))
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .padding(.horizontal, 7)
+            .frame(width: 82, height: 25, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(PortuTheme.dashboardPanelElevatedBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+
+            if let price = row.price {
+                Text(OverviewPriceDisplay.price(price))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
+                    .allowsTightening(true)
+                    .minimumScaleFactor(0.72)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            } else {
+                Text("-")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(PortuTheme.dashboardTertiaryText)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+
+            changeView
+                .frame(width: 52, alignment: .trailing)
+
+            if row.isWatchlisted, let coinGeckoId = row.coinGeckoId {
+                Button {
+                    remove(coinGeckoId)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                        .frame(width: 16, height: 16)
+                }
+                .buttonStyle(.plain)
+                .help("Remove from watchlist")
+            }
+        }
+        .frame(height: 38)
+    }
+
+    private var assetDot: some View {
+        ZStack {
+            Circle()
+                .fill(PortuTheme.dashboardGoldMuted)
+            Text(String(row.symbol.prefix(1)))
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(PortuTheme.dashboardText)
+        }
+        .frame(width: 16, height: 16)
+    }
+
+    @ViewBuilder
+    private var changeView: some View {
+        if let change = row.change24h {
+            HStack(spacing: 3) {
+                Image(systemName: change >= 0 ? "arrowtriangle.up.fill" : "arrowtriangle.down.fill")
+                    .font(.system(size: 8, weight: .semibold))
+                Text(change, format: .percent.precision(.fractionLength(1)))
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+            }
+            .foregroundStyle(change >= 0 ? PortuTheme.dashboardSuccess : PortuTheme.dashboardWarning)
+            .lineLimit(1)
+        } else {
+            Text("-")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(PortuTheme.dashboardTertiaryText)
+                .lineLimit(1)
         }
     }
 }

--- a/Sources/Portu/Features/Overview/TopAssetsDonut.swift
+++ b/Sources/Portu/Features/Overview/TopAssetsDonut.swift
@@ -34,7 +34,7 @@ struct TopAssetsDonut: View {
                 modeButton(.category)
                 Spacer()
 
-                Button("See all ->") {
+                Button(TopAssetsDonutText.seeAllButtonTitle) {
                     store.send(.sectionSelected(.allAssets))
                 }
                 .font(.caption.weight(.medium))
@@ -118,6 +118,10 @@ struct TopAssetsDonut: View {
         }
         .buttonStyle(.plain)
     }
+}
+
+enum TopAssetsDonutText {
+    static let seeAllButtonTitle = "See all →"
 }
 
 private enum TopAssetMode {

--- a/Sources/Portu/Features/Overview/TopAssetsDonut.swift
+++ b/Sources/Portu/Features/Overview/TopAssetsDonut.swift
@@ -11,110 +11,80 @@ struct TopAssetsDonut: View {
     @Environment(AppState.self) private var appState
     @Query private var tokens: [PositionToken]
 
-    @State private var groupByCategory = true
+    @State private var selectedMode: TopAssetMode = .assets
 
     /// Only tokens from active accounts
-    private var activeTokens: [PositionToken] {
-        tokens.filter { $0.position?.account?.isActive == true }
+    private var tokenEntries: [TokenEntry] {
+        TokenEntry.fromActiveTokens(tokens)
     }
 
-    private struct SliceData: Identifiable {
-        let id = UUID()
-        let label: String
-        let value: Decimal
-        let color: Color
-    }
-
-    private var slices: [SliceData] {
-        if groupByCategory {
-            var byCategory: [AssetCategory: Decimal] = [:]
-            for token in activeTokens where token.role.isPositive {
-                byCategory[token.asset?.category ?? .other, default: 0] += tokenUSDValue(token)
-            }
-            return buildSlices(from: byCategory) { $0.rawValue.capitalized }
-        } else {
-            var byAsset: [String: Decimal] = [:]
-            for token in activeTokens where token.role.isPositive {
-                byAsset[token.asset?.symbol ?? "???", default: 0] += tokenUSDValue(token)
-            }
-            return buildSlices(from: byAsset) { $0 }
+    private var slices: [OverviewAssetSlice] {
+        switch selectedMode {
+        case .assets:
+            OverviewFeature.topAssetSlices(from: tokenEntries, prices: appState.prices, limit: 5)
+        case .category:
+            OverviewFeature.categorySlices(from: tokenEntries, prices: appState.prices, limit: 6)
         }
     }
 
-    private func buildSlices<K: Hashable>(
-        from aggregated: [K: Decimal],
-        label: (K) -> String) -> [SliceData] {
-        aggregated
-            .sorted { $0.value > $1.value }
-            .prefix(8)
-            .enumerated()
-            .map { SliceData(
-                label: label($0.element.key),
-                value: $0.element.value,
-                color: chartColor(index: $0.offset)) }
-    }
-
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Top Assets")
-                    .font(DashboardStyle.sectionTitleFont)
-                    .foregroundStyle(PortuTheme.dashboardText)
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .firstTextBaseline, spacing: 18) {
+                modeButton(.assets)
+                modeButton(.category)
                 Spacer()
-                Picker("Group", selection: $groupByCategory) {
-                    Text("Category").tag(true)
-                    Text("Asset").tag(false)
+
+                Button("See all ->") {
+                    store.send(.sectionSelected(.allAssets))
                 }
-                .pickerStyle(.segmented)
-                .frame(width: 136)
-                .dashboardControl()
+                .font(.caption.weight(.medium))
+                .foregroundStyle(PortuTheme.dashboardGold)
+                .lineLimit(1)
+                .buttonStyle(.plain)
             }
 
             if slices.isEmpty {
                 Text("No data")
                     .font(.caption)
                     .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, minHeight: 180, alignment: .center)
             } else {
-                Chart(slices) { slice in
-                    SectorMark(
-                        angle: .value("Value", slice.value),
-                        innerRadius: .ratio(0.5),
-                        angularInset: 1)
-                        .foregroundStyle(slice.color)
-                        .annotation(position: .overlay) {
-                            Text(slice.label)
-                                .font(.caption2)
-                                .foregroundStyle(PortuTheme.dashboardText)
-                        }
-                }
-                .frame(height: 168)
-
-                // Legend
-                ForEach(slices) { slice in
-                    HStack(spacing: 6) {
-                        Circle().fill(slice.color).frame(width: 8, height: 8)
-                        Text(slice.label)
-                            .font(.caption)
-                            .foregroundStyle(PortuTheme.dashboardText)
-                        Spacer()
-                        Text(slice.value, format: .currency(code: "USD"))
-                            .font(.system(size: 12, design: .monospaced))
-                            .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                HStack(alignment: .center, spacing: 16) {
+                    Chart(slices) { slice in
+                        SectorMark(
+                            angle: .value("Value", slice.value),
+                            innerRadius: .ratio(0.58),
+                            angularInset: 1.4)
+                            .foregroundStyle(chartColor(index: slice.colorIndex))
                     }
+                    .chartLegend(.hidden)
+                    .frame(width: 162, height: 162)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(slices) { slice in
+                            HStack(spacing: 7) {
+                                Circle()
+                                    .fill(chartColor(index: slice.colorIndex))
+                                    .frame(width: 7, height: 7)
+
+                                Text(slice.label)
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .foregroundStyle(PortuTheme.dashboardText)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+
+                                Text("\(slice.displayPercent)%")
+                                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-
-            Button("See all \u{2192}") {
-                store.send(.sectionSelected(.allAssets))
-            }
-            .font(.caption)
-            .foregroundStyle(PortuTheme.dashboardGold)
-            .buttonStyle(.plain)
         }
-    }
-
-    private func tokenUSDValue(_ token: PositionToken) -> Decimal {
-        token.resolvedUSDValue(prices: appState.prices)
     }
 
     private func chartColor(index: Int) -> Color {
@@ -129,5 +99,35 @@ struct TopAssetsDonut: View {
             Color(red: 0.650, green: 0.450, blue: 0.320)
         ]
         return colors[index % colors.count]
+    }
+
+    private func modeButton(_ mode: TopAssetMode) -> some View {
+        Button {
+            selectedMode = mode
+        } label: {
+            Text(mode.title)
+                .font(.system(size: 14, weight: selectedMode == mode ? .semibold : .regular))
+                .foregroundStyle(selectedMode == mode ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                .lineLimit(1)
+                .padding(.bottom, 4)
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(selectedMode == mode ? PortuTheme.dashboardGold : .clear)
+                        .frame(height: 1)
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private enum TopAssetMode {
+    case assets
+    case category
+
+    var title: String {
+        switch self {
+        case .assets: "Top Assets"
+        case .category: "By Category"
+        }
     }
 }

--- a/Sources/Portu/Features/Shared/DashboardStyle.swift
+++ b/Sources/Portu/Features/Shared/DashboardStyle.swift
@@ -35,10 +35,12 @@ struct DashboardPageHeader<Actions: View>: View {
                 Text(title)
                     .font(DashboardStyle.pageTitleFont)
                     .foregroundStyle(PortuTheme.dashboardText)
+                    .lineLimit(1)
                 if let subtitle {
                     Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                        .lineLimit(1)
                 }
             }
 

--- a/Tests/PortuTests/AppStateBridgeTests.swift
+++ b/Tests/PortuTests/AppStateBridgeTests.swift
@@ -123,7 +123,7 @@ struct AppStateBridgeTests {
         #expect(appState.priceChanges24h == ["bitcoin": 2.5])
     }
 
-    @Test func `bridge propagates sync status changes`() async {
+    @Test func `bridge propagates sync status changes`() async throws {
         let syncCompleted = AsyncStream<Void>.makeStream()
         let store = Store(initialState: AppFeature.State()) {
             AppFeature()
@@ -144,18 +144,25 @@ struct AppStateBridgeTests {
 
         // Start sync — store status changes to .syncing
         store.send(.syncTapped)
-        await Task.yield()
 
         // Continuous observation should propagate this
-        #expect(appState.syncStatus == .syncing(progress: 0))
+        try await waitForSyncStatus(.syncing(progress: 0), in: appState)
 
         // Clean up: complete the sync and wait for the in-flight effect
         syncCompleted.continuation.finish()
 
-        for _ in 0 ..< 100 where appState.syncStatus != .idle {
-            await Task.yield()
+        try await waitForSyncStatus(.idle, in: appState)
+    }
+
+    private func waitForSyncStatus(
+        _ expectedStatus: SyncStatus,
+        in appState: AppState,
+        timeout: Duration = .seconds(2)) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while appState.syncStatus != expectedStatus, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
         }
 
-        #expect(appState.syncStatus == .idle)
+        #expect(appState.syncStatus == expectedStatus)
     }
 }

--- a/Tests/PortuTests/MainWindowPlacementTests.swift
+++ b/Tests/PortuTests/MainWindowPlacementTests.swift
@@ -1,0 +1,22 @@
+@testable import Portu
+import Testing
+
+struct MainWindowPlacementTests {
+    @Test func `large displays clamp to maximum launch size`() {
+        let size = MainWindowPlacement.launchSize(for: .init(width: 2560, height: 1440))
+
+        #expect(size == .init(width: 1440, height: 960))
+    }
+
+    @Test func `normal displays use ninety percent launch size`() {
+        let size = MainWindowPlacement.launchSize(for: .init(width: 1200, height: 900))
+
+        #expect(size == .init(width: 1080, height: 810))
+    }
+
+    @Test func `small displays clamp to minimum launch size`() {
+        let size = MainWindowPlacement.launchSize(for: .init(width: 800, height: 500))
+
+        #expect(size == .init(width: 900, height: 600))
+    }
+}

--- a/Tests/PortuTests/OverviewFeatureTests.swift
+++ b/Tests/PortuTests/OverviewFeatureTests.swift
@@ -142,11 +142,33 @@ struct OverviewFeatureTests {
             portfolioLimit: 1)
 
         let row = try #require(rows.first)
-        #expect(row.id == "bitcoin")
+        #expect(row.id == btc.uuidString)
         #expect(row.coinGeckoId == "bitcoin")
         #expect(row.price == 70000)
         #expect(row.change24h == 0.04)
         #expect(row.isWatchlisted)
+    }
+
+    @Test func `price rows keep distinct portfolio assets with the same coin gecko id`() {
+        let aave = UUID()
+        let bridgedAave = UUID()
+        let tokens = [
+            token(assetId: aave, symbol: "AAVE", coinGeckoId: "aave", amount: 2, usdValue: 100),
+            token(assetId: bridgedAave, symbol: "AAVE.e", coinGeckoId: "AAVE", amount: 1, usdValue: 90)
+        ]
+
+        let rows = OverviewFeature.priceRows(
+            tokens: tokens,
+            assets: [],
+            prices: ["aave": 100],
+            changes24h: ["aave": 0.02],
+            watchlistIDs: ["aave"],
+            portfolioLimit: 10)
+
+        #expect(rows.map(\.id) == [aave.uuidString, bridgedAave.uuidString])
+        #expect(rows.map(\.assetId) == [aave, bridgedAave])
+        #expect(rows.map(\.coinGeckoId) == ["aave", "aave"])
+        #expect(rows.map(\.isWatchlisted) == [true, true])
     }
 
     @Test func `price rows keep orphaned watchlist ids removable`() throws {
@@ -313,6 +335,12 @@ struct OverviewFeatureTests {
     @Test func `summary card empty text distinguishes futures placeholder`() {
         #expect(OverviewSummaryCardText.emptyState(for: "Futures") == "Coming soon")
         #expect(OverviewSummaryCardText.emptyState(for: "Deployed") == "No deployed positions")
+    }
+
+    @Test func `overview labels describe merged rows and named layout constants`() {
+        #expect(PriceWatchlistText.priceHeaderTitle == "Portfolio + Watchlist")
+        #expect(TopAssetsDonutText.seeAllButtonTitle == "See all →")
+        #expect(OverviewLayout.inspectorRailWidthAdjustment == 22)
     }
 
     private func token(

--- a/Tests/PortuTests/OverviewFeatureTests.swift
+++ b/Tests/PortuTests/OverviewFeatureTests.swift
@@ -44,6 +44,25 @@ struct OverviewFeatureTests {
         #expect(slices.first?.displayPercent == 67)
     }
 
+    @Test func `category slices preserve omitted values in other bucket`() throws {
+        let tokens = [
+            token(symbol: "MAJOR", category: .major, amount: 1, usdValue: 80),
+            token(symbol: "STABLE", category: .stablecoin, amount: 1, usdValue: 70),
+            token(symbol: "DEFI", category: .defi, amount: 1, usdValue: 60),
+            token(symbol: "MEME", category: .meme, amount: 1, usdValue: 50),
+            token(symbol: "PRIV", category: .privacy, amount: 1, usdValue: 40),
+            token(symbol: "FIAT", category: .fiat, amount: 1, usdValue: 30),
+            token(symbol: "GOV", category: .governance, amount: 1, usdValue: 20),
+            token(symbol: "OTHER", category: .other, amount: 1, usdValue: 10)
+        ]
+
+        let slices = OverviewFeature.categorySlices(from: tokens, prices: [:], limit: 6)
+
+        #expect(slices.map(\.label) == ["Major", "Stablecoin", "Defi", "Meme", "Privacy", "Fiat", "other"])
+        #expect(try #require(slices.last).value == 30)
+        #expect(slices.map(\.displayPercent).reduce(0, +) == 100)
+    }
+
     @Test func `price rows merge top portfolio assets with watchlist ids`() {
         let btc = UUID()
         let eth = UUID()
@@ -95,14 +114,51 @@ struct OverviewFeatureTests {
         #expect(row.coinGeckoId == nil)
     }
 
+    @Test func `asset candidates are pre grouped by normalized coin gecko id`() throws {
+        let preferred = asset(symbol: "AAVE", coinGeckoId: " aave ")
+        let later = asset(symbol: "ZAAVE", coinGeckoId: "AAVE")
+
+        let grouped = OverviewFeature.assetCandidatesByCoinGeckoId(from: [later, preferred])
+
+        #expect(grouped.keys.sorted() == ["aave"])
+        #expect(try #require(grouped["aave"]) == preferred)
+    }
+
     @Test func `price display uses compact dollar prefix and trims asset labels`() throws {
         #expect(OverviewPriceDisplay.assetLabel("wrappedsteth") == "wrappe")
         #expect(OverviewPriceDisplay.assetLabel("BTC") == "BTC")
 
-        let price = try OverviewPriceDisplay.price(#require(Decimal(string: "2866.478")))
+        let price = try OverviewPriceDisplay.price(#require(Decimal(
+            string: "2866.478",
+            locale: Locale(identifier: "en_US_POSIX"))))
         #expect(price.hasPrefix("$ "))
         #expect(!price.contains("US$"))
         #expect(!price.contains("US $"))
+    }
+
+    @Test func `price display keeps precision for very small assets`() throws {
+        let price = try OverviewPriceDisplay.price(#require(Decimal(
+            string: "0.00000012",
+            locale: Locale(identifier: "en_US_POSIX"))))
+
+        #expect(price == "$ 0.00000012")
+    }
+
+    @Test func `price countdown derives remaining seconds from last update`() {
+        let lastUpdate = Date(timeIntervalSince1970: 100)
+
+        #expect(OverviewPriceCountdown.secondsRemaining(
+            lastPriceUpdate: lastUpdate,
+            refreshInterval: 60,
+            now: Date(timeIntervalSince1970: 112.2)) == 48)
+        #expect(OverviewPriceCountdown.secondsRemaining(
+            lastPriceUpdate: lastUpdate,
+            refreshInterval: 60,
+            now: Date(timeIntervalSince1970: 170)) == 0)
+        #expect(OverviewPriceCountdown.secondsRemaining(
+            lastPriceUpdate: nil,
+            refreshInterval: 60,
+            now: lastUpdate) == 60)
     }
 
     @Test func `overview sync button uses compact reference metrics`() {
@@ -126,18 +182,19 @@ struct OverviewFeatureTests {
         #expect(removed == ["ethereum"])
     }
 
-    @Test func `price polling ids combine active portfolio and watchlist ids`() {
+    @Test func `price polling ids combine active portfolio and watchlist ids in stable order`() {
         let tokens = [
             token(symbol: "ETH", coinGeckoId: "ethereum", amount: 1, usdValue: 3000),
             token(symbol: "BTC", coinGeckoId: "bitcoin", amount: 1, usdValue: 70000),
-            token(symbol: "ETH", coinGeckoId: "ethereum", amount: 2, usdValue: 6000)
+            token(symbol: "ETH", coinGeckoId: "ethereum", amount: 2, usdValue: 6000),
+            token(symbol: "ZERO", coinGeckoId: "zero-token", amount: 10, usdValue: 0)
         ]
 
         let ids = OverviewFeature.pricePollingIDs(
             tokens: tokens,
-            watchlistIDs: ["solana", "bitcoin", "monero"])
+            watchlistIDs: ["solana", " Bitcoin ", "monero"])
 
-        #expect(ids == ["bitcoin", "ethereum", "solana", "monero"])
+        #expect(ids == ["bitcoin", "ethereum", "monero", "solana", "zero-token"])
     }
 
     private func token(

--- a/Tests/PortuTests/OverviewFeatureTests.swift
+++ b/Tests/PortuTests/OverviewFeatureTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+@testable import Portu
+import PortuCore
+import Testing
+
+struct OverviewFeatureTests {
+    @Test func `top assets aggregate by asset and put residual into other`() throws {
+        let btc = UUID()
+        let eth = UUID()
+        let sol = UUID()
+        let usdc = UUID()
+        let doge = UUID()
+        let tokens = [
+            token(assetId: btc, symbol: "BTC", coinGeckoId: "bitcoin", amount: 1, usdValue: 60000),
+            token(assetId: btc, symbol: "BTC", coinGeckoId: "bitcoin", amount: 0.5, usdValue: 30000),
+            token(assetId: eth, symbol: "ETH", coinGeckoId: "ethereum", amount: 10, usdValue: 30000),
+            token(assetId: sol, symbol: "SOL", coinGeckoId: "solana", amount: 100, usdValue: 10000),
+            token(assetId: usdc, symbol: "USDC", coinGeckoId: "usd-coin", amount: 5000, usdValue: 5000),
+            token(assetId: doge, symbol: "DOGE", coinGeckoId: "dogecoin", amount: 10000, usdValue: 2000)
+        ]
+
+        let slices = OverviewFeature.topAssetSlices(
+            from: tokens,
+            prices: ["bitcoin": 70000, "ethereum": 3000],
+            limit: 3)
+
+        #expect(slices.map(\.label) == ["BTC", "ETH", "SOL", "other"])
+        #expect(slices.map(\.displayPercent).reduce(0, +) == 100)
+        #expect(try #require(slices.first).value == 105_000)
+        #expect(try #require(slices.last).value == 7000)
+    }
+
+    @Test func `category slices round display percentages to exactly one hundred`() {
+        let tokens = [
+            token(symbol: "BTC", category: .major, amount: 1, usdValue: 34),
+            token(symbol: "ETH", category: .major, amount: 1, usdValue: 33),
+            token(symbol: "USDC", category: .stablecoin, amount: 1, usdValue: 33)
+        ]
+
+        let slices = OverviewFeature.categorySlices(from: tokens, prices: [:], limit: 6)
+
+        #expect(slices.map(\.displayPercent).reduce(0, +) == 100)
+        #expect(slices.first?.label == "Major")
+        #expect(slices.first?.displayPercent == 67)
+    }
+
+    @Test func `price rows merge top portfolio assets with watchlist ids`() {
+        let btc = UUID()
+        let eth = UUID()
+        let sui = UUID()
+        let xmr = UUID()
+        let assets = [
+            asset(id: btc, symbol: "BTC", coinGeckoId: "bitcoin"),
+            asset(id: eth, symbol: "ETH", coinGeckoId: "ethereum"),
+            asset(id: sui, symbol: "SUI", coinGeckoId: "sui"),
+            asset(id: xmr, symbol: "XMR", coinGeckoId: "monero")
+        ]
+        let tokens = [
+            token(assetId: eth, symbol: "ETH", coinGeckoId: "ethereum", amount: 2, usdValue: 6000),
+            token(assetId: btc, symbol: "BTC", coinGeckoId: "bitcoin", amount: 0.2, usdValue: 12000)
+        ]
+
+        let rows = OverviewFeature.priceRows(
+            tokens: tokens,
+            assets: assets,
+            prices: ["bitcoin": 70000, "ethereum": 3000, "sui": 1.1, "monero": 350],
+            changes24h: ["bitcoin": -0.03, "ethereum": 0.01, "monero": 0.02],
+            watchlistIDs: ["monero", "bitcoin", "sui"],
+            portfolioLimit: 2)
+
+        #expect(rows.map(\.coinGeckoId) == ["bitcoin", "ethereum", "monero", "sui"])
+        #expect(rows[0].isWatchlisted)
+        #expect(!rows[1].isWatchlisted)
+        #expect(rows[2].change24h == 0.02)
+    }
+
+    @Test func `price rows include top portfolio assets without coin gecko ids`() throws {
+        let localAsset = UUID()
+        let tokens = [
+            token(assetId: localAsset, symbol: "LOCAL", amount: 4, usdValue: 100)
+        ]
+
+        let rows = OverviewFeature.priceRows(
+            tokens: tokens,
+            assets: [],
+            prices: [:],
+            changes24h: [:],
+            watchlistIDs: [],
+            portfolioLimit: 10)
+
+        let row = try #require(rows.first)
+        #expect(rows.count == 1)
+        #expect(row.symbol == "LOCAL")
+        #expect(row.price == 25)
+        #expect(row.coinGeckoId == nil)
+    }
+
+    @Test func `price display uses compact dollar prefix and trims asset labels`() throws {
+        #expect(OverviewPriceDisplay.assetLabel("wrappedsteth") == "wrappe")
+        #expect(OverviewPriceDisplay.assetLabel("BTC") == "BTC")
+
+        let price = try OverviewPriceDisplay.price(#require(Decimal(string: "2866.478")))
+        #expect(price.hasPrefix("$ "))
+        #expect(!price.contains("US$"))
+        #expect(!price.contains("US $"))
+    }
+
+    @Test func `overview sync button uses compact reference metrics`() {
+        #expect(OverviewSyncButtonStyleMetrics.iconName == "arrow.triangle.2.circlepath")
+        #expect(OverviewSyncButtonStyleMetrics.height == 30)
+        #expect(OverviewSyncButtonStyleMetrics.cornerRadius == 6)
+        #expect(OverviewSyncButtonStyleMetrics.horizontalPadding == 11)
+    }
+
+    @Test func `watchlist persistence keeps order and uniqueness`() {
+        let encoded = OverviewWatchlistStore.encode(["bitcoin", "ethereum", "bitcoin", "solana"])
+        #expect(OverviewWatchlistStore.decode(encoded) == ["bitcoin", "ethereum", "solana"])
+
+        let added = OverviewWatchlistStore.add("ethereum", to: ["bitcoin"])
+        #expect(added == ["bitcoin", "ethereum"])
+
+        let duplicate = OverviewWatchlistStore.add("bitcoin", to: added)
+        #expect(duplicate == added)
+
+        let removed = OverviewWatchlistStore.remove("bitcoin", from: duplicate)
+        #expect(removed == ["ethereum"])
+    }
+
+    @Test func `price polling ids combine active portfolio and watchlist ids`() {
+        let tokens = [
+            token(symbol: "ETH", coinGeckoId: "ethereum", amount: 1, usdValue: 3000),
+            token(symbol: "BTC", coinGeckoId: "bitcoin", amount: 1, usdValue: 70000),
+            token(symbol: "ETH", coinGeckoId: "ethereum", amount: 2, usdValue: 6000)
+        ]
+
+        let ids = OverviewFeature.pricePollingIDs(
+            tokens: tokens,
+            watchlistIDs: ["solana", "bitcoin", "monero"])
+
+        #expect(ids == ["bitcoin", "ethereum", "solana", "monero"])
+    }
+
+    private func token(
+        assetId: UUID = UUID(),
+        symbol: String,
+        category: AssetCategory = .major,
+        coinGeckoId: String? = nil,
+        role: TokenRole = .balance,
+        amount: Decimal,
+        usdValue: Decimal) -> TokenEntry {
+        TokenEntry(
+            assetId: assetId,
+            symbol: symbol,
+            name: symbol,
+            category: category,
+            coinGeckoId: coinGeckoId,
+            role: role,
+            amount: amount,
+            usdValue: usdValue)
+    }
+
+    private func asset(
+        id: UUID = UUID(),
+        symbol: String,
+        category: AssetCategory = .major,
+        coinGeckoId: String) -> OverviewAssetCandidate {
+        OverviewAssetCandidate(
+            id: id,
+            symbol: symbol,
+            name: symbol,
+            category: category,
+            coinGeckoId: coinGeckoId)
+    }
+}

--- a/Tests/PortuTests/OverviewFeatureTests.swift
+++ b/Tests/PortuTests/OverviewFeatureTests.swift
@@ -25,9 +25,24 @@ struct OverviewFeatureTests {
             limit: 3)
 
         #expect(slices.map(\.label) == ["BTC", "ETH", "SOL", "other"])
+        #expect(slices.map(\.id) == [btc.uuidString, eth.uuidString, sol.uuidString, "asset-residual"])
         #expect(slices.map(\.displayPercent).reduce(0, +) == 100)
         #expect(try #require(slices.first).value == 105_000)
         #expect(try #require(slices.last).value == 7000)
+    }
+
+    @Test func `top asset slices keep asset stable ids when coin gecko ids collide`() {
+        let aave = UUID()
+        let bridgedAave = UUID()
+        let tokens = [
+            token(assetId: aave, symbol: "AAVE", coinGeckoId: "aave", amount: 1, usdValue: 100),
+            token(assetId: bridgedAave, symbol: "AAVE.e", coinGeckoId: "aave", amount: 1, usdValue: 90)
+        ]
+
+        let slices = OverviewFeature.topAssetSlices(from: tokens, prices: [:], limit: 2)
+
+        #expect(slices.map(\.id) == [aave.uuidString, bridgedAave.uuidString])
+        #expect(Set(slices.map(\.id)).count == slices.count)
     }
 
     @Test func `category slices round display percentages to exactly one hundred`() {
@@ -63,6 +78,25 @@ struct OverviewFeatureTests {
         #expect(slices.map(\.displayPercent).reduce(0, +) == 100)
     }
 
+    @Test func `category residual bucket does not collide with visible other category`() {
+        let tokens = [
+            token(symbol: "OTHER", category: .other, amount: 1, usdValue: 90),
+            token(symbol: "MAJOR", category: .major, amount: 1, usdValue: 80),
+            token(symbol: "STABLE", category: .stablecoin, amount: 1, usdValue: 70),
+            token(symbol: "DEFI", category: .defi, amount: 1, usdValue: 60),
+            token(symbol: "MEME", category: .meme, amount: 1, usdValue: 50),
+            token(symbol: "PRIV", category: .privacy, amount: 1, usdValue: 40),
+            token(symbol: "GOV", category: .governance, amount: 1, usdValue: 30)
+        ]
+
+        let slices = OverviewFeature.categorySlices(from: tokens, prices: [:], limit: 6)
+
+        #expect(slices.map(\.id).contains("other"))
+        #expect(slices.map(\.id).contains("category-residual"))
+        #expect(Set(slices.map(\.id)).count == slices.count)
+        #expect(slices.map(\.displayPercent).reduce(0, +) == 100)
+    }
+
     @Test func `price rows merge top portfolio assets with watchlist ids`() {
         let btc = UUID()
         let eth = UUID()
@@ -91,6 +125,47 @@ struct OverviewFeatureTests {
         #expect(rows[0].isWatchlisted)
         #expect(!rows[1].isWatchlisted)
         #expect(rows[2].change24h == 0.02)
+    }
+
+    @Test func `price rows normalize portfolio coin gecko ids for lookups and watchlist state`() throws {
+        let btc = UUID()
+        let tokens = [
+            token(assetId: btc, symbol: "BTC", coinGeckoId: " Bitcoin ", amount: 0.5, usdValue: 10)
+        ]
+
+        let rows = OverviewFeature.priceRows(
+            tokens: tokens,
+            assets: [],
+            prices: ["bitcoin": 70000],
+            changes24h: ["bitcoin": 0.04],
+            watchlistIDs: ["bitcoin"],
+            portfolioLimit: 1)
+
+        let row = try #require(rows.first)
+        #expect(row.id == "bitcoin")
+        #expect(row.coinGeckoId == "bitcoin")
+        #expect(row.price == 70000)
+        #expect(row.change24h == 0.04)
+        #expect(row.isWatchlisted)
+    }
+
+    @Test func `price rows keep orphaned watchlist ids removable`() throws {
+        let rows = OverviewFeature.priceRows(
+            tokens: [],
+            assets: [],
+            prices: ["ghost-token": 1.23],
+            changes24h: ["ghost-token": -0.05],
+            watchlistIDs: ["ghost-token"],
+            portfolioLimit: 10)
+
+        let row = try #require(rows.first)
+        #expect(row.id == "ghost-token")
+        #expect(row.assetId == nil)
+        #expect(row.symbol == "ghost-token")
+        #expect(row.coinGeckoId == "ghost-token")
+        #expect(row.price == 1.23)
+        #expect(row.change24h == -0.05)
+        #expect(row.isWatchlisted)
     }
 
     @Test func `price rows include top portfolio assets without coin gecko ids`() throws {
@@ -122,6 +197,19 @@ struct OverviewFeatureTests {
 
         #expect(grouped.keys.sorted() == ["aave"])
         #expect(try #require(grouped["aave"]) == preferred)
+    }
+
+    @Test func `watchlist suggestions are deduplicated by normalized coin gecko id`() {
+        let preferred = asset(symbol: "AAVE", coinGeckoId: " aave ")
+        let duplicate = asset(symbol: "ZAAVE", coinGeckoId: "AAVE")
+        let sol = asset(symbol: "SOL", coinGeckoId: "solana")
+
+        let suggestions = OverviewFeature.watchlistSuggestions(
+            assets: [duplicate, sol, preferred],
+            watchlistIDs: ["solana"],
+            query: "aave")
+
+        #expect(suggestions == [preferred])
     }
 
     @Test func `price display uses compact dollar prefix and trims asset labels`() throws {
@@ -195,6 +283,36 @@ struct OverviewFeatureTests {
             watchlistIDs: ["solana", " Bitcoin ", "monero"])
 
         #expect(ids == ["bitcoin", "ethereum", "monero", "solana", "zero-token"])
+    }
+
+    @Test func `position pricing normalizes coin gecko ids`() {
+        #expect(OverviewPositionPricing.price(
+            coinGeckoId: " Ethereum ",
+            amount: 2,
+            usdValue: 10,
+            prices: ["ethereum": 3000]) == 3000)
+        #expect(OverviewPositionPricing.tokenValue(
+            coinGeckoId: " Ethereum ",
+            amount: 2,
+            usdValue: 10,
+            prices: ["ethereum": 3000]) == 6000)
+        #expect(OverviewPositionPricing.change24h(
+            coinGeckoId: " Ethereum ",
+            amount: 2,
+            prices: ["ethereum": 3000],
+            changes24h: ["ethereum": 0.05]) == 300)
+    }
+
+    @Test func `borrow change tone treats increasing liabilities as unfavorable`() {
+        #expect(OverviewPositionChangeTone.tone(for: .borrow, change: 10) == .unfavorable)
+        #expect(OverviewPositionChangeTone.tone(for: .borrow, change: -10) == .favorable)
+        #expect(OverviewPositionChangeTone.tone(for: .balance, change: 10) == .favorable)
+        #expect(OverviewPositionChangeTone.tone(for: .balance, change: -10) == .unfavorable)
+    }
+
+    @Test func `summary card empty text distinguishes futures placeholder`() {
+        #expect(OverviewSummaryCardText.emptyState(for: "Futures") == "Coming soon")
+        #expect(OverviewSummaryCardText.emptyState(for: "Deployed") == "No deployed positions")
     }
 
     private func token(

--- a/Tests/PortuTests/ViewRenderSmokeTests.swift
+++ b/Tests/PortuTests/ViewRenderSmokeTests.swift
@@ -34,6 +34,22 @@ struct ViewRenderSmokeTests {
         render(view)
     }
 
+    @Test(arguments: OverviewRenderSize.allCases)
+    func `overview renders at supported dashboard sizes`(_ renderSize: OverviewRenderSize) throws {
+        let container = try makeContainer()
+        let store = makeStore(section: .overview)
+        let appState = AppState()
+        appState.bridge(from: store)
+        let size = renderSize.size
+
+        let view = ContentView(store: store)
+            .modelContainer(container)
+            .environment(appState)
+            .frame(width: size.width, height: size.height)
+
+        render(view, size: size)
+    }
+
     @Test(arguments: AssetTab.allCases)
     func `all assets tabs render without crashing`(_ tab: AssetTab) throws {
         let container = try makeContainer()
@@ -101,6 +117,8 @@ struct ViewRenderSmokeTests {
             $0.syncEngine.sync = { SyncResult(failedAccounts: []) }
             $0.priceService.fetchPrices = { _ in PriceUpdate(prices: [:], changes24h: [:]) }
             $0.priceService.invalidateCache = {}
+            $0.continuousClock = TestClock()
+            $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
         }
     }
 
@@ -246,9 +264,11 @@ struct ViewRenderSmokeTests {
         let batch = UUID(uuidString: "00000000-0000-0000-0000-0000000000B1")!
     }
 
-    private func render(_ view: some View) {
+    private func render(
+        _ view: some View,
+        size: CGSize = CGSize(width: 1400, height: 900)) {
         let hostingView = NSHostingView(rootView: view)
-        hostingView.frame = CGRect(x: 0, y: 0, width: 1400, height: 900)
+        hostingView.frame = CGRect(origin: .zero, size: size)
 
         let window = NSWindow(
             contentRect: hostingView.frame,
@@ -264,6 +284,18 @@ struct ViewRenderSmokeTests {
         Self.retainedWindows.append(window)
         if Self.retainedWindows.count > Self.maxRetainedWindows {
             Self.retainedWindows.removeFirst(Self.retainedWindows.count - Self.maxRetainedWindows)
+        }
+    }
+
+    enum OverviewRenderSize: CaseIterable {
+        case large
+        case compact
+
+        var size: CGSize {
+            switch self {
+            case .large: CGSize(width: 1400, height: 900)
+            case .compact: CGSize(width: 900, height: 600)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Redesigns the Overview content area into a dense dark dashboard matching the provided reference.
- Adds adaptive first-launch window sizing while preserving macOS state restoration.
- Adds persisted Overview watchlist/price row aggregation helpers and smoke coverage for supported Overview sizes.

## Validation
- just format
- just lint (passes with existing repository warnings outside this change)
- xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test -only-testing:PortuTests/OverviewFeatureTests -only-testing:PortuTests/ViewRenderSmokeTests
- xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test
- ./script/build_and_run.sh --verify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overview feature with enhanced portfolio analytics, asset aggregation, and watchlist-driven price rows
  * Price watchlist with search, suggestions, and row-based pricing
  * Futures and Options tabs; mode-driven top-assets visualization
  * Initial app window sizing adjusted for varied displays

* **Improvements**
  * Responsive wide/compact layout, streamlined top bar, and UI consistency refinements
  * One-month focused portfolio chart and updated summary cards
  * Optional inspector divider and improved single-line title handling

* **Tests**
  * New unit and render smoke tests covering overview, sizing, watchlist, polling, and sync flows

* **Chores**
  * Updated ignore rules for project artifacts and mockups
<!-- end of auto-generated comment: release notes by coderabbit.ai -->