### PR TITLE
feat: add provider-aware sync intervals

### DIFF
--- a/Portu.xcodeproj/project.pbxproj
+++ b/Portu.xcodeproj/project.pbxproj
@@ -9,8 +9,10 @@
 /* Begin PBXBuildFile section */
 		010C49B4C2BB4659CAF03E36 /* HistoricalPriceBackfillRequestTimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FAC79936969B0BBA1C5A51 /* HistoricalPriceBackfillRequestTimingTests.swift */; };
 		02CEF7FE408D5CF38B5A88D9 /* ViewRenderSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03E305DDC6E4458F794B16A /* ViewRenderSmokeTests.swift */; };
+		031B921A0352C8F769525FB9 /* AppFeatureIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5671DBA75C15FCC72727EA8E /* AppFeatureIntervalTests.swift */; };
 		0654CA81A46C611A8907B53C /* ReleaseAutomationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A372B5E40F5617842721225 /* ReleaseAutomationTests.swift */; };
 		06D3B554E7A6183B58C4C8B9 /* DashboardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E73BD66578FD9C7009C3632 /* DashboardStyle.swift */; };
+		0772087C877663D9748CF6E3 /* SettingsIntervalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813D162565D572ED30229095 /* SettingsIntervalRow.swift */; };
 		07BD53EBDDCBE8986B49DE74 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = B357CC2B1177EF25A668EAD5 /* SnapshotTesting */; };
 		082777E4EA26D945BF5DBEFD /* PerformanceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6CA054F3A64E61E608548C /* PerformanceFeature.swift */; };
 		098327AF92DE46CA6FC8FB45 /* AppStateBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79425078F4E02B149F06E972 /* AppStateBridgeTests.swift */; };
@@ -24,6 +26,7 @@
 		1BDB9A824777E2A4F92F7E07 /* PortfolioCategoryWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60FC797AEDAEE0B5D45B7D7 /* PortfolioCategoryWriterTests.swift */; };
 		1C06ED9173A0F7A77803D08F /* PortfolioHealthFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F694EE203BEF1CB7608A00BE /* PortfolioHealthFeatureTests.swift */; };
 		1D0A4B3DFE7518356DFD4EA4 /* DebugSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC9DC89BDF0E1C6B014896 /* DebugSettingsTab.swift */; };
+		225B9560EE490E4AD49C03F2 /* AppDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAB6958F228996FEDEDC07A /* AppDependencies.swift */; };
 		230FDDF90C3B1EB88AF0981C /* APIKeysViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FADFCF9394107370CEE271 /* APIKeysViewModel.swift */; };
 		2669929F16BEC301F7B3987A /* AllAssetsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3E823F7D4F67B3ECD15695 /* AllAssetsFeatureTests.swift */; };
 		27E53486CF666A3F5FAC1814 /* CategorySettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0780688B311CE54C295F894E /* CategorySettingsTab.swift */; };
@@ -82,6 +85,7 @@
 		7FC9EA4EB046CFDA835911D3 /* AddPositionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD13B1599F995F29139DFB24 /* AddPositionSheet.swift */; };
 		7FE55C3B27ABF3CC4228467F /* AddAccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CF78486A93514E2377BA00 /* AddAccountSheet.swift */; };
 		81210B84C4D9C2AAE588C929 /* HistoricalPriceBackfillSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032C6036352F4AD17F90B9DF /* HistoricalPriceBackfillSettings.swift */; };
+		81582A3A6DCC6E837276A93D /* LivePriceUpdateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B4F100EB837B2FE370A607 /* LivePriceUpdateBuilder.swift */; };
 		81C6E52FD35E2CB7C82CFC36 /* DebugServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA60071A304587735578219 /* DebugServerTests.swift */; };
 		81F643EE066888DB62D2F0EC /* PerformanceBottomPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F36B6C43CF041F988F7F8E /* PerformanceBottomPanel.swift */; };
 		8204D636F56CF53DBBC827FE /* PricePollingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964AB9906CC767712B3BDC29 /* PricePollingSettings.swift */; };
@@ -101,6 +105,7 @@
 		913B93FE3DE708F14BF56BE0 /* APIKeysSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2757D87DCE83DD991B68E43 /* APIKeysSettingsTab.swift */; };
 		989FF781B777ECC77152A454 /* TokenIdentityMappingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CF024449593948154682D9 /* TokenIdentityMappingFeature.swift */; };
 		A50DC572E3368D154DFB79B2 /* PortfolioHealthPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F1EDADED217BABCD15C10 /* PortfolioHealthPanel.swift */; };
+		A53307EFF266FA209E6AEBDD /* SyncEngineScopedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1159F8509C86C08B1C489415 /* SyncEngineScopedTests.swift */; };
 		A9DD558859FDAB7461BA502E /* TokenSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E54D85696E2BF460995DFC2 /* TokenSettingsTab.swift */; };
 		B0C7EF78282E58C9FF84D11B /* OverviewFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7514F4EF1D675DEFD3D00B80 /* OverviewFeature.swift */; };
 		B15A829AC4BE771ECBA38995 /* TokenSettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF501A47E70AF0FF687F80D9 /* TokenSettingsRow.swift */; };
@@ -170,10 +175,12 @@
 		09FAC79936969B0BBA1C5A51 /* HistoricalPriceBackfillRequestTimingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalPriceBackfillRequestTimingTests.swift; sourceTree = "<group>"; };
 		0AF7B3690D6CF6C34EF93FAC /* AssetPriceChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetPriceChart.swift; sourceTree = "<group>"; };
 		0B8F6274FD67590BE1049ED3 /* AssetDetailFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDetailFeature.swift; sourceTree = "<group>"; };
+		1159F8509C86C08B1C489415 /* SyncEngineScopedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngineScopedTests.swift; sourceTree = "<group>"; };
 		1439A6AFF1671C8CD649E9C3 /* PerformanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceView.swift; sourceTree = "<group>"; };
 		16CCD222A9A7CFBEFD51B77C /* OverviewPriceDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewPriceDisplay.swift; sourceTree = "<group>"; };
 		187BA85D9D8DD15A770F50DA /* PortfolioCategoryResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioCategoryResolverTests.swift; sourceTree = "<group>"; };
 		190DDDD6C7E50B4300F8F595 /* DebugEndpointsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugEndpointsTests.swift; sourceTree = "<group>"; };
+		1AAB6958F228996FEDEDC07A /* AppDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDependencies.swift; sourceTree = "<group>"; };
 		1B00E51B9CD5D696629A76B9 /* PositionGroupValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionGroupValueTests.swift; sourceTree = "<group>"; };
 		1D2F33C046095EBD74E27BAF /* MainWindowPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowPlacement.swift; sourceTree = "<group>"; };
 		1DA99E382DD98BFE068BB0D3 /* HistoricalBackfillStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalBackfillStatusRow.swift; sourceTree = "<group>"; };
@@ -207,8 +214,10 @@
 		52E52E92A4ADD1CA36A62709 /* AccountsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsView.swift; sourceTree = "<group>"; };
 		550D6F6A8C36881EAA48DF2E /* AssetLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetLogoView.swift; sourceTree = "<group>"; };
 		55EC9DC89BDF0E1C6B014896 /* DebugSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettingsTab.swift; sourceTree = "<group>"; };
+		5671DBA75C15FCC72727EA8E /* AppFeatureIntervalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureIntervalTests.swift; sourceTree = "<group>"; };
 		5694C6AAF80F978B3E6A0EB7 /* AssetsChartMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsChartMode.swift; sourceTree = "<group>"; };
 		583795FC83FFEAAE83E1BEAE /* PerformanceFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceFeatureTests.swift; sourceTree = "<group>"; };
+		59B4F100EB837B2FE370A607 /* LivePriceUpdateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePriceUpdateBuilder.swift; sourceTree = "<group>"; };
 		59F1B452183C058E480F9BCC /* AddPositionCategoryRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPositionCategoryRuleTests.swift; sourceTree = "<group>"; };
 		5A372B5E40F5617842721225 /* ReleaseAutomationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseAutomationTests.swift; sourceTree = "<group>"; };
 		5C5ACF35FFCCB23A6F4AE3C4 /* HTTPParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPParser.swift; sourceTree = "<group>"; };
@@ -236,6 +245,7 @@
 		7866868ACC3675760E807169 /* TokenSettingsAggregate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSettingsAggregate.swift; sourceTree = "<group>"; };
 		79425078F4E02B149F06E972 /* AppStateBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateBridgeTests.swift; sourceTree = "<group>"; };
 		80D8A6F5E0D27CFE2E0F5446 /* InspectorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorPanel.swift; sourceTree = "<group>"; };
+		813D162565D572ED30229095 /* SettingsIntervalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIntervalRow.swift; sourceTree = "<group>"; };
 		8391D55809DB666FE792AD77 /* TokenSettingsFeature+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TokenSettingsFeature+Helpers.swift"; sourceTree = "<group>"; };
 		8489FFB3B14202D63DFC5284 /* HistoricalPortfolioEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalPortfolioEstimator.swift; sourceTree = "<group>"; };
 		84E0CE70F797E90EC7D5347A /* PortfolioCategorySeederTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioCategorySeederTests.swift; sourceTree = "<group>"; };
@@ -398,10 +408,12 @@
 		1BB45D8E46D49C69EA8D36E9 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				1AAB6958F228996FEDEDC07A /* AppDependencies.swift */,
 				394B6E5490B3F08DC65B0B9E /* AppFeature.swift */,
 				FEC920312DC620E98B3A81AE /* AppState.swift */,
 				371ED7D4DE3A82EBE87230AC /* CategorySymbolRuleWriter.swift */,
 				219795B37821B012821DECB6 /* ContentView.swift */,
+				59B4F100EB837B2FE370A607 /* LivePriceUpdateBuilder.swift */,
 				1D2F33C046095EBD74E27BAF /* MainWindowPlacement.swift */,
 				D3539209B8431690D9850A7F /* ModelContainerFactory.swift */,
 				C1E06309E68FBD62B4957310 /* PortfolioCategorySeeder.swift */,
@@ -513,6 +525,7 @@
 				032C6036352F4AD17F90B9DF /* HistoricalPriceBackfillSettings.swift */,
 				D93E3454276B4BC9DCF6C1DF /* SettingsComponents.swift */,
 				6380B90DF490867620EB850A /* SettingsIconography.swift */,
+				813D162565D572ED30229095 /* SettingsIntervalRow.swift */,
 				9C9330A7E8F8102FE57BFE75 /* SettingsView.swift */,
 				4C5B647C18FB90D4BF98BB5E /* TokenPricingOverrideWriter.swift */,
 				7866868ACC3675760E807169 /* TokenSettingsAggregate.swift */,
@@ -533,6 +546,7 @@
 				59F1B452183C058E480F9BCC /* AddPositionCategoryRuleTests.swift */,
 				2C3E823F7D4F67B3ECD15695 /* AllAssetsFeatureTests.swift */,
 				8F2E020479C2D59A564DAD6A /* APIKeysViewModelTests.swift */,
+				5671DBA75C15FCC72727EA8E /* AppFeatureIntervalTests.swift */,
 				BD13FDD77A649AA0A7CBEA62 /* AppFeatureTests.swift */,
 				79425078F4E02B149F06E972 /* AppStateBridgeTests.swift */,
 				39320574FA8ED9762F65B1CE /* AssetDetailFeatureTests.swift */,
@@ -569,6 +583,7 @@
 				5A372B5E40F5617842721225 /* ReleaseAutomationTests.swift */,
 				726D62A9E7F60014EDC7E0EC /* SettingsTabTests.swift */,
 				ACC72A910CE88E69A0A79746 /* SidebarLayoutTests.swift */,
+				1159F8509C86C08B1C489415 /* SyncEngineScopedTests.swift */,
 				FB29EB7B31D9B8FE27EDCC5A /* SyncEngineTests.swift */,
 				C0412B0DAC1B4988B6325F2A /* TokenIdentityMappingFeatureTests.swift */,
 				ECC1F6B301E1E56B6C1071A7 /* TokenSettingsFeatureTests.swift */,
@@ -728,6 +743,7 @@
 				FE1471C345B27517D92D3487 /* AllAssetsFeature.swift in Sources */,
 				906ACAF81CA1C6438049CE41 /* AllAssetsView.swift in Sources */,
 				F06E951CED72BB742AE2D8B3 /* AllPositionsView.swift in Sources */,
+				225B9560EE490E4AD49C03F2 /* AppDependencies.swift in Sources */,
 				69414F722F9492E52A68DCBD /* AppFeature.swift in Sources */,
 				7B4832C5A117B2657930D15D /* AppState.swift in Sources */,
 				35DECC9143BD8374E60C7454 /* AssetDetailFeature.swift in Sources */,
@@ -761,6 +777,7 @@
 				81210B84C4D9C2AAE588C929 /* HistoricalPriceBackfillSettings.swift in Sources */,
 				41D3D4320D5DBB104D837166 /* HistoricalPriceChanges24hProvider.swift in Sources */,
 				2E1ECF2FEFF79728EE7CA698 /* InspectorPanel.swift in Sources */,
+				81582A3A6DCC6E837276A93D /* LivePriceUpdateBuilder.swift in Sources */,
 				52A6CFFFCF82E2F1F98C0C35 /* MainWindowPlacement.swift in Sources */,
 				911345DDA176D415CF7662CE /* ModelContainerFactory.swift in Sources */,
 				288195E041046D1915F4C4EF /* NetworkLogger.swift in Sources */,
@@ -794,6 +811,7 @@
 				F67935A9EFB62B5F8D0305B6 /* ProviderFactory.swift in Sources */,
 				C2D8CF8E1A9C6B23E1BE4D23 /* SettingsComponents.swift in Sources */,
 				DF997E9BFA1EC22DEE29A934 /* SettingsIconography.swift in Sources */,
+				0772087C877663D9748CF6E3 /* SettingsIntervalRow.swift in Sources */,
 				FB5341029C65812E010217B6 /* SettingsView.swift in Sources */,
 				7586E5633F191DC76655F7F0 /* SidebarLayout.swift in Sources */,
 				7C55B271CBDE85BDC34EC423 /* SidebarView.swift in Sources */,
@@ -821,6 +839,7 @@
 				C5153D7BAD7942A4D8EC3429 /* AddAccountSupportChipTests.swift in Sources */,
 				FE3D3F7A3293898A4A4EE084 /* AddPositionCategoryRuleTests.swift in Sources */,
 				2669929F16BEC301F7B3987A /* AllAssetsFeatureTests.swift in Sources */,
+				031B921A0352C8F769525FB9 /* AppFeatureIntervalTests.swift in Sources */,
 				C422E37331613CA04BA8E9EC /* AppFeatureTests.swift in Sources */,
 				098327AF92DE46CA6FC8FB45 /* AppStateBridgeTests.swift in Sources */,
 				E543202CAE4F8EFF78CE997E /* AssetDetailFeatureTests.swift in Sources */,
@@ -857,6 +876,7 @@
 				0654CA81A46C611A8907B53C /* ReleaseAutomationTests.swift in Sources */,
 				09EFC1288E41DCA2CF416638 /* SettingsTabTests.swift in Sources */,
 				688D94778A29B329D3197E6F /* SidebarLayoutTests.swift in Sources */,
+				A53307EFF266FA209E6AEBDD /* SyncEngineScopedTests.swift in Sources */,
 				E73D6C01F3051356E0E4D2FE /* SyncEngineTests.swift in Sources */,
 				462A7D62D2D04E4AF70BC552 /* TokenIdentityMappingFeatureTests.swift in Sources */,
 				EFA1E6D5CA1AE75621F8C9A4 /* TokenSettingsFeatureTests.swift in Sources */,

--- a/Sources/Portu/App/AppDependencies.swift
+++ b/Sources/Portu/App/AppDependencies.swift
@@ -1,0 +1,247 @@
+import ComposableArchitecture
+import Foundation
+import PortuCore
+import PortuNetwork
+
+// MARK: - SyncEngineClient
+
+struct SyncResult: Equatable {
+    var failedAccounts: [String]
+    var isPartial: Bool {
+        !failedAccounts.isEmpty
+    }
+}
+
+struct SyncEngineClient {
+    var sync: @Sendable () async throws -> SyncResult
+    var syncScope: @Sendable (PortfolioSyncScope) async throws -> SyncResult
+
+    init(
+        sync: @escaping @Sendable () async throws -> SyncResult,
+        syncScope: @escaping @Sendable (PortfolioSyncScope) async throws -> SyncResult = { _ in SyncResult(failedAccounts: []) }) {
+        self.sync = sync
+        self.syncScope = syncScope
+    }
+}
+
+extension SyncEngineClient: DependencyKey {
+    static let liveValue = Self(
+        sync: { fatalError("SyncEngineClient.liveValue must be overridden at Store creation") },
+        syncScope: { _ in fatalError("SyncEngineClient.liveValue must be overridden at Store creation") })
+    static let testValue = Self(
+        sync: { SyncResult(failedAccounts: []) },
+        syncScope: { _ in SyncResult(failedAccounts: []) })
+
+    static func live(engine: SyncEngine) -> Self {
+        Self(
+            sync: { try await engine.sync() },
+            syncScope: { scope in try await engine.sync(scope: scope) })
+    }
+}
+
+extension DependencyValues {
+    var syncEngine: SyncEngineClient {
+        get { self[SyncEngineClient.self] }
+        set { self[SyncEngineClient.self] = newValue }
+    }
+}
+
+enum PortfolioSyncScope: Equatable {
+    case zapper
+    case exchange
+}
+
+// MARK: - PriceServiceClient
+
+struct PriceServiceClient {
+    enum ClientError: Error {
+        /// Returned by `fetchZapperHistoricalPrices` when no Zapper API key is configured.
+        /// The backfill runner's upstream pre-filter normally prevents reaching this path,
+        /// but a missing key here means the candidate cannot be fetched — surface it as a
+        /// failure instead of silently returning an empty result set.
+        case zapperProviderUnavailable
+    }
+
+    var fetchPrices: @Sendable ([String]) async throws -> PriceUpdate
+    private var fetchCoinGeckoPricesOverride: (@Sendable (PricePollingRequest) async throws -> PriceUpdate)?
+    private var fetchZapperPricesOverride: (@Sendable ([OnchainTokenIdentity]) async throws -> PriceUpdate)?
+    var fetchHistoricalPrices: @Sendable (String, Int) async throws -> [HistoricalPriceDTO]
+    var resolveCoinGeckoIDs: @Sendable ([OnchainTokenIdentity]) async throws -> [OnchainTokenIdentity: String]
+    var fetchZapperHistoricalPrices: @Sendable (OnchainTokenIdentity, Int) async throws -> [HistoricalPriceDTO]
+    var canFetchZapperHistoricalPrices: @Sendable () -> Bool
+    var invalidateCache: @Sendable () async -> Void
+
+    var fetchCoinGeckoPrices: @Sendable (PricePollingRequest) async throws -> PriceUpdate {
+        get {
+            if let fetchCoinGeckoPricesOverride {
+                return fetchCoinGeckoPricesOverride
+            }
+            let fetchPrices = fetchPrices
+            return { request in
+                try await fetchPrices(request.allPriceIDs)
+            }
+        }
+        set { fetchCoinGeckoPricesOverride = newValue }
+    }
+
+    var fetchZapperPrices: @Sendable ([OnchainTokenIdentity]) async throws -> PriceUpdate {
+        get {
+            if let fetchZapperPricesOverride {
+                return fetchZapperPricesOverride
+            }
+            let fetchPrices = fetchPrices
+            return { identities in
+                try await fetchPrices(identities.map(\.historicalPriceID))
+            }
+        }
+        set { fetchZapperPricesOverride = newValue }
+    }
+
+    init(
+        fetchPrices: @escaping @Sendable ([String]) async throws -> PriceUpdate,
+        fetchCoinGeckoPrices: (@Sendable (PricePollingRequest) async throws -> PriceUpdate)? = nil,
+        fetchZapperPrices: (@Sendable ([OnchainTokenIdentity]) async throws -> PriceUpdate)? = nil,
+        fetchHistoricalPrices: @escaping @Sendable (String, Int) async throws -> [HistoricalPriceDTO],
+        resolveCoinGeckoIDs: @escaping @Sendable ([OnchainTokenIdentity]) async throws -> [OnchainTokenIdentity: String] = { _ in [:] },
+        fetchZapperHistoricalPrices: @escaping @Sendable (OnchainTokenIdentity, Int) async throws -> [HistoricalPriceDTO] = { _, _ in [] },
+        canFetchZapperHistoricalPrices: @escaping @Sendable () -> Bool = { true },
+        invalidateCache: @escaping @Sendable () async -> Void) {
+        self.fetchPrices = fetchPrices
+        self.fetchCoinGeckoPricesOverride = fetchCoinGeckoPrices
+        self.fetchZapperPricesOverride = fetchZapperPrices
+        self.fetchHistoricalPrices = fetchHistoricalPrices
+        self.resolveCoinGeckoIDs = resolveCoinGeckoIDs
+        self.fetchZapperHistoricalPrices = fetchZapperHistoricalPrices
+        self.canFetchZapperHistoricalPrices = canFetchZapperHistoricalPrices
+        self.invalidateCache = invalidateCache
+    }
+}
+
+extension PriceServiceClient: DependencyKey {
+    static let liveValue = Self(
+        fetchPrices: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        fetchCoinGeckoPrices: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        fetchZapperPrices: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        fetchHistoricalPrices: { _, _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        resolveCoinGeckoIDs: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        fetchZapperHistoricalPrices: { _, _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        canFetchZapperHistoricalPrices: { fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
+        invalidateCache: { fatalError("PriceServiceClient.liveValue must be overridden at Store creation") })
+    static let testValue = Self(
+        fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) },
+        fetchHistoricalPrices: { _, _ in [] },
+        resolveCoinGeckoIDs: { _ in [:] },
+        fetchZapperHistoricalPrices: { _, _ in [] },
+        canFetchZapperHistoricalPrices: { true },
+        invalidateCache: {})
+
+    static func live(service: PriceService, zapperProvider: ZapperProvider? = nil) -> Self {
+        Self(
+            fetchPrices: { coinIds in
+                try await LivePriceUpdateBuilder.fetchPrices(
+                    coinIds: coinIds,
+                    priceService: service) { identities in
+                        guard let zapperProvider, !identities.isEmpty else {
+                            return PricePollingIDResolver.emptyUpdate
+                        }
+                        return try await zapperProvider.fetchPriceUpdate(for: identities)
+                    }
+            },
+            fetchCoinGeckoPrices: { request in
+                try await LivePriceUpdateBuilder.fetchCoinGeckoPrices(
+                    request: request,
+                    priceService: service)
+            },
+            fetchZapperPrices: { identities in
+                guard let zapperProvider, !identities.isEmpty else {
+                    return PricePollingIDResolver.emptyUpdate
+                }
+                return try await zapperProvider.fetchPriceUpdate(for: identities)
+            },
+            fetchHistoricalPrices: { coinId, days in
+                try await service.fetchHistoricalPrices(for: coinId, days: days)
+            },
+            resolveCoinGeckoIDs: { identities in
+                try await service.resolveCoinGeckoIDs(for: identities)
+            },
+            fetchZapperHistoricalPrices: { identity, days in
+                guard let zapperProvider else {
+                    throw ClientError.zapperProviderUnavailable
+                }
+                return try await zapperProvider.fetchHistoricalPrices(identity: identity, days: days)
+            },
+            canFetchZapperHistoricalPrices: { zapperProvider != nil },
+            invalidateCache: { await service.invalidateCache() })
+    }
+}
+
+extension DependencyValues {
+    var priceService: PriceServiceClient {
+        get { self[PriceServiceClient.self] }
+        set { self[PriceServiceClient.self] = newValue }
+    }
+}
+
+// MARK: - PricePollingSettingsClient
+
+struct PricePollingSettingsClient {
+    var refreshInterval: @Sendable () -> Duration
+    var zapperFallbackInterval: @Sendable () -> Duration?
+}
+
+extension PricePollingSettingsClient: DependencyKey {
+    static let liveValue = Self(
+        refreshInterval: { PricePollingSettings.refreshInterval() },
+        zapperFallbackInterval: { ProviderIntervalSettings.zapperLivePriceInterval() })
+    static let testValue = Self(
+        refreshInterval: { .seconds(PricePollingSettings.defaultRefreshIntervalSeconds) },
+        zapperFallbackInterval: { .seconds(ProviderIntervalSettings.defaultZapperLivePriceIntervalSeconds) })
+}
+
+extension DependencyValues {
+    var pricePollingSettings: PricePollingSettingsClient {
+        get { self[PricePollingSettingsClient.self] }
+        set { self[PricePollingSettingsClient.self] = newValue }
+    }
+}
+
+// MARK: - ProviderSyncSettingsClient
+
+struct ProviderSyncSettingsClient {
+    var zapperPortfolioSyncInterval: @Sendable () -> Duration?
+    var exchangePortfolioSyncInterval: @Sendable () -> Duration?
+}
+
+extension ProviderSyncSettingsClient: DependencyKey {
+    static let liveValue = Self(
+        zapperPortfolioSyncInterval: { ProviderIntervalSettings.zapperPortfolioSyncInterval() },
+        exchangePortfolioSyncInterval: { ProviderIntervalSettings.exchangePortfolioSyncInterval() })
+    static let testValue = Self(
+        zapperPortfolioSyncInterval: { .seconds(ProviderIntervalSettings.defaultZapperPortfolioSyncIntervalSeconds) },
+        exchangePortfolioSyncInterval: { .seconds(ProviderIntervalSettings.defaultExchangePortfolioSyncIntervalSeconds) })
+}
+
+extension DependencyValues {
+    var providerSyncSettings: ProviderSyncSettingsClient {
+        get { self[ProviderSyncSettingsClient.self] }
+        set { self[ProviderSyncSettingsClient.self] = newValue }
+    }
+}
+
+// MARK: - CurrentDateClient
+
+struct CurrentDateClient {
+    var now: @Sendable () -> Date
+}
+
+extension CurrentDateClient: DependencyKey {
+    static let liveValue = Self(now: { Date.now })
+    static let testValue = Self(now: { Date(timeIntervalSince1970: 1_000_000) })
+}
+
+extension DependencyValues {
+    var currentDate: CurrentDateClient {
+        get { self[CurrentDateClient.self] }
+        set { self[CurrentDateClient.self] = newValue }
+    }
+}

--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -3,211 +3,6 @@ import Foundation
 import PortuCore
 import PortuNetwork
 
-// MARK: - SyncEngineClient
-
-struct SyncResult: Equatable {
-    var failedAccounts: [String]
-    var isPartial: Bool {
-        !failedAccounts.isEmpty
-    }
-}
-
-struct SyncEngineClient {
-    var sync: @Sendable () async throws -> SyncResult
-}
-
-extension SyncEngineClient: DependencyKey {
-    static let liveValue = Self(
-        sync: { fatalError("SyncEngineClient.liveValue must be overridden at Store creation") })
-    static let testValue = Self(
-        sync: { SyncResult(failedAccounts: []) })
-
-    static func live(engine: SyncEngine) -> Self {
-        Self(sync: { try await engine.sync() })
-    }
-}
-
-extension DependencyValues {
-    var syncEngine: SyncEngineClient {
-        get { self[SyncEngineClient.self] }
-        set { self[SyncEngineClient.self] = newValue }
-    }
-}
-
-// MARK: - PriceServiceClient
-
-struct PriceServiceClient {
-    enum ClientError: Error {
-        /// Returned by `fetchZapperHistoricalPrices` when no Zapper API key is configured.
-        /// The backfill runner's upstream pre-filter normally prevents reaching this path,
-        /// but a missing key here means the candidate cannot be fetched — surface it as a
-        /// failure instead of silently returning an empty result set.
-        case zapperProviderUnavailable
-    }
-
-    var fetchPrices: @Sendable ([String]) async throws -> PriceUpdate
-    var fetchHistoricalPrices: @Sendable (String, Int) async throws -> [HistoricalPriceDTO]
-    var resolveCoinGeckoIDs: @Sendable ([OnchainTokenIdentity]) async throws -> [OnchainTokenIdentity: String]
-    var fetchZapperHistoricalPrices: @Sendable (OnchainTokenIdentity, Int) async throws -> [HistoricalPriceDTO]
-    var canFetchZapperHistoricalPrices: @Sendable () -> Bool
-    var invalidateCache: @Sendable () async -> Void
-
-    init(
-        fetchPrices: @escaping @Sendable ([String]) async throws -> PriceUpdate,
-        fetchHistoricalPrices: @escaping @Sendable (String, Int) async throws -> [HistoricalPriceDTO],
-        resolveCoinGeckoIDs: @escaping @Sendable ([OnchainTokenIdentity]) async throws -> [OnchainTokenIdentity: String] = { _ in [:] },
-        fetchZapperHistoricalPrices: @escaping @Sendable (OnchainTokenIdentity, Int) async throws -> [HistoricalPriceDTO] = { _, _ in [] },
-        canFetchZapperHistoricalPrices: @escaping @Sendable () -> Bool = { true },
-        invalidateCache: @escaping @Sendable () async -> Void) {
-        self.fetchPrices = fetchPrices
-        self.fetchHistoricalPrices = fetchHistoricalPrices
-        self.resolveCoinGeckoIDs = resolveCoinGeckoIDs
-        self.fetchZapperHistoricalPrices = fetchZapperHistoricalPrices
-        self.canFetchZapperHistoricalPrices = canFetchZapperHistoricalPrices
-        self.invalidateCache = invalidateCache
-    }
-}
-
-enum LivePriceUpdateBuilder {
-    static func fetchPrices(
-        coinIds: [String],
-        priceService: PriceService,
-        fetchZapperUpdate: @escaping @Sendable ([OnchainTokenIdentity]) async throws -> PriceUpdate) async throws -> PriceUpdate {
-        let request = PricePollingIDResolver.split(coinIds)
-        let coinGeckoUpdate = try await fetchCoinGeckoIDUpdate(
-            coinIDs: request.coinGeckoIDs,
-            priceService: priceService,
-            allowEmptyOnFailure: !request.zapperIdentities.isEmpty)
-        let tokenUpdate = await fetchCoinGeckoTokenUpdate(
-            identities: request.zapperIdentities,
-            priceService: priceService)
-        let unresolvedZapperIdentities = request.zapperIdentities.filter {
-            tokenUpdate.prices[$0.historicalPriceID] == nil
-        }
-        let zapperUpdate: PriceUpdate
-        do {
-            zapperUpdate = try await fetchZapperUpdate(unresolvedZapperIdentities)
-        } catch {
-            zapperUpdate = PricePollingIDResolver.emptyUpdate
-        }
-        return PricePollingIDResolver.merge([coinGeckoUpdate, tokenUpdate, zapperUpdate])
-    }
-
-    private static func fetchCoinGeckoIDUpdate(
-        coinIDs: [String],
-        priceService: PriceService,
-        allowEmptyOnFailure: Bool) async throws -> PriceUpdate {
-        guard !coinIDs.isEmpty else { return PricePollingIDResolver.emptyUpdate }
-        do {
-            return try await priceService.fetchPriceUpdate(for: coinIDs)
-        } catch {
-            guard allowEmptyOnFailure else { throw error }
-            return PricePollingIDResolver.emptyUpdate
-        }
-    }
-
-    private static func fetchCoinGeckoTokenUpdate(
-        identities: [OnchainTokenIdentity],
-        priceService: PriceService) async -> PriceUpdate {
-        guard !identities.isEmpty else { return PricePollingIDResolver.emptyUpdate }
-        do {
-            return try await priceService.fetchTokenPriceUpdate(for: identities)
-        } catch {
-            return PricePollingIDResolver.emptyUpdate
-        }
-    }
-}
-
-extension PriceServiceClient: DependencyKey {
-    static let liveValue = Self(
-        fetchPrices: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
-        fetchHistoricalPrices: { _, _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
-        resolveCoinGeckoIDs: { _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
-        fetchZapperHistoricalPrices: { _, _ in fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
-        canFetchZapperHistoricalPrices: { fatalError("PriceServiceClient.liveValue must be overridden at Store creation") },
-        invalidateCache: { fatalError("PriceServiceClient.liveValue must be overridden at Store creation") })
-    static let testValue = Self(
-        fetchPrices: { _ in PriceUpdate(prices: [:], changes24h: [:]) },
-        fetchHistoricalPrices: { _, _ in [] },
-        resolveCoinGeckoIDs: { _ in [:] },
-        fetchZapperHistoricalPrices: { _, _ in [] },
-        canFetchZapperHistoricalPrices: { true },
-        invalidateCache: {})
-
-    static func live(service: PriceService, zapperProvider: ZapperProvider? = nil) -> Self {
-        Self(
-            fetchPrices: { coinIds in
-                try await LivePriceUpdateBuilder.fetchPrices(
-                    coinIds: coinIds,
-                    priceService: service) { identities in
-                        guard let zapperProvider, !identities.isEmpty else {
-                            return PricePollingIDResolver.emptyUpdate
-                        }
-                        return try await zapperProvider.fetchPriceUpdate(for: identities)
-                    }
-            },
-            fetchHistoricalPrices: { coinId, days in
-                try await service.fetchHistoricalPrices(for: coinId, days: days)
-            },
-            resolveCoinGeckoIDs: { identities in
-                try await service.resolveCoinGeckoIDs(for: identities)
-            },
-            fetchZapperHistoricalPrices: { identity, days in
-                guard let zapperProvider else {
-                    throw ClientError.zapperProviderUnavailable
-                }
-                return try await zapperProvider.fetchHistoricalPrices(identity: identity, days: days)
-            },
-            canFetchZapperHistoricalPrices: { zapperProvider != nil },
-            invalidateCache: { await service.invalidateCache() })
-    }
-}
-
-extension DependencyValues {
-    var priceService: PriceServiceClient {
-        get { self[PriceServiceClient.self] }
-        set { self[PriceServiceClient.self] = newValue }
-    }
-}
-
-// MARK: - PricePollingSettingsClient
-
-struct PricePollingSettingsClient {
-    var refreshInterval: @Sendable () -> Duration
-}
-
-extension PricePollingSettingsClient: DependencyKey {
-    static let liveValue = Self(
-        refreshInterval: { PricePollingSettings.refreshInterval() })
-    static let testValue = Self(
-        refreshInterval: { .seconds(PricePollingSettings.defaultRefreshIntervalSeconds) })
-}
-
-extension DependencyValues {
-    var pricePollingSettings: PricePollingSettingsClient {
-        get { self[PricePollingSettingsClient.self] }
-        set { self[PricePollingSettingsClient.self] = newValue }
-    }
-}
-
-// MARK: - CurrentDateClient
-
-struct CurrentDateClient {
-    var now: @Sendable () -> Date
-}
-
-extension CurrentDateClient: DependencyKey {
-    static let liveValue = Self(now: { Date.now })
-    static let testValue = Self(now: { Date(timeIntervalSince1970: 1_000_000) })
-}
-
-extension DependencyValues {
-    var currentDate: CurrentDateClient {
-        get { self[CurrentDateClient.self] }
-        set { self[CurrentDateClient.self] = newValue }
-    }
-}
-
 // MARK: - AppFeature
 
 @Reducer
@@ -244,6 +39,10 @@ struct AppFeature {
         case syncTapped
         case syncProgressUpdated(Double)
         case syncCompleted(Result<SyncResult, Error>)
+        case startScheduledSync
+        case stopScheduledSync
+        case scheduledSyncDue(PortfolioSyncScope)
+        case scheduledSyncCompleted(Result<SyncResult, Error>)
         case startPricePolling([String])
         case stopPricePolling
         case pricesReceived(PriceUpdate)
@@ -258,11 +57,13 @@ struct AppFeature {
 
     private enum CancelID {
         case pricePolling
+        case scheduledSync
     }
 
     @Dependency(\.syncEngine) var syncEngine
     @Dependency(\.priceService) var priceService
     @Dependency(\.pricePollingSettings) var pricePollingSettings
+    @Dependency(\.providerSyncSettings) var providerSyncSettings
     @Dependency(\.continuousClock) var clock
     @Dependency(\.currentDate) var currentDate
 
@@ -322,20 +123,90 @@ struct AppFeature {
                 state.syncStatus = .error(error.localizedDescription)
                 return .none
 
-            case let .startPricePolling(coinIds):
-                state.connectionStatus = .fetching
-                return .run { send in
-                    while !Task.isCancelled {
-                        do {
-                            let update = try await priceService.fetchPrices(coinIds)
-                            await send(.pricesReceived(update))
-                        } catch {
-                            await send(.priceFetchFailed(error))
+            case .startScheduledSync:
+                var effects: [Effect<Action>] = []
+                if let zapperInterval = providerSyncSettings.zapperPortfolioSyncInterval() {
+                    effects.append(.run { send in
+                        while !Task.isCancelled {
+                            try await clock.sleep(for: zapperInterval)
+                            await send(.scheduledSyncDue(.zapper))
                         }
-                        try await clock.sleep(for: pricePollingSettings.refreshInterval())
-                    }
+                    })
                 }
-                .cancellable(id: CancelID.pricePolling, cancelInFlight: true)
+                if let exchangeInterval = providerSyncSettings.exchangePortfolioSyncInterval() {
+                    effects.append(.run { send in
+                        while !Task.isCancelled {
+                            try await clock.sleep(for: exchangeInterval)
+                            await send(.scheduledSyncDue(.exchange))
+                        }
+                    })
+                }
+                guard effects.isEmpty == false else { return .none }
+                return .merge(effects)
+                    .cancellable(id: CancelID.scheduledSync, cancelInFlight: true)
+
+            case .stopScheduledSync:
+                return .cancel(id: CancelID.scheduledSync)
+
+            case let .scheduledSyncDue(scope):
+                if case .syncing = state.syncStatus { return .none }
+                state.syncStatus = .syncing(progress: 0)
+                return .run { send in
+                    let result = try await syncEngine.syncScope(scope)
+                    await send(.scheduledSyncCompleted(.success(result)))
+                } catch: { error, send in
+                    await send(.scheduledSyncCompleted(.failure(error)))
+                }
+
+            case let .scheduledSyncCompleted(.success(result)):
+                if result.isPartial {
+                    state.syncStatus = .completedWithErrors(failedAccounts: result.failedAccounts)
+                } else {
+                    state.syncStatus = .idle
+                }
+                return .none
+
+            case let .scheduledSyncCompleted(.failure(error)):
+                state.syncStatus = .error(error.localizedDescription)
+                return .none
+
+            case let .startPricePolling(coinIds):
+                let request = PricePollingIDResolver.split(coinIds)
+                guard request.isEmpty == false else { return .none }
+                state.connectionStatus = .fetching
+
+                var effects: [Effect<Action>] = [
+                    .run { send in
+                        while !Task.isCancelled {
+                            do {
+                                let update = try await priceService.fetchCoinGeckoPrices(request)
+                                await send(.pricesReceived(update))
+                            } catch {
+                                await send(.priceFetchFailed(error))
+                            }
+                            try await clock.sleep(for: pricePollingSettings.refreshInterval())
+                        }
+                    }
+                ]
+
+                if
+                    request.zapperIdentities.isEmpty == false,
+                    let zapperFallbackInterval = pricePollingSettings.zapperFallbackInterval() {
+                    effects.append(.run { send in
+                        while !Task.isCancelled {
+                            do {
+                                let update = try await priceService.fetchZapperPrices(request.zapperIdentities)
+                                await send(.pricesReceived(update))
+                            } catch {
+                                await send(.priceFetchFailed(error))
+                            }
+                            try await clock.sleep(for: zapperFallbackInterval)
+                        }
+                    })
+                }
+
+                return .merge(effects)
+                    .cancellable(id: CancelID.pricePolling, cancelInFlight: true)
 
             case let .pricesReceived(update):
                 state.prices.merge(update.prices) { _, new in new }
@@ -386,6 +257,11 @@ extension AppFeature.Action: Equatable {
         case let (.syncProgressUpdated(l), .syncProgressUpdated(r)): l == r
         case let (.syncCompleted(.success(l)), .syncCompleted(.success(r))): l == r
         case (.syncCompleted(.failure), .syncCompleted(.failure)): true
+        case (.startScheduledSync, .startScheduledSync): true
+        case (.stopScheduledSync, .stopScheduledSync): true
+        case let (.scheduledSyncDue(l), .scheduledSyncDue(r)): l == r
+        case let (.scheduledSyncCompleted(.success(l)), .scheduledSyncCompleted(.success(r))): l == r
+        case (.scheduledSyncCompleted(.failure), .scheduledSyncCompleted(.failure)): true
         case let (.startPricePolling(l), .startPricePolling(r)): l == r
         case (.stopPricePolling, .stopPricePolling): true
         case let (.pricesReceived(l), .pricesReceived(r)): l == r

--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -124,26 +124,43 @@ struct AppFeature {
                 return .none
 
             case .startScheduledSync:
-                var effects: [Effect<Action>] = []
-                if let zapperInterval = providerSyncSettings.zapperPortfolioSyncInterval() {
-                    effects.append(.run { send in
-                        while !Task.isCancelled {
-                            try await clock.sleep(for: zapperInterval)
-                            await send(.scheduledSyncDue(.zapper))
+                return .run { send in
+                    var lastZapperSync = currentDate.now()
+                    var lastExchangeSync = currentDate.now()
+
+                    while !Task.isCancelled {
+                        let now = currentDate.now()
+                        let zapperInterval = providerSyncSettings.zapperPortfolioSyncInterval()
+                        let exchangeInterval = providerSyncSettings.exchangePortfolioSyncInterval()
+
+                        if let zapperInterval {
+                            if now.timeIntervalSince(lastZapperSync) >= Self.timeInterval(for: zapperInterval) {
+                                lastZapperSync = now
+                                await send(.scheduledSyncDue(.zapper))
+                            }
+                        } else {
+                            lastZapperSync = now
                         }
-                    })
-                }
-                if let exchangeInterval = providerSyncSettings.exchangePortfolioSyncInterval() {
-                    effects.append(.run { send in
-                        while !Task.isCancelled {
-                            try await clock.sleep(for: exchangeInterval)
-                            await send(.scheduledSyncDue(.exchange))
+
+                        if let exchangeInterval {
+                            if now.timeIntervalSince(lastExchangeSync) >= Self.timeInterval(for: exchangeInterval) {
+                                lastExchangeSync = now
+                                await send(.scheduledSyncDue(.exchange))
+                            }
+                        } else {
+                            lastExchangeSync = now
                         }
-                    })
+
+                        let sleepDuration = Self.scheduledSyncSleepDuration(
+                            now: now,
+                            lastZapperSync: lastZapperSync,
+                            lastExchangeSync: lastExchangeSync,
+                            zapperInterval: zapperInterval,
+                            exchangeInterval: exchangeInterval)
+                        try await clock.sleep(for: sleepDuration)
+                    }
                 }
-                guard effects.isEmpty == false else { return .none }
-                return .merge(effects)
-                    .cancellable(id: CancelID.scheduledSync, cancelInFlight: true)
+                .cancellable(id: CancelID.scheduledSync, cancelInFlight: true)
 
             case .stopScheduledSync:
                 return .cancel(id: CancelID.scheduledSync)
@@ -189,18 +206,32 @@ struct AppFeature {
                     }
                 ]
 
-                if
-                    request.zapperIdentities.isEmpty == false,
-                    let zapperFallbackInterval = pricePollingSettings.zapperFallbackInterval() {
+                if request.zapperIdentities.isEmpty == false {
                     effects.append(.run { send in
                         while !Task.isCancelled {
+                            guard let zapperFallbackInterval = pricePollingSettings.zapperFallbackInterval() else {
+                                try await clock.sleep(for: Self.settingsRecheckInterval)
+                                continue
+                            }
+
                             do {
                                 let update = try await priceService.fetchZapperPrices(request.zapperIdentities)
                                 await send(.pricesReceived(update))
                             } catch {
                                 await send(.priceFetchFailed(error))
                             }
-                            try await clock.sleep(for: zapperFallbackInterval)
+
+                            var elapsed: Duration = .zero
+                            while !Task.isCancelled {
+                                guard let currentInterval = pricePollingSettings.zapperFallbackInterval() else {
+                                    break
+                                }
+                                guard elapsed < currentInterval else { break }
+                                let remaining = currentInterval - elapsed
+                                let sleepDuration = Self.shorterDuration(remaining, Self.settingsRecheckInterval)
+                                try await clock.sleep(for: sleepDuration)
+                                elapsed += sleepDuration
+                            }
                         }
                     })
                 }
@@ -242,6 +273,49 @@ struct AppFeature {
                 return .none
             }
         }
+    }
+}
+
+private extension AppFeature {
+    static let settingsRecheckInterval: Duration = .seconds(10)
+
+    static func scheduledSyncSleepDuration(
+        now: Date,
+        lastZapperSync: Date,
+        lastExchangeSync: Date,
+        zapperInterval: Duration?,
+        exchangeInterval: Duration?) -> Duration {
+        var sleepDuration = settingsRecheckInterval
+
+        if let zapperInterval {
+            sleepDuration = shorterDuration(
+                sleepDuration,
+                remainingDuration(interval: zapperInterval, lastSync: lastZapperSync, now: now))
+        }
+
+        if let exchangeInterval {
+            sleepDuration = shorterDuration(
+                sleepDuration,
+                remainingDuration(interval: exchangeInterval, lastSync: lastExchangeSync, now: now))
+        }
+
+        return sleepDuration
+    }
+
+    static func remainingDuration(interval: Duration, lastSync: Date, now: Date) -> Duration {
+        let remainingSeconds = timeInterval(for: interval) - now.timeIntervalSince(lastSync)
+        guard remainingSeconds > 0 else { return .zero }
+        return .seconds(remainingSeconds)
+    }
+
+    static func shorterDuration(_ lhs: Duration, _ rhs: Duration) -> Duration {
+        lhs < rhs ? lhs : rhs
+    }
+
+    static func timeInterval(for duration: Duration) -> TimeInterval {
+        let components = duration.components
+        let attosecondsPerSecond = 1_000_000_000_000_000_000.0
+        return TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / attosecondsPerSecond
     }
 }
 

--- a/Sources/Portu/App/ContentView.swift
+++ b/Sources/Portu/App/ContentView.swift
@@ -13,6 +13,12 @@ struct ContentView: View {
             mainDashboard
         }
         .frame(minWidth: 900, minHeight: 600)
+        .task {
+            store.send(.startScheduledSync)
+        }
+        .onDisappear {
+            store.send(.stopScheduledSync)
+        }
     }
 
     private var mainDashboard: some View {

--- a/Sources/Portu/App/LivePriceUpdateBuilder.swift
+++ b/Sources/Portu/App/LivePriceUpdateBuilder.swift
@@ -1,0 +1,66 @@
+import Foundation
+import PortuCore
+import PortuNetwork
+
+enum LivePriceUpdateBuilder {
+    static func fetchPrices(
+        coinIds: [String],
+        priceService: PriceService,
+        fetchZapperUpdate: @escaping @Sendable ([OnchainTokenIdentity]) async throws -> PriceUpdate) async throws -> PriceUpdate {
+        let request = PricePollingIDResolver.split(coinIds)
+        let coinGeckoUpdate = try await fetchCoinGeckoIDUpdate(
+            coinIDs: request.coinGeckoIDs,
+            priceService: priceService,
+            allowEmptyOnFailure: !request.zapperIdentities.isEmpty)
+        let tokenUpdate = await fetchCoinGeckoTokenUpdate(
+            identities: request.zapperIdentities,
+            priceService: priceService)
+        let unresolvedZapperIdentities = request.zapperIdentities.filter {
+            tokenUpdate.prices[$0.historicalPriceID] == nil
+        }
+        let zapperUpdate: PriceUpdate
+        do {
+            zapperUpdate = try await fetchZapperUpdate(unresolvedZapperIdentities)
+        } catch {
+            zapperUpdate = PricePollingIDResolver.emptyUpdate
+        }
+        return PricePollingIDResolver.merge([coinGeckoUpdate, tokenUpdate, zapperUpdate])
+    }
+
+    static func fetchCoinGeckoPrices(
+        request: PricePollingRequest,
+        priceService: PriceService) async throws -> PriceUpdate {
+        let coinGeckoUpdate = try await fetchCoinGeckoIDUpdate(
+            coinIDs: request.coinGeckoIDs,
+            priceService: priceService,
+            allowEmptyOnFailure: !request.zapperIdentities.isEmpty)
+        let tokenUpdate = await fetchCoinGeckoTokenUpdate(
+            identities: request.zapperIdentities,
+            priceService: priceService)
+        return PricePollingIDResolver.merge([coinGeckoUpdate, tokenUpdate])
+    }
+
+    private static func fetchCoinGeckoIDUpdate(
+        coinIDs: [String],
+        priceService: PriceService,
+        allowEmptyOnFailure: Bool) async throws -> PriceUpdate {
+        guard !coinIDs.isEmpty else { return PricePollingIDResolver.emptyUpdate }
+        do {
+            return try await priceService.fetchPriceUpdate(for: coinIDs)
+        } catch {
+            guard allowEmptyOnFailure else { throw error }
+            return PricePollingIDResolver.emptyUpdate
+        }
+    }
+
+    private static func fetchCoinGeckoTokenUpdate(
+        identities: [OnchainTokenIdentity],
+        priceService: PriceService) async -> PriceUpdate {
+        guard !identities.isEmpty else { return PricePollingIDResolver.emptyUpdate }
+        do {
+            return try await priceService.fetchTokenPriceUpdate(for: identities)
+        } catch {
+            return PricePollingIDResolver.emptyUpdate
+        }
+    }
+}

--- a/Sources/Portu/App/PortuApp.swift
+++ b/Sources/Portu/App/PortuApp.swift
@@ -134,6 +134,21 @@ struct PortuApp: App {
                         return try await zapperProvider.fetchPriceUpdate(for: identities)
                     }
             },
+            fetchCoinGeckoPrices: { request in
+                try await LivePriceUpdateBuilder.fetchCoinGeckoPrices(
+                    request: request,
+                    priceService: priceService)
+            },
+            fetchZapperPrices: { identities in
+                guard
+                    !identities.isEmpty,
+                    let apiKey = zapperAPIKey(from: secretStore)
+                else {
+                    return PricePollingIDResolver.emptyUpdate
+                }
+                let zapperProvider = ZapperProvider(apiKey: apiKey, session: session)
+                return try await zapperProvider.fetchPriceUpdate(for: identities)
+            },
             fetchHistoricalPrices: { coinId, days in
                 try await priceService.fetchHistoricalPrices(for: coinId, days: days)
             },

--- a/Sources/Portu/App/PricePollingIDResolver.swift
+++ b/Sources/Portu/App/PricePollingIDResolver.swift
@@ -4,6 +4,14 @@ import PortuCore
 struct PricePollingRequest: Equatable {
     var coinGeckoIDs: [String]
     var zapperIdentities: [OnchainTokenIdentity]
+
+    var isEmpty: Bool {
+        coinGeckoIDs.isEmpty && zapperIdentities.isEmpty
+    }
+
+    var allPriceIDs: [String] {
+        coinGeckoIDs + zapperIdentities.map(\.historicalPriceID)
+    }
 }
 
 enum PricePollingIDResolver {

--- a/Sources/Portu/App/PricePollingSettings.swift
+++ b/Sources/Portu/App/PricePollingSettings.swift
@@ -3,7 +3,7 @@ import Foundation
 enum PricePollingSettings {
     static let refreshIntervalKey = "refreshInterval"
     static let defaultRefreshIntervalSeconds = 30.0
-    static let allowedRefreshIntervalSeconds: Set<Double> = [15, 30, 60, 300]
+    static let allowedRefreshIntervalSeconds: Set<Double> = [30, 60, 300, 900, 3600, 21600, 86400]
 
     static func refreshIntervalSeconds(defaults: UserDefaults = .standard) -> Double {
         guard
@@ -18,5 +18,77 @@ enum PricePollingSettings {
 
     static func refreshInterval(defaults: UserDefaults = .standard) -> Duration {
         .seconds(refreshIntervalSeconds(defaults: defaults))
+    }
+}
+
+enum ProviderIntervalSettings {
+    static let manualOnlySeconds = 0.0
+
+    static let zapperLivePriceIntervalKey = "providerIntervals.zapperLivePrice"
+    static let zapperPortfolioSyncIntervalKey = "providerIntervals.zapperPortfolioSync"
+    static let exchangePortfolioSyncIntervalKey = "providerIntervals.exchangePortfolioSync"
+
+    static let defaultZapperLivePriceIntervalSeconds = 3600.0
+    static let defaultZapperPortfolioSyncIntervalSeconds = 21600.0
+    static let defaultExchangePortfolioSyncIntervalSeconds = 3600.0
+
+    static let allowedZapperLivePriceIntervalSeconds: Set<Double> = [0, 600, 3600, 21600, 86400]
+    static let allowedZapperPortfolioSyncIntervalSeconds: Set<Double> = [0, 3600, 21600, 86400]
+    static let allowedExchangePortfolioSyncIntervalSeconds: Set<Double> = [0, 600, 3600, 21600, 86400]
+
+    static func zapperLivePriceIntervalSeconds(defaults: UserDefaults = .standard) -> Double {
+        intervalSeconds(
+            key: zapperLivePriceIntervalKey,
+            defaultValue: defaultZapperLivePriceIntervalSeconds,
+            allowedValues: allowedZapperLivePriceIntervalSeconds,
+            defaults: defaults)
+    }
+
+    static func zapperLivePriceInterval(defaults: UserDefaults = .standard) -> Duration? {
+        duration(for: zapperLivePriceIntervalSeconds(defaults: defaults))
+    }
+
+    static func zapperPortfolioSyncIntervalSeconds(defaults: UserDefaults = .standard) -> Double {
+        intervalSeconds(
+            key: zapperPortfolioSyncIntervalKey,
+            defaultValue: defaultZapperPortfolioSyncIntervalSeconds,
+            allowedValues: allowedZapperPortfolioSyncIntervalSeconds,
+            defaults: defaults)
+    }
+
+    static func zapperPortfolioSyncInterval(defaults: UserDefaults = .standard) -> Duration? {
+        duration(for: zapperPortfolioSyncIntervalSeconds(defaults: defaults))
+    }
+
+    static func exchangePortfolioSyncIntervalSeconds(defaults: UserDefaults = .standard) -> Double {
+        intervalSeconds(
+            key: exchangePortfolioSyncIntervalKey,
+            defaultValue: defaultExchangePortfolioSyncIntervalSeconds,
+            allowedValues: allowedExchangePortfolioSyncIntervalSeconds,
+            defaults: defaults)
+    }
+
+    static func exchangePortfolioSyncInterval(defaults: UserDefaults = .standard) -> Duration? {
+        duration(for: exchangePortfolioSyncIntervalSeconds(defaults: defaults))
+    }
+
+    private static func intervalSeconds(
+        key: String,
+        defaultValue: Double,
+        allowedValues: Set<Double>,
+        defaults: UserDefaults) -> Double {
+        guard
+            let stored = defaults.object(forKey: key) as? Double,
+            allowedValues.contains(stored)
+        else {
+            return defaultValue
+        }
+
+        return stored
+    }
+
+    private static func duration(for seconds: Double) -> Duration? {
+        guard seconds != manualOnlySeconds else { return nil }
+        return .seconds(seconds)
     }
 }

--- a/Sources/Portu/Features/Settings/SettingsIntervalRow.swift
+++ b/Sources/Portu/Features/Settings/SettingsIntervalRow.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct SettingsIntervalOption: Identifiable, Equatable {
+    let seconds: Double
+    let title: String
+
+    var id: Double {
+        seconds
+    }
+}
+
+extension [SettingsIntervalOption] {
+    static let coinGeckoLivePrices: Self = [
+        SettingsIntervalOption(seconds: 30, title: "30 seconds"),
+        SettingsIntervalOption(seconds: 60, title: "1 minute"),
+        SettingsIntervalOption(seconds: 300, title: "5 minutes"),
+        SettingsIntervalOption(seconds: 900, title: "15 minutes"),
+        SettingsIntervalOption(seconds: 3600, title: "1 hour"),
+        SettingsIntervalOption(seconds: 21600, title: "6 hours"),
+        SettingsIntervalOption(seconds: 86400, title: "24 hours")
+    ]
+
+    static let zapperLivePriceFallback: Self = [
+        SettingsIntervalOption(seconds: 0, title: "Manual only"),
+        SettingsIntervalOption(seconds: 600, title: "10 minutes"),
+        SettingsIntervalOption(seconds: 3600, title: "1 hour"),
+        SettingsIntervalOption(seconds: 21600, title: "6 hours"),
+        SettingsIntervalOption(seconds: 86400, title: "24 hours")
+    ]
+
+    static let zapperPortfolioSync: Self = [
+        SettingsIntervalOption(seconds: 0, title: "Manual only"),
+        SettingsIntervalOption(seconds: 3600, title: "1 hour"),
+        SettingsIntervalOption(seconds: 21600, title: "6 hours"),
+        SettingsIntervalOption(seconds: 86400, title: "24 hours")
+    ]
+
+    static let exchangePortfolioSync: Self = [
+        SettingsIntervalOption(seconds: 0, title: "Manual only"),
+        SettingsIntervalOption(seconds: 600, title: "10 minutes"),
+        SettingsIntervalOption(seconds: 3600, title: "1 hour"),
+        SettingsIntervalOption(seconds: 21600, title: "6 hours"),
+        SettingsIntervalOption(seconds: 86400, title: "24 hours")
+    ]
+}
+
+struct SettingsIntervalRow: View {
+    let title: String
+    let subtitle: String
+    @Binding var selection: Double
+    let fallbackSeconds: Double
+    let options: [SettingsIntervalOption]
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 18) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
+                    .foregroundStyle(SettingsDesign.primaryText)
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(SettingsDesign.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 18)
+
+            Menu {
+                ForEach(options) { option in
+                    if isSelected(option) {
+                        Button {
+                            selection = option.seconds
+                        } label: {
+                            Label(option.title, systemImage: "checkmark")
+                        }
+                    } else {
+                        Button(option.title) {
+                            selection = option.seconds
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(selectedTitle)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(SettingsDesign.secondaryText)
+                }
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(SettingsDesign.primaryText)
+                .padding(.horizontal, 12)
+                .frame(minWidth: 128, minHeight: SettingsMetrics.compactControlHeight)
+                .background(
+                    RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
+                        .fill(SettingsDesign.sidebarSearchBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
+                        .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, minHeight: SettingsDesign.switchRowMinHeight, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
+                .fill(SettingsDesign.subtleCardBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
+                .stroke(SettingsDesign.cardStroke, lineWidth: 1))
+    }
+
+    private var selectedTitle: String {
+        options.first { $0.seconds == selection }?.title
+            ?? options.first { $0.seconds == fallbackSeconds }?.title
+            ?? options.first?.title
+            ?? ""
+    }
+
+    private func isSelected(_ option: SettingsIntervalOption) -> Bool {
+        if options.contains(where: { $0.seconds == selection }) {
+            return selection == option.seconds
+        }
+        return option.seconds == fallbackSeconds
+    }
+}

--- a/Sources/Portu/Features/Settings/SettingsView.swift
+++ b/Sources/Portu/Features/Settings/SettingsView.swift
@@ -262,6 +262,12 @@ private struct GeneralSettingsTab: View {
 
     @AppStorage(PricePollingSettings.refreshIntervalKey)
     private var refreshInterval = PricePollingSettings.defaultRefreshIntervalSeconds
+    @AppStorage(ProviderIntervalSettings.zapperLivePriceIntervalKey)
+    private var zapperLivePriceInterval = ProviderIntervalSettings.defaultZapperLivePriceIntervalSeconds
+    @AppStorage(ProviderIntervalSettings.zapperPortfolioSyncIntervalKey)
+    private var zapperPortfolioSyncInterval = ProviderIntervalSettings.defaultZapperPortfolioSyncIntervalSeconds
+    @AppStorage(ProviderIntervalSettings.exchangePortfolioSyncIntervalKey)
+    private var exchangePortfolioSyncInterval = ProviderIntervalSettings.defaultExchangePortfolioSyncIntervalSeconds
     @AppStorage(HistoricalPriceBackfillSettings.isEnabledKey)
     private var historicalBackfillEnabled = HistoricalPriceBackfillSettings.defaultIsEnabled
 
@@ -269,20 +275,44 @@ private struct GeneralSettingsTab: View {
         SettingsPage(tab: .general) {
             VStack(alignment: .leading, spacing: 14) {
                 SettingsSectionCard(
-                    title: "Price Updates",
-                    subtitle: "Choose how often Portu refreshes token pricing.",
+                    title: "Live Prices",
+                    subtitle: "Choose automatic refresh intervals by price provider.",
                     icon: .priceUpdates) {
-                        VStack(alignment: .leading, spacing: 14) {
-                            VStack(alignment: .leading, spacing: 5) {
-                                Text("Refresh interval")
-                                    .font(.system(size: SettingsMetrics.rowTitleSize, weight: .bold))
-                                    .foregroundStyle(SettingsDesign.primaryText)
-                                Text("Default: 30 seconds")
-                                    .font(.footnote)
-                                    .foregroundStyle(SettingsDesign.secondaryText)
-                            }
+                        VStack(alignment: .leading, spacing: 10) {
+                            SettingsIntervalRow(
+                                title: "CoinGecko live prices",
+                                subtitle: "Default: 30 seconds. Longer intervals intentionally keep dashboard prices stale between refreshes.",
+                                selection: $refreshInterval,
+                                fallbackSeconds: PricePollingSettings.defaultRefreshIntervalSeconds,
+                                options: .coinGeckoLivePrices)
 
-                            RefreshIntervalControl(selection: $refreshInterval)
+                            SettingsIntervalRow(
+                                title: "Zapper live price fallback",
+                                subtitle: "Default: 1 hour. Used only for onchain tokens CoinGecko cannot price.",
+                                selection: $zapperLivePriceInterval,
+                                fallbackSeconds: ProviderIntervalSettings.defaultZapperLivePriceIntervalSeconds,
+                                options: .zapperLivePriceFallback)
+                        }
+                    }
+
+                SettingsSectionCard(
+                    title: "Portfolio Sync",
+                    subtitle: "Control automatic portfolio sync calls by provider.",
+                    icon: .priceUpdates) {
+                        VStack(alignment: .leading, spacing: 10) {
+                            SettingsIntervalRow(
+                                title: "Zapper portfolio sync",
+                                subtitle: "Default: 6 hours. Manual only disables scheduled Zapper portfolio refreshes.",
+                                selection: $zapperPortfolioSyncInterval,
+                                fallbackSeconds: ProviderIntervalSettings.defaultZapperPortfolioSyncIntervalSeconds,
+                                options: .zapperPortfolioSync)
+
+                            SettingsIntervalRow(
+                                title: "Exchange portfolio sync",
+                                subtitle: "Default: 1 hour. Manual only disables scheduled exchange portfolio refreshes.",
+                                selection: $exchangePortfolioSyncInterval,
+                                fallbackSeconds: ProviderIntervalSettings.defaultExchangePortfolioSyncIntervalSeconds,
+                                options: .exchangePortfolioSync)
                         }
                     }
 
@@ -324,7 +354,7 @@ private struct GeneralSettingsTab: View {
 
                 SettingsInfoCard(
                     title: "Auto-saved",
-                    message: "This setting is stored locally with AppStorage and applies across Portu views.")
+                    message: "These settings are stored locally with AppStorage and apply across Portu views.")
             }
         }
     }
@@ -387,74 +417,5 @@ enum HistoricalBackfillStatusFormatter {
             return "\(head):\(tail.prefix(6))...\(tail.suffix(4))"
         }
         return "\(trimmed.prefix(12))...\(trimmed.suffix(8))"
-    }
-}
-
-private enum RefreshIntervalOption: Double, CaseIterable, Identifiable {
-    case fifteenSeconds = 15
-    case thirtySeconds = 30
-    case oneMinute = 60
-    case fiveMinutes = 300
-
-    var id: Double {
-        rawValue
-    }
-
-    var title: String {
-        switch self {
-        case .fifteenSeconds: "15 seconds"
-        case .thirtySeconds: "30 seconds"
-        case .oneMinute: "1 minute"
-        case .fiveMinutes: "5 minutes"
-        }
-    }
-}
-
-private struct RefreshIntervalControl: View {
-    @Binding var selection: Double
-
-    var body: some View {
-        HStack(spacing: 0) {
-            ForEach(RefreshIntervalOption.allCases) { option in
-                Button {
-                    selection = option.rawValue
-                } label: {
-                    Text(option.title)
-                        .font(.footnote.weight(isSelected(option) ? .bold : .regular))
-                        .foregroundStyle(isSelected(option) ? SettingsDesign.primaryText : SettingsDesign.secondaryText)
-                        .frame(width: 84, height: 30)
-                        .background(selectedBackground(for: option))
-                }
-                .buttonStyle(.plain)
-
-                if option != .fiveMinutes {
-                    Rectangle()
-                        .fill(SettingsDesign.separator)
-                        .frame(width: 1, height: 24)
-                }
-            }
-        }
-        .padding(2)
-        .background(
-            RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
-                .fill(SettingsDesign.subtleCardBackground))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
-                .stroke(SettingsDesign.cardStroke, lineWidth: 1))
-    }
-
-    private func isSelected(_ option: RefreshIntervalOption) -> Bool {
-        selection == option.rawValue
-    }
-
-    @ViewBuilder
-    private func selectedBackground(for option: RefreshIntervalOption) -> some View {
-        if isSelected(option) {
-            RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
-                .fill(SettingsDesign.accentPrimary.opacity(0.42))
-                .overlay(
-                    RoundedRectangle(cornerRadius: SettingsDesign.controlCornerRadius, style: .continuous)
-                        .stroke(SettingsDesign.accentPrimary.opacity(0.62), lineWidth: 1))
-        }
     }
 }

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -23,6 +23,15 @@ final class SyncEngine: @unchecked Sendable {
         let activeSyncable = try fetchActiveSyncableAccounts()
         let activeManual = try fetchActiveManualAccounts()
 
+        return try await sync(activeSyncable: activeSyncable, activeManual: activeManual)
+    }
+
+    func sync(scope: PortfolioSyncScope) async throws -> SyncResult {
+        let activeSyncable = try fetchActiveSyncableAccounts(scope: scope)
+        return try await sync(activeSyncable: activeSyncable, activeManual: [])
+    }
+
+    private func sync(activeSyncable: [Account], activeManual: [Account]) async throws -> SyncResult {
         guard !activeSyncable.isEmpty || !activeManual.isEmpty else {
             throw SyncError.noActiveAccounts
         }
@@ -395,6 +404,17 @@ final class SyncEngine: @unchecked Sendable {
     private func fetchActiveSyncableAccounts() throws -> [Account] {
         let descriptor = FetchDescriptor<Account>()
         return try modelContext.fetch(descriptor).filter { $0.isActive && $0.dataSource != .manual }
+    }
+
+    private func fetchActiveSyncableAccounts(scope: PortfolioSyncScope) throws -> [Account] {
+        try fetchActiveSyncableAccounts().filter { account in
+            switch scope {
+            case .zapper:
+                account.dataSource == .zapper
+            case .exchange:
+                account.dataSource == .exchange
+            }
+        }
     }
 
     private func fetchActiveManualAccounts() throws -> [Account] {

--- a/Tests/PortuTests/AppFeatureIntervalTests.swift
+++ b/Tests/PortuTests/AppFeatureIntervalTests.swift
@@ -1,0 +1,208 @@
+import ComposableArchitecture
+import Foundation
+@testable import Portu
+import PortuCore
+import Testing
+
+@MainActor
+struct AppFeatureIntervalTests {
+    @Test func `scheduled provider sync uses provider intervals`() async {
+        let testClock = TestClock()
+        nonisolated(unsafe) var syncedScopes: [PortfolioSyncScope] = []
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.providerSyncSettings.zapperPortfolioSyncInterval = { .seconds(10) }
+            $0.providerSyncSettings.exchangePortfolioSyncInterval = { .seconds(21) }
+            $0.syncEngine.syncScope = { scope in
+                syncedScopes.append(scope)
+                return SyncResult(failedAccounts: [])
+            }
+            $0.continuousClock = testClock
+        }
+
+        await store.send(.startScheduledSync)
+        await testClock.advance(by: .seconds(9))
+        #expect(syncedScopes.isEmpty)
+
+        await testClock.advance(by: .seconds(1))
+        await store.receive(.scheduledSyncDue(.zapper)) {
+            $0.syncStatus = .syncing(progress: 0)
+        }
+        await store.receive(\.scheduledSyncCompleted) {
+            $0.syncStatus = .idle
+        }
+        #expect(syncedScopes == [.zapper])
+
+        await testClock.advance(by: .seconds(10))
+        await store.receive(.scheduledSyncDue(.zapper)) {
+            $0.syncStatus = .syncing(progress: 0)
+        }
+        await store.receive(\.scheduledSyncCompleted) {
+            $0.syncStatus = .idle
+        }
+        #expect(syncedScopes == [.zapper, .zapper])
+
+        await testClock.advance(by: .seconds(1))
+        await store.receive(.scheduledSyncDue(.exchange)) {
+            $0.syncStatus = .syncing(progress: 0)
+        }
+        await store.receive(\.scheduledSyncCompleted) {
+            $0.syncStatus = .idle
+        }
+        #expect(syncedScopes == [.zapper, .zapper, .exchange])
+
+        await store.send(.stopScheduledSync)
+    }
+
+    @Test func `manual only scheduled sync starts no automatic provider loops`() async {
+        let testClock = TestClock()
+        nonisolated(unsafe) var syncCount = 0
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.providerSyncSettings.zapperPortfolioSyncInterval = { nil }
+            $0.providerSyncSettings.exchangePortfolioSyncInterval = { nil }
+            $0.syncEngine.syncScope = { _ in
+                syncCount += 1
+                return SyncResult(failedAccounts: [])
+            }
+            $0.continuousClock = testClock
+        }
+
+        await store.send(.startScheduledSync)
+        await testClock.advance(by: .seconds(86400))
+        #expect(syncCount == 0)
+        await store.send(.stopScheduledSync)
+    }
+
+    @Test func `scheduled sync due skips while another sync is running`() async {
+        let testClock = TestClock()
+        nonisolated(unsafe) var syncCount = 0
+
+        let store = TestStore(
+            initialState: AppFeature.State(syncStatus: .syncing(progress: 0.25))) {
+                AppFeature()
+            } withDependencies: {
+                $0.providerSyncSettings.zapperPortfolioSyncInterval = { .seconds(5) }
+                $0.providerSyncSettings.exchangePortfolioSyncInterval = { nil }
+                $0.syncEngine.syncScope = { _ in
+                    syncCount += 1
+                    return SyncResult(failedAccounts: [])
+                }
+                $0.continuousClock = testClock
+            }
+
+        await store.send(.startScheduledSync)
+        await testClock.advance(by: .seconds(5))
+        await store.receive(.scheduledSyncDue(.zapper))
+        #expect(syncCount == 0)
+
+        await store.send(.stopScheduledSync)
+    }
+
+    @Test func `price polling with no ids leaves connection idle`() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+
+        await store.send(.startPricePolling([]))
+    }
+
+    @Test func `zapper price fallback uses independent refresh interval`() async {
+        let identity = OnchainTokenIdentity(chain: .base, contractAddress: "0xToken")
+        let testClock = TestClock()
+        let testDate = Date(timeIntervalSince1970: 1_000_000)
+        nonisolated(unsafe) var coinGeckoFetchCount = 0
+        nonisolated(unsafe) var zapperFetchCount = 0
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.priceService.fetchCoinGeckoPrices = { request in
+                coinGeckoFetchCount += 1
+                #expect(request.coinGeckoIDs == ["bitcoin"])
+                #expect(request.zapperIdentities == [identity])
+                return PriceUpdate(prices: ["bitcoin": Decimal(coinGeckoFetchCount)], changes24h: [:])
+            }
+            $0.priceService.fetchZapperPrices = { identities in
+                zapperFetchCount += 1
+                #expect(identities == [identity])
+                return PriceUpdate(
+                    prices: [identity.historicalPriceID: Decimal(zapperFetchCount * 10)],
+                    changes24h: [:])
+            }
+            $0.pricePollingSettings.refreshInterval = { .seconds(20) }
+            $0.pricePollingSettings.zapperFallbackInterval = { .seconds(5) }
+            $0.continuousClock = testClock
+            $0.currentDate.now = { testDate }
+        }
+
+        await store.send(.startPricePolling(["bitcoin", identity.historicalPriceID])) {
+            $0.connectionStatus = .fetching
+        }
+        await store.receive(\.pricesReceived) {
+            $0.prices = ["bitcoin": 1]
+            $0.lastPriceUpdate = testDate
+            $0.connectionStatus = .idle
+        }
+        await store.receive(\.pricesReceived) {
+            $0.prices = ["bitcoin": 1, identity.historicalPriceID: 10]
+            $0.lastPriceUpdate = testDate
+        }
+
+        await testClock.advance(by: .seconds(4))
+        #expect(coinGeckoFetchCount == 1)
+        #expect(zapperFetchCount == 1)
+
+        await testClock.advance(by: .seconds(1))
+        await store.receive(\.pricesReceived) {
+            $0.prices = ["bitcoin": 1, identity.historicalPriceID: 20]
+            $0.lastPriceUpdate = testDate
+        }
+        #expect(coinGeckoFetchCount == 1)
+        #expect(zapperFetchCount == 2)
+
+        await store.send(.stopPricePolling)
+    }
+
+    @Test func `manual only zapper price fallback suppresses automatic zapper calls`() async {
+        let identity = OnchainTokenIdentity(chain: .base, contractAddress: "0xToken")
+        let testClock = TestClock()
+        let testDate = Date(timeIntervalSince1970: 1_000_000)
+        nonisolated(unsafe) var zapperFetchCount = 0
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.priceService.fetchCoinGeckoPrices = { request in
+                #expect(request.coinGeckoIDs.isEmpty)
+                #expect(request.zapperIdentities == [identity])
+                return PriceUpdate(prices: [:], changes24h: [:])
+            }
+            $0.priceService.fetchZapperPrices = { _ in
+                zapperFetchCount += 1
+                return PriceUpdate(prices: [identity.historicalPriceID: 10], changes24h: [:])
+            }
+            $0.pricePollingSettings.refreshInterval = { .seconds(100) }
+            $0.pricePollingSettings.zapperFallbackInterval = { nil }
+            $0.continuousClock = testClock
+            $0.currentDate.now = { testDate }
+        }
+
+        await store.send(.startPricePolling([identity.historicalPriceID])) {
+            $0.connectionStatus = .fetching
+        }
+        await store.receive(\.pricesReceived) {
+            $0.lastPriceUpdate = testDate
+            $0.connectionStatus = .idle
+        }
+
+        await testClock.advance(by: .seconds(30))
+        #expect(zapperFetchCount == 0)
+
+        await store.send(.stopPricePolling)
+    }
+}

--- a/Tests/PortuTests/AppFeatureIntervalTests.swift
+++ b/Tests/PortuTests/AppFeatureIntervalTests.swift
@@ -8,6 +8,7 @@ import Testing
 struct AppFeatureIntervalTests {
     @Test func `scheduled provider sync uses provider intervals`() async {
         let testClock = TestClock()
+        nonisolated(unsafe) var now = Date(timeIntervalSince1970: 1_000_000)
         nonisolated(unsafe) var syncedScopes: [PortfolioSyncScope] = []
 
         let store = TestStore(initialState: AppFeature.State()) {
@@ -20,12 +21,15 @@ struct AppFeatureIntervalTests {
                 return SyncResult(failedAccounts: [])
             }
             $0.continuousClock = testClock
+            $0.currentDate.now = { now }
         }
 
         await store.send(.startScheduledSync)
+        now = now.addingTimeInterval(9)
         await testClock.advance(by: .seconds(9))
         #expect(syncedScopes.isEmpty)
 
+        now = now.addingTimeInterval(1)
         await testClock.advance(by: .seconds(1))
         await store.receive(.scheduledSyncDue(.zapper)) {
             $0.syncStatus = .syncing(progress: 0)
@@ -35,6 +39,7 @@ struct AppFeatureIntervalTests {
         }
         #expect(syncedScopes == [.zapper])
 
+        now = now.addingTimeInterval(10)
         await testClock.advance(by: .seconds(10))
         await store.receive(.scheduledSyncDue(.zapper)) {
             $0.syncStatus = .syncing(progress: 0)
@@ -44,6 +49,7 @@ struct AppFeatureIntervalTests {
         }
         #expect(syncedScopes == [.zapper, .zapper])
 
+        now = now.addingTimeInterval(1)
         await testClock.advance(by: .seconds(1))
         await store.receive(.scheduledSyncDue(.exchange)) {
             $0.syncStatus = .syncing(progress: 0)
@@ -56,8 +62,53 @@ struct AppFeatureIntervalTests {
         await store.send(.stopScheduledSync)
     }
 
+    @Test func `scheduled provider sync observes manual only changes after startup`() async {
+        let testClock = TestClock()
+        nonisolated(unsafe) var now = Date(timeIntervalSince1970: 1_000_000)
+        nonisolated(unsafe) var zapperInterval: Duration?
+        nonisolated(unsafe) var syncCount = 0
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.providerSyncSettings.zapperPortfolioSyncInterval = { zapperInterval }
+            $0.providerSyncSettings.exchangePortfolioSyncInterval = { nil }
+            $0.syncEngine.syncScope = { scope in
+                #expect(scope == .zapper)
+                syncCount += 1
+                return SyncResult(failedAccounts: [])
+            }
+            $0.continuousClock = testClock
+            $0.currentDate.now = { now }
+        }
+
+        await store.send(.startScheduledSync)
+        now = now.addingTimeInterval(30)
+        await testClock.advance(by: .seconds(30))
+        #expect(syncCount == 0)
+
+        zapperInterval = .seconds(10)
+        now = now.addingTimeInterval(10)
+        await testClock.advance(by: .seconds(10))
+        await store.receive(.scheduledSyncDue(.zapper)) {
+            $0.syncStatus = .syncing(progress: 0)
+        }
+        await store.receive(\.scheduledSyncCompleted) {
+            $0.syncStatus = .idle
+        }
+        #expect(syncCount == 1)
+
+        zapperInterval = nil
+        now = now.addingTimeInterval(30)
+        await testClock.advance(by: .seconds(30))
+        #expect(syncCount == 1)
+
+        await store.send(.stopScheduledSync)
+    }
+
     @Test func `manual only scheduled sync starts no automatic provider loops`() async {
         let testClock = TestClock()
+        nonisolated(unsafe) var now = Date(timeIntervalSince1970: 1_000_000)
         nonisolated(unsafe) var syncCount = 0
 
         let store = TestStore(initialState: AppFeature.State()) {
@@ -70,16 +121,19 @@ struct AppFeatureIntervalTests {
                 return SyncResult(failedAccounts: [])
             }
             $0.continuousClock = testClock
+            $0.currentDate.now = { now }
         }
 
         await store.send(.startScheduledSync)
-        await testClock.advance(by: .seconds(86400))
+        now = now.addingTimeInterval(30)
+        await testClock.advance(by: .seconds(30))
         #expect(syncCount == 0)
         await store.send(.stopScheduledSync)
     }
 
     @Test func `scheduled sync due skips while another sync is running`() async {
         let testClock = TestClock()
+        nonisolated(unsafe) var now = Date(timeIntervalSince1970: 1_000_000)
         nonisolated(unsafe) var syncCount = 0
 
         let store = TestStore(
@@ -93,9 +147,11 @@ struct AppFeatureIntervalTests {
                     return SyncResult(failedAccounts: [])
                 }
                 $0.continuousClock = testClock
+                $0.currentDate.now = { now }
             }
 
         await store.send(.startScheduledSync)
+        now = now.addingTimeInterval(5)
         await testClock.advance(by: .seconds(5))
         await store.receive(.scheduledSyncDue(.zapper))
         #expect(syncCount == 0)
@@ -164,6 +220,60 @@ struct AppFeatureIntervalTests {
         }
         #expect(coinGeckoFetchCount == 1)
         #expect(zapperFetchCount == 2)
+
+        await store.send(.stopPricePolling)
+    }
+
+    @Test func `zapper price fallback observes manual only changes after startup`() async {
+        let identity = OnchainTokenIdentity(chain: .base, contractAddress: "0xToken")
+        let testClock = TestClock()
+        let testDate = Date(timeIntervalSince1970: 1_000_000)
+        nonisolated(unsafe) var zapperInterval: Duration?
+        nonisolated(unsafe) var zapperFetchCount = 0
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.priceService.fetchCoinGeckoPrices = { request in
+                #expect(request.coinGeckoIDs.isEmpty)
+                #expect(request.zapperIdentities == [identity])
+                return PriceUpdate(prices: [:], changes24h: [:])
+            }
+            $0.priceService.fetchZapperPrices = { identities in
+                zapperFetchCount += 1
+                #expect(identities == [identity])
+                return PriceUpdate(
+                    prices: [identity.historicalPriceID: Decimal(zapperFetchCount * 10)],
+                    changes24h: [:])
+            }
+            $0.pricePollingSettings.refreshInterval = { .seconds(100) }
+            $0.pricePollingSettings.zapperFallbackInterval = { zapperInterval }
+            $0.continuousClock = testClock
+            $0.currentDate.now = { testDate }
+        }
+
+        await store.send(.startPricePolling([identity.historicalPriceID])) {
+            $0.connectionStatus = .fetching
+        }
+        await store.receive(\.pricesReceived) {
+            $0.lastPriceUpdate = testDate
+            $0.connectionStatus = .idle
+        }
+
+        await testClock.advance(by: .seconds(30))
+        #expect(zapperFetchCount == 0)
+
+        zapperInterval = .seconds(10)
+        await testClock.advance(by: .seconds(10))
+        await store.receive(\.pricesReceived) {
+            $0.prices = [identity.historicalPriceID: 10]
+            $0.lastPriceUpdate = testDate
+        }
+        #expect(zapperFetchCount == 1)
+
+        zapperInterval = nil
+        await testClock.advance(by: .seconds(30))
+        #expect(zapperFetchCount == 1)
 
         await store.send(.stopPricePolling)
     }

--- a/Tests/PortuTests/SettingsTabTests.swift
+++ b/Tests/PortuTests/SettingsTabTests.swift
@@ -82,13 +82,51 @@ struct SettingsTabTests {
         let defaults = cleanDefaults()
 
         #expect(PricePollingSettings.refreshIntervalKey == "refreshInterval")
+        #expect(PricePollingSettings.allowedRefreshIntervalSeconds == [30, 60, 300, 900, 3600, 21600, 86400])
         #expect(PricePollingSettings.refreshIntervalSeconds(defaults: defaults) == 30)
 
-        defaults.set(60.0, forKey: PricePollingSettings.refreshIntervalKey)
-        #expect(PricePollingSettings.refreshIntervalSeconds(defaults: defaults) == 60)
+        defaults.set(86400.0, forKey: PricePollingSettings.refreshIntervalKey)
+        #expect(PricePollingSettings.refreshIntervalSeconds(defaults: defaults) == 86400)
 
-        defaults.set(7.0, forKey: PricePollingSettings.refreshIntervalKey)
+        defaults.set(15.0, forKey: PricePollingSettings.refreshIntervalKey)
         #expect(PricePollingSettings.refreshIntervalSeconds(defaults: defaults) == 30)
+    }
+
+    @Test func `provider interval settings use provider keys defaults and allowed values`() {
+        let defaults = cleanDefaults()
+
+        #expect(ProviderIntervalSettings.manualOnlySeconds == 0)
+        #expect(ProviderIntervalSettings.zapperLivePriceIntervalKey == "providerIntervals.zapperLivePrice")
+        #expect(ProviderIntervalSettings.zapperPortfolioSyncIntervalKey == "providerIntervals.zapperPortfolioSync")
+        #expect(ProviderIntervalSettings.exchangePortfolioSyncIntervalKey == "providerIntervals.exchangePortfolioSync")
+
+        #expect(ProviderIntervalSettings.allowedZapperLivePriceIntervalSeconds == [0, 600, 3600, 21600, 86400])
+        #expect(ProviderIntervalSettings.allowedZapperPortfolioSyncIntervalSeconds == [0, 3600, 21600, 86400])
+        #expect(ProviderIntervalSettings.allowedExchangePortfolioSyncIntervalSeconds == [0, 600, 3600, 21600, 86400])
+
+        #expect(ProviderIntervalSettings.zapperLivePriceIntervalSeconds(defaults: defaults) == 3600)
+        #expect(ProviderIntervalSettings.zapperPortfolioSyncIntervalSeconds(defaults: defaults) == 21600)
+        #expect(ProviderIntervalSettings.exchangePortfolioSyncIntervalSeconds(defaults: defaults) == 3600)
+    }
+
+    @Test func `provider interval settings convert manual only to no duration`() {
+        let defaults = cleanDefaults()
+
+        defaults.set(0.0, forKey: ProviderIntervalSettings.zapperLivePriceIntervalKey)
+        defaults.set(0.0, forKey: ProviderIntervalSettings.zapperPortfolioSyncIntervalKey)
+        defaults.set(0.0, forKey: ProviderIntervalSettings.exchangePortfolioSyncIntervalKey)
+
+        #expect(ProviderIntervalSettings.zapperLivePriceInterval(defaults: defaults) == nil)
+        #expect(ProviderIntervalSettings.zapperPortfolioSyncInterval(defaults: defaults) == nil)
+        #expect(ProviderIntervalSettings.exchangePortfolioSyncInterval(defaults: defaults) == nil)
+
+        defaults.set(7.0, forKey: ProviderIntervalSettings.zapperLivePriceIntervalKey)
+        defaults.set(7.0, forKey: ProviderIntervalSettings.zapperPortfolioSyncIntervalKey)
+        defaults.set(7.0, forKey: ProviderIntervalSettings.exchangePortfolioSyncIntervalKey)
+
+        #expect(ProviderIntervalSettings.zapperLivePriceIntervalSeconds(defaults: defaults) == 3600)
+        #expect(ProviderIntervalSettings.zapperPortfolioSyncIntervalSeconds(defaults: defaults) == 21600)
+        #expect(ProviderIntervalSettings.exchangePortfolioSyncIntervalSeconds(defaults: defaults) == 3600)
     }
 
     @Test func `historical price settings use shared keys and labels`() {

--- a/Tests/PortuTests/SyncEngineScopedTests.swift
+++ b/Tests/PortuTests/SyncEngineScopedTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+@testable import Portu
+import PortuCore
+import PortuNetwork
+import SwiftData
+import Testing
+
+@MainActor
+struct SyncEngineScopedTests {
+    @Test func `scoped zapper sync fetches only zapper accounts`() async throws {
+        let context = try makeModelContext()
+        let provider = ScopedSyncStubProvider(balances: [
+            PositionDTO(
+                positionType: .idle,
+                chain: .ethereum,
+                protocolId: nil,
+                protocolName: nil,
+                protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
+        ])
+        nonisolated(unsafe) var resolvedSources: [DataSource] = []
+        let factory = ProviderFactory(resolver: { dataSource, _ in
+            resolvedSources.append(dataSource)
+            return provider
+        })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        let wallet = Account(name: "Wallet", kind: .wallet, dataSource: .zapper)
+        let exchange = Account(name: "Kraken", kind: .exchange, exchangeType: .kraken, dataSource: .exchange)
+        context.insert(wallet)
+        context.insert(exchange)
+        try context.save()
+
+        let result = try await engine.sync(scope: .zapper)
+
+        #expect(resolvedSources == [.zapper])
+        #expect(wallet.lastSyncedAt != nil)
+        #expect(exchange.lastSyncedAt == nil)
+        #expect(result.failedAccounts.isEmpty)
+        #expect(try context.fetch(FetchDescriptor<AccountSnapshot>()).count == 2)
+    }
+
+    @Test func `scoped exchange sync fetches only exchange accounts`() async throws {
+        let context = try makeModelContext()
+        let provider = ScopedSyncStubProvider(balances: [
+            PositionDTO(
+                positionType: .idle,
+                chain: nil,
+                protocolId: nil,
+                protocolName: nil,
+                protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "BTC", name: "Bitcoin", coinGeckoId: "bitcoin")])
+        ])
+        nonisolated(unsafe) var resolvedSources: [DataSource] = []
+        let factory = ProviderFactory(resolver: { dataSource, _ in
+            resolvedSources.append(dataSource)
+            return provider
+        })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        let wallet = Account(name: "Wallet", kind: .wallet, dataSource: .zapper)
+        let exchange = Account(name: "Kraken", kind: .exchange, exchangeType: .kraken, dataSource: .exchange)
+        context.insert(wallet)
+        context.insert(exchange)
+        try context.save()
+
+        let result = try await engine.sync(scope: .exchange)
+
+        #expect(resolvedSources == [.exchange])
+        #expect(wallet.lastSyncedAt == nil)
+        #expect(exchange.lastSyncedAt != nil)
+        #expect(result.failedAccounts.isEmpty)
+        #expect(try context.fetch(FetchDescriptor<AccountSnapshot>()).count == 2)
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let schema = Schema([
+            Account.self, WalletAddress.self, Position.self,
+            PositionToken.self, Asset.self, TokenPricingOverride.self,
+            TokenIdentityMapping.self,
+            HistoricalPricePoint.self,
+            PortfolioCategory.self, CategorySymbolRule.self,
+            PortfolioSnapshot.self, AccountSnapshot.self, AssetSnapshot.self
+        ])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        return ModelContext(container)
+    }
+
+    private func makeTokenDTO(
+        symbol: String,
+        name: String,
+        coinGeckoId: String?) -> TokenDTO {
+        TokenDTO(
+            role: .balance,
+            symbol: symbol,
+            name: name,
+            amount: 100,
+            usdValue: 100,
+            chain: nil,
+            contractAddress: nil,
+            debankId: nil,
+            coinGeckoId: coinGeckoId,
+            sourceKey: nil,
+            logoURL: nil,
+            category: .other,
+            isVerified: false)
+    }
+}
+
+private actor ScopedSyncStubProvider: PortfolioDataProvider {
+    nonisolated var capabilities: ProviderCapabilities {
+        ProviderCapabilities()
+    }
+
+    let balances: [PositionDTO]
+
+    init(balances: [PositionDTO]) {
+        self.balances = balances
+    }
+
+    func fetchBalances(context _: SyncContext) async throws -> [PositionDTO] {
+        balances
+    }
+}


### PR DESCRIPTION
## Summary
- Split live-price and portfolio sync intervals by provider/cost surface.
- Added independent CoinGecko and Zapper fallback price polling plus scheduled Zapper/exchange portfolio sync.
- Updated settings UI with cost-aware interval menus and added scoped sync coverage.

## Validation
- `just format`
- `just lint`
- `xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation -only-testing:PortuTests/AppFeatureTests -only-testing:PortuTests/AppFeatureIntervalTests -only-testing:PortuTests/SettingsTabTests -only-testing:PortuTests/SyncEngineTests -only-testing:PortuTests/SyncEngineScopedTests test`
- `xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled portfolio synchronization with configurable intervals per data source
  * Provider-specific interval settings for portfolio sync and live price updates now available in Settings
  * Enhanced Settings with grouped interval controls for different providers

* **Tests**
  * Added comprehensive tests for interval-driven scheduled sync behavior
  * Added provider interval configuration tests
  * Added scoped sync functionality tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->