### PR TITLE
feat: add editable accounts and scoped sync

### DIFF
--- a/Packages/PortuCore/Sources/PortuCore/Models/AccountSyncEligibility.swift
+++ b/Packages/PortuCore/Sources/PortuCore/Models/AccountSyncEligibility.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Single source of truth for whether an account is eligible for syncing.
+/// Inactive accounts are soft-hidden and manual accounts have no data source,
+/// so neither can be synced.
+public enum AccountSyncEligibility {
+    public static func isSyncable(isActive: Bool, dataSource: DataSource) -> Bool {
+        isActive && dataSource != .manual
+    }
+}
+
+public extension Account {
+    /// Whether this account can be synced (active and not manual).
+    var isSyncable: Bool {
+        AccountSyncEligibility.isSyncable(isActive: isActive, dataSource: dataSource)
+    }
+}

--- a/Packages/PortuCore/Sources/PortuCore/Models/Chain.swift
+++ b/Packages/PortuCore/Sources/PortuCore/Models/Chain.swift
@@ -9,6 +9,8 @@ public enum Chain: String, Codable, CaseIterable, Sendable {
     case bsc
     case degen
     case gnosis
+    case celo
+    case opBNB = "opbnb"
     case unichain
     case berachain
     case sonic
@@ -49,6 +51,8 @@ public extension Chain {
         case .bsc: "binance-smart-chain"
         case .degen: nil
         case .gnosis: "xdai"
+        case .celo: "celo"
+        case .opBNB: "opbnb"
         case .unichain: "unichain"
         case .berachain: "berachain"
         case .sonic: "sonic"
@@ -84,6 +88,8 @@ public extension Chain {
         case .bsc: "bsc"
         case .degen: "degenchain"
         case .gnosis: "xdai"
+        case .celo: "celo"
+        case .opBNB: "opbnb"
         case .unichain: "unichain"
         case .berachain: "berachain"
         case .sonic: "sonic"

--- a/Packages/PortuCore/Tests/PortuCoreTests/EnumTests.swift
+++ b/Packages/PortuCore/Tests/PortuCoreTests/EnumTests.swift
@@ -75,9 +75,11 @@ struct EnumTests {
     // MARK: - Chain
 
     @Test func `chain cases`() {
-        #expect(Chain.allCases.count == 30)
+        #expect(Chain.allCases.count == 32)
         #expect(Chain.allCases.contains(.degen))
         #expect(Chain.allCases.contains(.gnosis))
+        #expect(Chain.allCases.contains(.celo))
+        #expect(Chain.allCases.contains(.opBNB))
         #expect(Chain.allCases.contains(.unichain))
         #expect(Chain.allCases.contains(.berachain))
         #expect(Chain.allCases.contains(.sonic))

--- a/Packages/PortuCore/Tests/PortuCoreTests/ModelTests.swift
+++ b/Packages/PortuCore/Tests/PortuCoreTests/ModelTests.swift
@@ -279,12 +279,16 @@ struct ModelTests {
         #expect(Chain.polygon.coinGeckoAssetPlatformID == "polygon-pos")
         #expect(Chain.arbitrum.coinGeckoAssetPlatformID == "arbitrum-one")
         #expect(Chain.base.coinGeckoAssetPlatformID == "base")
+        #expect(Chain.celo.coinGeckoAssetPlatformID == "celo")
+        #expect(Chain.opBNB.coinGeckoAssetPlatformID == "opbnb")
         #expect(Chain.monad.coinGeckoAssetPlatformID == "monad")
         #expect(Chain.bitcoin.coinGeckoAssetPlatformID == nil)
     }
 
     @Test func `chain exposes coingecko onchain network ids`() {
         #expect(Chain.degen.coinGeckoOnchainNetworkID == "degenchain")
+        #expect(Chain.celo.coinGeckoOnchainNetworkID == "celo")
+        #expect(Chain.opBNB.coinGeckoOnchainNetworkID == "opbnb")
         #expect(Chain.hyperEVM.coinGeckoOnchainNetworkID == "hyperevm")
     }
 

--- a/Packages/PortuNetwork/Sources/PortuNetwork/Providers/ZapperProvider.swift
+++ b/Packages/PortuNetwork/Sources/PortuNetwork/Providers/ZapperProvider.swift
@@ -375,6 +375,8 @@ public actor ZapperProvider: PortfolioDataProvider {
         .bsc: 56,
         .degen: 666_666_666,
         .gnosis: 100,
+        .celo: 42220,
+        .opBNB: 204,
         .unichain: 130,
         .berachain: 80094,
         .sonic: 146,

--- a/Packages/PortuNetwork/Tests/PortuNetworkTests/ZapperProviderTests.swift
+++ b/Packages/PortuNetwork/Tests/PortuNetworkTests/ZapperProviderTests.swift
@@ -64,6 +64,34 @@ struct ZapperProviderTests {
     }
 
     @Test
+    func `fetchBalances decodes Celo and opBNB Zapper chain ids`() async throws {
+        defer { ZapperMockURLProtocol.reset() }
+        ZapperMockURLProtocol.requestHandler = { request in
+            let variables = try graphQLVariables(from: request)
+            let chainIds = try #require(variables["chainIds"] as? [Int])
+            let chainId = try #require(chainIds.first)
+            let response = switch chainId {
+            case 204:
+                tokenResponse(symbol: "BNB", tokenAddress: "0xbnb", chainId: 204)
+            case 42220:
+                tokenResponse(symbol: "CELO", tokenAddress: "0xcelo", chainId: 42220)
+            default:
+                tokenResponse(symbol: "UNKNOWN", tokenAddress: "0xunknown", chainId: chainId)
+            }
+            return try (jsonData(response), 200)
+        }
+
+        let context = makeSyncContext(addresses: [
+            ("0xcelo-wallet", .celo),
+            ("0xbnb-wallet", .opBNB)
+        ])
+        let provider = makeProvider(session: session)
+        let results = try await provider.fetchBalances(context: context)
+
+        #expect(results.map(\.chain) == [.opBNB, .celo])
+    }
+
+    @Test
     func `fetch historical prices reads Zapper price ticks by onchain identity`() async throws {
         defer { ZapperMockURLProtocol.reset() }
         let identity = OnchainTokenIdentity(chain: .base, contractAddress: "0xToken")

--- a/Portu.xcodeproj/project.pbxproj
+++ b/Portu.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		FCDAFF6F94E07C9D18CBBDA8 /* NetworkLogEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB42CAF65672F19597D348EF /* NetworkLogEntryTests.swift */; };
 		FE1471C345B27517D92D3487 /* AllAssetsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A165041B6308661DEF4F7D /* AllAssetsFeature.swift */; };
 		FE3D3F7A3293898A4A4EE084 /* AddPositionCategoryRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F1B452183C058E480F9BCC /* AddPositionCategoryRuleTests.swift */; };
+		FE9FC93C2B94C62746C3E49A /* AccountSheetInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307EE29FCE573C37E94B776D /* AccountSheetInvalidationTests.swift */; };
 		FF81CC0D113B55DB616C0B11 /* HistoricalBackfillStatusRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA99E382DD98BFE068BB0D3 /* HistoricalBackfillStatusRow.swift */; };
 /* End PBXBuildFile section */
 
@@ -199,6 +200,7 @@
 		2C3E823F7D4F67B3ECD15695 /* AllAssetsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllAssetsFeatureTests.swift; sourceTree = "<group>"; };
 		2C5E29636BD6B99B6A038320 /* AddAccountSupportChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAccountSupportChipTests.swift; sourceTree = "<group>"; };
 		2E83779E156800BF99D5B42F /* ProtocolFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolFilterTests.swift; sourceTree = "<group>"; };
+		307EE29FCE573C37E94B776D /* AccountSheetInvalidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheetInvalidationTests.swift; sourceTree = "<group>"; };
 		30DC63C7FADF95C6E1C179E2 /* PnLChartMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PnLChartMode.swift; sourceTree = "<group>"; };
 		324795298041BC4BF594505C /* PriceWatchlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceWatchlist.swift; sourceTree = "<group>"; };
 		33C7EC8BA3C811AEF2E2D2DB /* OverviewPositionTabComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewPositionTabComponents.swift; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 			children = (
 				E14B8750CDB4B4FF65401D0B /* AccountsFeatureTests.swift */,
 				4B56D23BA9DF6CE549D5DBEA /* AccountSheetDraftTests.swift */,
+				307EE29FCE573C37E94B776D /* AccountSheetInvalidationTests.swift */,
 				737ADD29F72D176E21C41D96 /* AddAccountSheetReviewTests.swift */,
 				2C5E29636BD6B99B6A038320 /* AddAccountSupportChipTests.swift */,
 				59F1B452183C058E480F9BCC /* AddPositionCategoryRuleTests.swift */,
@@ -849,6 +852,7 @@
 			files = (
 				F9B5ED895D5E63A10F140714 /* APIKeysViewModelTests.swift in Sources */,
 				889082CDB81C331C5684C15F /* AccountSheetDraftTests.swift in Sources */,
+				FE9FC93C2B94C62746C3E49A /* AccountSheetInvalidationTests.swift in Sources */,
 				4BAE4A97F25DD88CC1E4297A /* AccountsFeatureTests.swift in Sources */,
 				4C8A429B6784A49DD450615A /* AddAccountSheetReviewTests.swift in Sources */,
 				C5153D7BAD7942A4D8EC3429 /* AddAccountSupportChipTests.swift in Sources */,

--- a/Portu.xcodeproj/project.pbxproj
+++ b/Portu.xcodeproj/project.pbxproj
@@ -93,11 +93,13 @@
 		84957F67FC8B550274FAAE42 /* AccountsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72F0D537E08E9AFCE7549E3 /* AccountsFeature.swift */; };
 		85E47194B92F2AD0CD67CBE9 /* NetworksTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB47E7990208DC0893BDB696 /* NetworksTab.swift */; };
 		867FA2DB1B4BF8FA9FD47FAA /* AssetValueFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBE743A9AC8B9A2C8333003 /* AssetValueFormatter.swift */; };
+		889082CDB81C331C5684C15F /* AccountSheetDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B56D23BA9DF6CE549D5DBEA /* AccountSheetDraftTests.swift */; };
 		88ABBA56E103152F9C2C6747 /* AssetLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550D6F6A8C36881EAA48DF2E /* AssetLogoView.swift */; };
 		8957FACC77F7C7A2DFD28870 /* HistoricalPortfolioEstimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7674696086937331A79F61C2 /* HistoricalPortfolioEstimatorTests.swift */; };
 		89921F97BBE4171B786506B5 /* OverviewPositionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C375F4CE08E3AAE9016A076E /* OverviewPositionHelpers.swift */; };
 		8CE67C48438DA1CFEAF7E502 /* PortuApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B42D0DD559419EC991282 /* PortuApp.swift */; };
 		8F8230FDECE6D8BCD873413E /* OverviewHistoricalPriceChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6935F5F9A743434D65A06333 /* OverviewHistoricalPriceChangeTests.swift */; };
+		8FBCA384E7FA9824860169F5 /* SyncEngineSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814E567DB3F1447A8A6FAF44 /* SyncEngineSupport.swift */; };
 		900BA59F4B44BD08BBBA4293 /* DebugMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482A88E8EF0B1290937A8602 /* DebugMode.swift */; };
 		906ACAF81CA1C6438049CE41 /* AllAssetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2624CDAC2AEF7348B52DC311 /* AllAssetsView.swift */; };
 		9101CA3661EBA99C68B3E318 /* OverviewPriceDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CCD222A9A7CFBEFD51B77C /* OverviewPriceDisplay.swift */; };
@@ -107,6 +109,8 @@
 		A50DC572E3368D154DFB79B2 /* PortfolioHealthPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F1EDADED217BABCD15C10 /* PortfolioHealthPanel.swift */; };
 		A53307EFF266FA209E6AEBDD /* SyncEngineScopedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1159F8509C86C08B1C489415 /* SyncEngineScopedTests.swift */; };
 		A9DD558859FDAB7461BA502E /* TokenSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E54D85696E2BF460995DFC2 /* TokenSettingsTab.swift */; };
+		AAAB1F935EF02D565C748435 /* AccountSheetDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB16B288A8FDA49E18239C2 /* AccountSheetDraft.swift */; };
+		ACABB35F9973A57572179B81 /* AppFeatureAccountSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A01CB6E84AA5F46CB9019A4 /* AppFeatureAccountSyncTests.swift */; };
 		B0C7EF78282E58C9FF84D11B /* OverviewFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7514F4EF1D675DEFD3D00B80 /* OverviewFeature.swift */; };
 		B15A829AC4BE771ECBA38995 /* TokenSettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF501A47E70AF0FF687F80D9 /* TokenSettingsRow.swift */; };
 		B20C5F008144723070453C36 /* ExposureSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDCD2E7AB5E238E29197697 /* ExposureSummaryTests.swift */; };
@@ -201,12 +205,14 @@
 		371ED7D4DE3A82EBE87230AC /* CategorySymbolRuleWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySymbolRuleWriter.swift; sourceTree = "<group>"; };
 		39320574FA8ED9762F65B1CE /* AssetDetailFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDetailFeatureTests.swift; sourceTree = "<group>"; };
 		394B6E5490B3F08DC65B0B9E /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
+		3A01CB6E84AA5F46CB9019A4 /* AppFeatureAccountSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureAccountSyncTests.swift; sourceTree = "<group>"; };
 		3AAFE42584C56DC967627234 /* PortfolioCategoryWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioCategoryWriter.swift; sourceTree = "<group>"; };
 		3BA60071A304587735578219 /* DebugServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugServerTests.swift; sourceTree = "<group>"; };
 		3E0F258A4C5B03A912AF1819 /* DebugEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugEndpoints.swift; sourceTree = "<group>"; };
 		482A88E8EF0B1290937A8602 /* DebugMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMode.swift; sourceTree = "<group>"; };
 		48A880B6FB599E98456B9375 /* PortuCore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PortuCore; path = Packages/PortuCore; sourceTree = SOURCE_ROOT; };
 		4A4E3AD17570EE2020F98B9D /* PositionFilterSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionFilterSidebar.swift; sourceTree = "<group>"; };
+		4B56D23BA9DF6CE549D5DBEA /* AccountSheetDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheetDraftTests.swift; sourceTree = "<group>"; };
 		4C5B647C18FB90D4BF98BB5E /* TokenPricingOverrideWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenPricingOverrideWriter.swift; sourceTree = "<group>"; };
 		4CDBA2EE4C821D8A05F6EB10 /* DebugModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugModeTests.swift; sourceTree = "<group>"; };
 		4D3610C266F9533CDB786A34 /* AssetMetadataSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetMetadataSidebar.swift; sourceTree = "<group>"; };
@@ -246,6 +252,7 @@
 		79425078F4E02B149F06E972 /* AppStateBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateBridgeTests.swift; sourceTree = "<group>"; };
 		80D8A6F5E0D27CFE2E0F5446 /* InspectorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorPanel.swift; sourceTree = "<group>"; };
 		813D162565D572ED30229095 /* SettingsIntervalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIntervalRow.swift; sourceTree = "<group>"; };
+		814E567DB3F1447A8A6FAF44 /* SyncEngineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngineSupport.swift; sourceTree = "<group>"; };
 		8391D55809DB666FE792AD77 /* TokenSettingsFeature+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TokenSettingsFeature+Helpers.swift"; sourceTree = "<group>"; };
 		8489FFB3B14202D63DFC5284 /* HistoricalPortfolioEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalPortfolioEstimator.swift; sourceTree = "<group>"; };
 		84E0CE70F797E90EC7D5347A /* PortfolioCategorySeederTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioCategorySeederTests.swift; sourceTree = "<group>"; };
@@ -270,6 +277,7 @@
 		ACC72A910CE88E69A0A79746 /* SidebarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarLayoutTests.swift; sourceTree = "<group>"; };
 		AEBF7569CFA70F275E8F1EA6 /* OverviewReviewFollowUpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewReviewFollowUpTests.swift; sourceTree = "<group>"; };
 		AF501A47E70AF0FF687F80D9 /* TokenSettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSettingsRow.swift; sourceTree = "<group>"; };
+		AFB16B288A8FDA49E18239C2 /* AccountSheetDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheetDraft.swift; sourceTree = "<group>"; };
 		B4277AFD26AF30FE26D12A5B /* PortfolioValueChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioValueChart.swift; sourceTree = "<group>"; };
 		B44BBABF8DC9D82CEE3CD750 /* PortfolioHealthMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioHealthMetricsTests.swift; sourceTree = "<group>"; };
 		B4CF024449593948154682D9 /* TokenIdentityMappingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenIdentityMappingFeature.swift; sourceTree = "<group>"; };
@@ -371,6 +379,7 @@
 			isa = PBXGroup;
 			children = (
 				E72F0D537E08E9AFCE7549E3 /* AccountsFeature.swift */,
+				AFB16B288A8FDA49E18239C2 /* AccountSheetDraft.swift */,
 				52E52E92A4ADD1CA36A62709 /* AccountsView.swift */,
 				F0CF78486A93514E2377BA00 /* AddAccountSheet.swift */,
 				2C03252A4CF793DE2EE4F390 /* AddAccountSheetComponents.swift */,
@@ -474,6 +483,7 @@
 				F709EE1D55A2C734A3B4FE8A /* AssetLookupCache.swift */,
 				9078C9F74F4C43AE558D8BA3 /* ProviderFactory.swift */,
 				C652E9A00074B7A22943B6A7 /* SyncEngine.swift */,
+				814E567DB3F1447A8A6FAF44 /* SyncEngineSupport.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -541,11 +551,13 @@
 			isa = PBXGroup;
 			children = (
 				E14B8750CDB4B4FF65401D0B /* AccountsFeatureTests.swift */,
+				4B56D23BA9DF6CE549D5DBEA /* AccountSheetDraftTests.swift */,
 				737ADD29F72D176E21C41D96 /* AddAccountSheetReviewTests.swift */,
 				2C5E29636BD6B99B6A038320 /* AddAccountSupportChipTests.swift */,
 				59F1B452183C058E480F9BCC /* AddPositionCategoryRuleTests.swift */,
 				2C3E823F7D4F67B3ECD15695 /* AllAssetsFeatureTests.swift */,
 				8F2E020479C2D59A564DAD6A /* APIKeysViewModelTests.swift */,
+				3A01CB6E84AA5F46CB9019A4 /* AppFeatureAccountSyncTests.swift */,
 				5671DBA75C15FCC72727EA8E /* AppFeatureIntervalTests.swift */,
 				BD13FDD77A649AA0A7CBEA62 /* AppFeatureTests.swift */,
 				79425078F4E02B149F06E972 /* AppStateBridgeTests.swift */,
@@ -734,6 +746,7 @@
 			files = (
 				913B93FE3DE708F14BF56BE0 /* APIKeysSettingsTab.swift in Sources */,
 				230FDDF90C3B1EB88AF0981C /* APIKeysViewModel.swift in Sources */,
+				AAAB1F935EF02D565C748435 /* AccountSheetDraft.swift in Sources */,
 				84957F67FC8B550274FAAE42 /* AccountsFeature.swift in Sources */,
 				C5983C7BEF4CC57836BD456E /* AccountsView.swift in Sources */,
 				7FE55C3B27ABF3CC4228467F /* AddAccountSheet.swift in Sources */,
@@ -817,6 +830,7 @@
 				7C55B271CBDE85BDC34EC423 /* SidebarView.swift in Sources */,
 				15A71008787601EB0E7F3266 /* StatusBarView.swift in Sources */,
 				CBB2399EDE69E054EDEFED12 /* SyncEngine.swift in Sources */,
+				8FBCA384E7FA9824860169F5 /* SyncEngineSupport.swift in Sources */,
 				989FF781B777ECC77152A454 /* TokenIdentityMappingFeature.swift in Sources */,
 				446DB5318394D5247E6A5316 /* TokenPricingOverrideWriter.swift in Sources */,
 				D6029E2BDCA1E820C3C19471 /* TokenSettingsAggregate.swift in Sources */,
@@ -834,11 +848,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				F9B5ED895D5E63A10F140714 /* APIKeysViewModelTests.swift in Sources */,
+				889082CDB81C331C5684C15F /* AccountSheetDraftTests.swift in Sources */,
 				4BAE4A97F25DD88CC1E4297A /* AccountsFeatureTests.swift in Sources */,
 				4C8A429B6784A49DD450615A /* AddAccountSheetReviewTests.swift in Sources */,
 				C5153D7BAD7942A4D8EC3429 /* AddAccountSupportChipTests.swift in Sources */,
 				FE3D3F7A3293898A4A4EE084 /* AddPositionCategoryRuleTests.swift in Sources */,
 				2669929F16BEC301F7B3987A /* AllAssetsFeatureTests.swift in Sources */,
+				ACABB35F9973A57572179B81 /* AppFeatureAccountSyncTests.swift in Sources */,
 				031B921A0352C8F769525FB9 /* AppFeatureIntervalTests.swift in Sources */,
 				C422E37331613CA04BA8E9EC /* AppFeatureTests.swift in Sources */,
 				098327AF92DE46CA6FC8FB45 /* AppStateBridgeTests.swift in Sources */,

--- a/Portu.xcodeproj/project.pbxproj
+++ b/Portu.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00B310F5BCFFD8B2B9FA759E /* ExchangeCredentialSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C92AA921F540823BA2AC34B /* ExchangeCredentialSnapshot.swift */; };
 		010C49B4C2BB4659CAF03E36 /* HistoricalPriceBackfillRequestTimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FAC79936969B0BBA1C5A51 /* HistoricalPriceBackfillRequestTimingTests.swift */; };
 		02CEF7FE408D5CF38B5A88D9 /* ViewRenderSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03E305DDC6E4458F794B16A /* ViewRenderSmokeTests.swift */; };
 		031B921A0352C8F769525FB9 /* AppFeatureIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5671DBA75C15FCC72727EA8E /* AppFeatureIntervalTests.swift */; };
@@ -156,6 +157,7 @@
 		FB4F5BEA50F1EDE6B9121C82 /* NetworkLogBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94809A29D35ED92B6A354DA /* NetworkLogBufferTests.swift */; };
 		FB5341029C65812E010217B6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9330A7E8F8102FE57BFE75 /* SettingsView.swift */; };
 		FCDAFF6F94E07C9D18CBBDA8 /* NetworkLogEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB42CAF65672F19597D348EF /* NetworkLogEntryTests.swift */; };
+		FDDE3D68C93ED50ABB115E73 /* AccountSheetSaveError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20002294759D52134305A0B6 /* AccountSheetSaveError.swift */; };
 		FE1471C345B27517D92D3487 /* AllAssetsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A165041B6308661DEF4F7D /* AllAssetsFeature.swift */; };
 		FE3D3F7A3293898A4A4EE084 /* AddPositionCategoryRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F1B452183C058E480F9BCC /* AddPositionCategoryRuleTests.swift */; };
 		FE9FC93C2B94C62746C3E49A /* AccountSheetInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307EE29FCE573C37E94B776D /* AccountSheetInvalidationTests.swift */; };
@@ -191,6 +193,7 @@
 		1DA99E382DD98BFE068BB0D3 /* HistoricalBackfillStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalBackfillStatusRow.swift; sourceTree = "<group>"; };
 		1E714A3E651A52EC4CAA306C /* NetworkLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerTests.swift; sourceTree = "<group>"; };
 		1FC509B87C11FACA89871DE9 /* DebugServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugServer.swift; sourceTree = "<group>"; };
+		20002294759D52134305A0B6 /* AccountSheetSaveError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheetSaveError.swift; sourceTree = "<group>"; };
 		219795B37821B012821DECB6 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		22DAC31141B1910B142D9060 /* PortuNetwork */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PortuNetwork; path = Packages/PortuNetwork; sourceTree = SOURCE_ROOT; };
 		2624CDAC2AEF7348B52DC311 /* AllAssetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllAssetsView.swift; sourceTree = "<group>"; };
@@ -229,6 +232,7 @@
 		59F1B452183C058E480F9BCC /* AddPositionCategoryRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPositionCategoryRuleTests.swift; sourceTree = "<group>"; };
 		5A372B5E40F5617842721225 /* ReleaseAutomationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseAutomationTests.swift; sourceTree = "<group>"; };
 		5C5ACF35FFCCB23A6F4AE3C4 /* HTTPParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPParser.swift; sourceTree = "<group>"; };
+		5C92AA921F540823BA2AC34B /* ExchangeCredentialSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeCredentialSnapshot.swift; sourceTree = "<group>"; };
 		5E78AD0A4DDFB6A8F52A9515 /* ValueChartMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueChartMode.swift; sourceTree = "<group>"; };
 		5F65FF1713209FB3D1DDB9C2 /* PricePollingIDResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricePollingIDResolver.swift; sourceTree = "<group>"; };
 		633176F0FC26C90721D6E759 /* HistoricalPriceBackfillLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalPriceBackfillLiveTests.swift; sourceTree = "<group>"; };
@@ -382,10 +386,12 @@
 			children = (
 				E72F0D537E08E9AFCE7549E3 /* AccountsFeature.swift */,
 				AFB16B288A8FDA49E18239C2 /* AccountSheetDraft.swift */,
+				20002294759D52134305A0B6 /* AccountSheetSaveError.swift */,
 				52E52E92A4ADD1CA36A62709 /* AccountsView.swift */,
 				F0CF78486A93514E2377BA00 /* AddAccountSheet.swift */,
 				2C03252A4CF793DE2EE4F390 /* AddAccountSheetComponents.swift */,
 				8A6FF70061475C4B92F546CE /* AddAccountSheetFields.swift */,
+				5C92AA921F540823BA2AC34B /* ExchangeCredentialSnapshot.swift */,
 			);
 			path = Accounts;
 			sourceTree = "<group>";
@@ -750,6 +756,7 @@
 				913B93FE3DE708F14BF56BE0 /* APIKeysSettingsTab.swift in Sources */,
 				230FDDF90C3B1EB88AF0981C /* APIKeysViewModel.swift in Sources */,
 				AAAB1F935EF02D565C748435 /* AccountSheetDraft.swift in Sources */,
+				FDDE3D68C93ED50ABB115E73 /* AccountSheetSaveError.swift in Sources */,
 				84957F67FC8B550274FAAE42 /* AccountsFeature.swift in Sources */,
 				C5983C7BEF4CC57836BD456E /* AccountsView.swift in Sources */,
 				7FE55C3B27ABF3CC4228467F /* AddAccountSheet.swift in Sources */,
@@ -782,6 +789,7 @@
 				900BA59F4B44BD08BBBA4293 /* DebugMode.swift in Sources */,
 				7821F57194F06922936CF189 /* DebugServer.swift in Sources */,
 				1D0A4B3DFE7518356DFD4EA4 /* DebugSettingsTab.swift in Sources */,
+				00B310F5BCFFD8B2B9FA759E /* ExchangeCredentialSnapshot.swift in Sources */,
 				6B29C704D2A50D541BE721D5 /* ExposureCells.swift in Sources */,
 				D4B37B7013275E0393B345B1 /* ExposureFeature.swift in Sources */,
 				83245BEC701E64C1A764211B /* ExposureView.swift in Sources */,

--- a/Sources/Portu/App/AppDependencies.swift
+++ b/Sources/Portu/App/AppDependencies.swift
@@ -15,27 +15,33 @@ struct SyncResult: Equatable {
 struct SyncEngineClient {
     var sync: @Sendable () async throws -> SyncResult
     var syncScope: @Sendable (PortfolioSyncScope) async throws -> SyncResult
+    var syncAccount: @Sendable (UUID) async throws -> SyncResult
 
     init(
         sync: @escaping @Sendable () async throws -> SyncResult,
-        syncScope: @escaping @Sendable (PortfolioSyncScope) async throws -> SyncResult = { _ in SyncResult(failedAccounts: []) }) {
+        syncScope: @escaping @Sendable (PortfolioSyncScope) async throws -> SyncResult = { _ in SyncResult(failedAccounts: []) },
+        syncAccount: @escaping @Sendable (UUID) async throws -> SyncResult = { _ in SyncResult(failedAccounts: []) }) {
         self.sync = sync
         self.syncScope = syncScope
+        self.syncAccount = syncAccount
     }
 }
 
 extension SyncEngineClient: DependencyKey {
     static let liveValue = Self(
         sync: { fatalError("SyncEngineClient.liveValue must be overridden at Store creation") },
-        syncScope: { _ in fatalError("SyncEngineClient.liveValue must be overridden at Store creation") })
+        syncScope: { _ in fatalError("SyncEngineClient.liveValue must be overridden at Store creation") },
+        syncAccount: { _ in fatalError("SyncEngineClient.liveValue must be overridden at Store creation") })
     static let testValue = Self(
         sync: { SyncResult(failedAccounts: []) },
-        syncScope: { _ in SyncResult(failedAccounts: []) })
+        syncScope: { _ in SyncResult(failedAccounts: []) },
+        syncAccount: { _ in SyncResult(failedAccounts: []) })
 
     static func live(engine: SyncEngine) -> Self {
         Self(
             sync: { try await engine.sync() },
-            syncScope: { scope in try await engine.sync(scope: scope) })
+            syncScope: { scope in try await engine.sync(scope: scope) },
+            syncAccount: { accountID in try await engine.sync(accountID: accountID) })
     }
 }
 

--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -149,12 +149,17 @@ struct AppFeature {
                 }
                 return .none
 
-            case .accountSyncCompleted(.failure):
+            case let .accountSyncCompleted(.failure(error)):
                 // A single-account failure is surfaced on that row's `lastSyncError`
-                // (the engine persists it); don't escalate a scoped sync to a global
-                // error banner that implies the whole portfolio failed.
+                // when the engine throws allAccountsFailed after persisting the row
+                // error. Later-stage failures (snapshot/save) have no row error to
+                // show, so surface those globally.
                 state.syncingAccountID = nil
-                state.syncStatus = .idle
+                if (error as? SyncError) == .allAccountsFailed {
+                    state.syncStatus = .idle
+                } else {
+                    state.syncStatus = .error(error.localizedDescription)
+                }
                 return .none
 
             case .startScheduledSync:

--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -149,9 +149,12 @@ struct AppFeature {
                 }
                 return .none
 
-            case let .accountSyncCompleted(.failure(error)):
+            case .accountSyncCompleted(.failure):
+                // A single-account failure is surfaced on that row's `lastSyncError`
+                // (the engine persists it); don't escalate a scoped sync to a global
+                // error banner that implies the whole portfolio failed.
                 state.syncingAccountID = nil
-                state.syncStatus = .error(error.localizedDescription)
+                state.syncStatus = .idle
                 return .none
 
             case .startScheduledSync:

--- a/Sources/Portu/App/AppFeature.swift
+++ b/Sources/Portu/App/AppFeature.swift
@@ -20,6 +20,7 @@ struct AppFeature {
         }
 
         var syncStatus: SyncStatus = .idle
+        var syncingAccountID: UUID?
         var connectionStatus: ConnectionStatus = .idle
         var prices: [String: Decimal] = [:]
         var priceChanges24h: [String: Decimal] = [:]
@@ -37,8 +38,10 @@ struct AppFeature {
         case sectionSelected(SidebarSection)
         case settingsSelected
         case syncTapped
+        case accountSyncTapped(UUID)
         case syncProgressUpdated(Double)
         case syncCompleted(Result<SyncResult, Error>)
+        case accountSyncCompleted(Result<SyncResult, Error>)
         case startScheduledSync
         case stopScheduledSync
         case scheduledSyncDue(PortfolioSyncScope)
@@ -100,6 +103,7 @@ struct AppFeature {
             case .syncTapped:
                 if case .syncing = state.syncStatus { return .none }
                 state.syncStatus = .syncing(progress: 0)
+                state.syncingAccountID = nil
                 return .run { send in
                     let result = try await syncEngine.sync()
                     await send(.syncCompleted(.success(result)))
@@ -107,11 +111,23 @@ struct AppFeature {
                     await send(.syncCompleted(.failure(error)))
                 }
 
+            case let .accountSyncTapped(accountID):
+                if case .syncing = state.syncStatus { return .none }
+                state.syncStatus = .syncing(progress: 0)
+                state.syncingAccountID = accountID
+                return .run { send in
+                    let result = try await syncEngine.syncAccount(accountID)
+                    await send(.accountSyncCompleted(.success(result)))
+                } catch: { error, send in
+                    await send(.accountSyncCompleted(.failure(error)))
+                }
+
             case let .syncProgressUpdated(progress):
                 state.syncStatus = .syncing(progress: progress)
                 return .none
 
             case let .syncCompleted(.success(result)):
+                state.syncingAccountID = nil
                 if result.isPartial {
                     state.syncStatus = .completedWithErrors(failedAccounts: result.failedAccounts)
                 } else {
@@ -120,6 +136,21 @@ struct AppFeature {
                 return .none
 
             case let .syncCompleted(.failure(error)):
+                state.syncingAccountID = nil
+                state.syncStatus = .error(error.localizedDescription)
+                return .none
+
+            case let .accountSyncCompleted(.success(result)):
+                state.syncingAccountID = nil
+                if result.isPartial {
+                    state.syncStatus = .completedWithErrors(failedAccounts: result.failedAccounts)
+                } else {
+                    state.syncStatus = .idle
+                }
+                return .none
+
+            case let .accountSyncCompleted(.failure(error)):
+                state.syncingAccountID = nil
                 state.syncStatus = .error(error.localizedDescription)
                 return .none
 
@@ -168,6 +199,7 @@ struct AppFeature {
             case let .scheduledSyncDue(scope):
                 if case .syncing = state.syncStatus { return .none }
                 state.syncStatus = .syncing(progress: 0)
+                state.syncingAccountID = nil
                 return .run { send in
                     let result = try await syncEngine.syncScope(scope)
                     await send(.scheduledSyncCompleted(.success(result)))
@@ -176,6 +208,7 @@ struct AppFeature {
                 }
 
             case let .scheduledSyncCompleted(.success(result)):
+                state.syncingAccountID = nil
                 if result.isPartial {
                     state.syncStatus = .completedWithErrors(failedAccounts: result.failedAccounts)
                 } else {
@@ -184,6 +217,7 @@ struct AppFeature {
                 return .none
 
             case let .scheduledSyncCompleted(.failure(error)):
+                state.syncingAccountID = nil
                 state.syncStatus = .error(error.localizedDescription)
                 return .none
 
@@ -328,9 +362,12 @@ extension AppFeature.Action: Equatable {
         case let (.sectionSelected(l), .sectionSelected(r)): l == r
         case (.settingsSelected, .settingsSelected): true
         case (.syncTapped, .syncTapped): true
+        case let (.accountSyncTapped(l), .accountSyncTapped(r)): l == r
         case let (.syncProgressUpdated(l), .syncProgressUpdated(r)): l == r
         case let (.syncCompleted(.success(l)), .syncCompleted(.success(r))): l == r
         case (.syncCompleted(.failure), .syncCompleted(.failure)): true
+        case let (.accountSyncCompleted(.success(l)), .accountSyncCompleted(.success(r))): l == r
+        case (.accountSyncCompleted(.failure), .accountSyncCompleted(.failure)): true
         case (.startScheduledSync, .startScheduledSync): true
         case (.stopScheduledSync, .stopScheduledSync): true
         case let (.scheduledSyncDue(l), .scheduledSyncDue(r)): l == r

--- a/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
+++ b/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
@@ -115,26 +115,6 @@ struct AccountSheetDraft: Equatable {
     }
 }
 
-enum AccountSheetSaveError: Error, LocalizedError, Equatable {
-    case missingEditedAccount
-    case editedAccountMismatch
-    case credentialSaveFailed(String)
-    case accountSaveFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .missingEditedAccount:
-            "The account being edited is no longer available."
-        case .editedAccountMismatch:
-            "The account being edited does not match the open sheet."
-        case let .credentialSaveFailed(message):
-            "Failed to save credentials: \(message)"
-        case let .accountSaveFailed(message):
-            "Failed to save account: \(message)"
-        }
-    }
-}
-
 enum AccountSheetSaveCoordinator {
     @MainActor
     static func save(
@@ -221,14 +201,14 @@ enum AccountSheetSaveCoordinator {
                     secretStore: secretStore,
                     rollbackTo: emptyCredentials)
             } catch {
-                deleteExchangeCredentials(accountID, secretStore: secretStore)
+                deleteExchangeCredentialsBestEffort(accountID, secretStore: secretStore)
                 throw error
             }
 
             do {
                 try insertAndSave(account, modelContext: modelContext)
             } catch {
-                deleteExchangeCredentials(accountID, secretStore: secretStore)
+                deleteExchangeCredentialsBestEffort(accountID, secretStore: secretStore)
                 throw error
             }
         }
@@ -374,15 +354,28 @@ enum AccountSheetSaveCoordinator {
         save: @MainActor (ModelContext) throws -> Void = { try $0.save() }) throws {
         let accountID = account.id
         let isExchange = account.kind == .exchange
+        let previousCredentials = if isExchange {
+            try readExchangeCredentials(for: accountID, secretStore: secretStore)
+        } else {
+            ExchangeCredentialSnapshot.empty
+        }
+        if isExchange {
+            do {
+                try deleteExchangeCredentials(accountID, secretStore: secretStore)
+            } catch {
+                restoreExchangeCredentials(previousCredentials, for: accountID, secretStore: secretStore)
+                throw AccountSheetSaveError.credentialSaveFailed(error.localizedDescription)
+            }
+        }
         modelContext.delete(account)
         do {
             try save(modelContext)
         } catch {
             modelContext.rollback()
+            if isExchange {
+                restoreExchangeCredentials(previousCredentials, for: accountID, secretStore: secretStore)
+            }
             throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
-        }
-        if isExchange {
-            deleteExchangeCredentials(accountID, secretStore: secretStore)
         }
     }
 
@@ -479,7 +472,13 @@ enum AccountSheetSaveCoordinator {
     /// Removes all keychain entries for an account. Safe to call for non-exchange
     /// accounts (deletes of missing keys are no-ops); used both by the failure-cleanup
     /// paths here and by account deletion.
-    static func deleteExchangeCredentials(_ accountID: UUID, secretStore: any SecretStore) {
+    static func deleteExchangeCredentials(_ accountID: UUID, secretStore: any SecretStore) throws {
+        try secretStore.delete(key: .exchangeAPIKey(accountID))
+        try secretStore.delete(key: .exchangeAPISecret(accountID))
+        try secretStore.delete(key: .exchangePassphrase(accountID))
+    }
+
+    private static func deleteExchangeCredentialsBestEffort(_ accountID: UUID, secretStore: any SecretStore) {
         try? secretStore.delete(key: .exchangeAPIKey(accountID))
         try? secretStore.delete(key: .exchangeAPISecret(accountID))
         try? secretStore.delete(key: .exchangePassphrase(accountID))
@@ -489,12 +488,4 @@ enum AccountSheetSaveCoordinator {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
-}
-
-private struct ExchangeCredentialSnapshot: Equatable {
-    var apiKey: String?
-    var apiSecret: String?
-    var passphrase: String?
-
-    static let empty = Self(apiKey: nil, apiSecret: nil, passphrase: nil)
 }

--- a/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
+++ b/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
@@ -24,12 +24,21 @@ struct AccountSheetDraft: Equatable {
     var exchangeGroup = ""
     var exchangeNotes = ""
 
+    /// Whether the exchange credentials were read back from the keychain successfully.
+    /// Stays `true` for non-exchange drafts and before a load is attempted; set to
+    /// `false` if a keychain read fails so saving never blindly overwrites or deletes
+    /// secrets it could not load.
+    var exchangeCredentialsLoaded = true
+
     static func adding() -> Self {
         Self()
     }
 
+    /// Builds an edit draft from the account's non-secret fields only. Keychain
+    /// reads are deliberately excluded so this can run in a SwiftUI view initializer
+    /// without side effects; load credentials separately via `loadExchangeCredentials`.
     @MainActor
-    static func editing(account: Account, secretStore: any SecretStore = LocalSecretStore()) -> Self {
+    static func editing(account: Account) -> Self {
         var draft = Self()
 
         switch account.kind {
@@ -60,12 +69,34 @@ struct AccountSheetDraft: Equatable {
             draft.exchangeType = account.exchangeType ?? .kraken
             draft.exchangeGroup = account.group ?? ""
             draft.exchangeNotes = account.notes ?? ""
-            draft.exchangeAPIKey = (try? secretStore.get(key: .exchangeAPIKey(account.id))) ?? ""
-            draft.exchangeAPISecret = (try? secretStore.get(key: .exchangeAPISecret(account.id))) ?? ""
-            draft.exchangePassphrase = (try? secretStore.get(key: .exchangePassphrase(account.id))) ?? ""
         }
 
         return draft
+    }
+
+    /// Builds an edit draft and eagerly loads exchange credentials. Performs keychain
+    /// I/O, so call off the view-initializer path (tests, or `loadExchangeCredentials`).
+    @MainActor
+    static func editing(account: Account, secretStore: any SecretStore) -> Self {
+        var draft = editing(account: account)
+        if account.kind == .exchange {
+            draft.loadExchangeCredentials(accountID: account.id, secretStore: secretStore)
+        }
+        return draft
+    }
+
+    /// Reads exchange credentials from the keychain into the draft. A read failure is
+    /// recorded in `exchangeCredentialsLoaded` (rather than being silently coalesced to
+    /// an empty string) so the save path can avoid clobbering secrets it never loaded.
+    mutating func loadExchangeCredentials(accountID: UUID, secretStore: any SecretStore) {
+        do {
+            exchangeAPIKey = try secretStore.get(key: .exchangeAPIKey(accountID)) ?? ""
+            exchangeAPISecret = try secretStore.get(key: .exchangeAPISecret(accountID)) ?? ""
+            exchangePassphrase = try secretStore.get(key: .exchangePassphrase(accountID)) ?? ""
+            exchangeCredentialsLoaded = true
+        } catch {
+            exchangeCredentialsLoaded = false
+        }
     }
 
     var canSave: Bool {
@@ -120,8 +151,21 @@ enum AccountSheetSaveCoordinator {
             guard account.id == accountID else {
                 throw AccountSheetSaveError.editedAccountMismatch
             }
+            // The captured Account may have been deleted while the sheet was open
+            // (e.g. via the table context menu). Mutating + saving a tombstoned model
+            // is undefined; confirm it still lives in the context first.
+            guard accountExists(id: accountID, modelContext: modelContext) else {
+                throw AccountSheetSaveError.missingEditedAccount
+            }
             try update(account, from: draft, modelContext: modelContext, secretStore: secretStore)
         }
+    }
+
+    @MainActor
+    private static func accountExists(id: UUID, modelContext: ModelContext) -> Bool {
+        var descriptor = FetchDescriptor<Account>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? modelContext.fetch(descriptor))?.isEmpty == false
     }
 
     @MainActor
@@ -204,11 +248,14 @@ enum AccountSheetSaveCoordinator {
             account.notes = nilIfEmpty(draft.manualNotes)
 
         case .exchange:
+            // Persist credentials first. If the keychain write fails the model is left
+            // untouched, so autosave can't flush a renamed account that still points at
+            // the old secrets.
+            try saveExchangeCredentials(for: account.id, from: draft, secretStore: secretStore)
             account.name = draft.exchangeName
             account.exchangeType = draft.exchangeType
             account.group = nilIfEmpty(draft.exchangeGroup)
             account.notes = nilIfEmpty(draft.exchangeNotes)
-            try saveExchangeCredentials(for: account.id, from: draft, secretStore: secretStore)
         }
 
         do {
@@ -224,19 +271,14 @@ enum AccountSheetSaveCoordinator {
         chain: Chain?,
         address: String,
         modelContext: ModelContext) {
-        let currentAddresses = account.addresses
-        if let first = currentAddresses.first {
-            first.chain = chain
-            first.address = address
-            first.account = account
-            account.addresses = [first]
-
-            for extra in currentAddresses.dropFirst() {
-                modelContext.delete(extra)
-            }
-        } else {
-            account.addresses = [WalletAddress(chain: chain, address: address, account: account)]
+        // Replace the whole address set with a single fresh row. Mutating an existing
+        // row in place reused its identity (stale position resolution after a chain
+        // change) and relied on the non-deterministic order of an unordered to-many;
+        // recreating is deterministic and handles the empty/multi-address cases alike.
+        for existing in account.addresses {
+            modelContext.delete(existing)
         }
+        account.addresses = [WalletAddress(chain: chain, address: address, account: account)]
     }
 
     @MainActor
@@ -262,7 +304,9 @@ enum AccountSheetSaveCoordinator {
                     draft.exchangePassphrase,
                     for: draft.exchangeType) {
                 try secretStore.set(key: .exchangePassphrase(accountID), value: passphrase)
-            } else {
+            } else if draft.exchangeCredentialsLoaded {
+                // Only delete when we know the prior state: a blank field after a
+                // failed credential read must not be mistaken for "user cleared it".
                 try secretStore.delete(key: .exchangePassphrase(accountID))
             }
         } catch {
@@ -270,13 +314,17 @@ enum AccountSheetSaveCoordinator {
         }
     }
 
-    private static func deleteExchangeCredentials(_ accountID: UUID, secretStore: any SecretStore) {
+    /// Removes all keychain entries for an account. Safe to call for non-exchange
+    /// accounts (deletes of missing keys are no-ops); used both by the failure-cleanup
+    /// paths here and by account deletion.
+    static func deleteExchangeCredentials(_ accountID: UUID, secretStore: any SecretStore) {
         try? secretStore.delete(key: .exchangeAPIKey(accountID))
         try? secretStore.delete(key: .exchangeAPISecret(accountID))
         try? secretStore.delete(key: .exchangePassphrase(accountID))
     }
 
     private static func nilIfEmpty(_ value: String) -> String? {
-        value.isEmpty ? nil : value
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
+++ b/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
@@ -353,6 +353,23 @@ enum AccountSheetSaveCoordinator {
         }
     }
 
+    @MainActor
+    static func setAccount(
+        _ account: Account,
+        isActive: Bool,
+        modelContext: ModelContext,
+        save: @MainActor (ModelContext) throws -> Void = { try $0.save() }) throws {
+        let previousValue = account.isActive
+        account.isActive = isActive
+        do {
+            try save(modelContext)
+        } catch {
+            modelContext.rollback()
+            account.isActive = previousValue
+            throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
+        }
+    }
+
     private static func saveExchangeCredentials(
         for accountID: UUID,
         from draft: AccountSheetDraft,

--- a/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
+++ b/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
@@ -242,14 +242,22 @@ enum AccountSheetSaveCoordinator {
         secretStore: any SecretStore) throws {
         switch account.kind {
         case .wallet:
+            let chain = draft.isEVM ? nil : draft.specificChain
+            let identityChanged = walletIdentityChanged(
+                for: account,
+                chain: chain,
+                address: draft.chainAddress)
             account.name = draft.chainName
             account.group = nilIfEmpty(draft.chainGroup)
             account.notes = nilIfEmpty(draft.chainNotes)
             replaceWalletAddress(
                 for: account,
-                chain: draft.isEVM ? nil : draft.specificChain,
+                chain: chain,
                 address: draft.chainAddress,
                 modelContext: modelContext)
+            if identityChanged {
+                invalidateSyncedPositions(for: account, modelContext: modelContext)
+            }
 
         case .manual:
             account.name = draft.manualName
@@ -261,6 +269,10 @@ enum AccountSheetSaveCoordinator {
             // untouched, so autosave can't flush a renamed account that still points at
             // the old secrets.
             let previousCredentials = try readExchangeCredentials(for: account.id, secretStore: secretStore)
+            let credentialsAfterSave = exchangeCredentialsAfterApplying(
+                draft,
+                previousCredentials: previousCredentials)
+            let identityChanged = account.exchangeType != draft.exchangeType || previousCredentials != credentialsAfterSave
             try saveExchangeCredentials(
                 for: account.id,
                 from: draft,
@@ -270,6 +282,9 @@ enum AccountSheetSaveCoordinator {
             account.exchangeType = draft.exchangeType
             account.group = nilIfEmpty(draft.exchangeGroup)
             account.notes = nilIfEmpty(draft.exchangeNotes)
+            if identityChanged {
+                invalidateSyncedPositions(for: account, modelContext: modelContext)
+            }
 
             do {
                 try modelContext.save()
@@ -306,6 +321,24 @@ enum AccountSheetSaveCoordinator {
         let newAddress = WalletAddress(chain: chain, address: address, account: account)
         modelContext.insert(newAddress)
         account.addresses = [newAddress]
+    }
+
+    @MainActor
+    private static func walletIdentityChanged(for account: Account, chain: Chain?, address: String) -> Bool {
+        let addresses = Array(account.addresses)
+        guard addresses.count == 1, let existing = addresses.first else {
+            return true
+        }
+        return existing.chain != chain || existing.address != address
+    }
+
+    @MainActor
+    private static func invalidateSyncedPositions(for account: Account, modelContext: ModelContext) {
+        for position in Array(account.positions) {
+            modelContext.delete(position)
+        }
+        account.lastSyncedAt = nil
+        account.lastSyncError = nil
     }
 
     @MainActor
@@ -394,6 +427,25 @@ enum AccountSheetSaveCoordinator {
         }
     }
 
+    private static func exchangeCredentialsAfterApplying(
+        _ draft: AccountSheetDraft,
+        previousCredentials: ExchangeCredentialSnapshot) -> ExchangeCredentialSnapshot {
+        let passphrase: String? = if
+            let persistedPassphrase = AddAccountExchangeSecrets.persistedPassphrase(
+                draft.exchangePassphrase,
+                for: draft.exchangeType) {
+            persistedPassphrase
+        } else if draft.exchangeCredentialsLoaded {
+            nil
+        } else {
+            previousCredentials.passphrase
+        }
+        return ExchangeCredentialSnapshot(
+            apiKey: draft.exchangeAPIKey,
+            apiSecret: draft.exchangeAPISecret,
+            passphrase: passphrase)
+    }
+
     private static func readExchangeCredentials(
         for accountID: UUID,
         secretStore: any SecretStore) throws -> ExchangeCredentialSnapshot {
@@ -439,7 +491,7 @@ enum AccountSheetSaveCoordinator {
     }
 }
 
-private struct ExchangeCredentialSnapshot {
+private struct ExchangeCredentialSnapshot: Equatable {
     var apiKey: String?
     var apiSecret: String?
     var passphrase: String?

--- a/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
+++ b/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
@@ -1,0 +1,282 @@
+import Foundation
+import PortuCore
+import SwiftData
+
+struct AccountSheetDraft: Equatable {
+    var selectedTab: AddAccountTab = .chain
+
+    var chainName = ""
+    var chainAddress = ""
+    var chainGroup = ""
+    var chainNotes = ""
+    var isEVM = true
+    var specificChain: Chain = .solana
+
+    var manualName = ""
+    var manualNotes = ""
+    var manualGroup = ""
+
+    var exchangeName = ""
+    var exchangeType: ExchangeType = .kraken
+    var exchangeAPIKey = ""
+    var exchangeAPISecret = ""
+    var exchangePassphrase = ""
+    var exchangeGroup = ""
+    var exchangeNotes = ""
+
+    static func adding() -> Self {
+        Self()
+    }
+
+    @MainActor
+    static func editing(account: Account, secretStore: any SecretStore = LocalSecretStore()) -> Self {
+        var draft = Self()
+
+        switch account.kind {
+        case .wallet:
+            draft.selectedTab = .chain
+            draft.chainName = account.name
+            draft.chainGroup = account.group ?? ""
+            draft.chainNotes = account.notes ?? ""
+            if let address = account.addresses.first {
+                draft.chainAddress = address.address
+                if let chain = address.chain {
+                    draft.isEVM = false
+                    draft.specificChain = chain
+                } else {
+                    draft.isEVM = true
+                }
+            }
+
+        case .manual:
+            draft.selectedTab = .manual
+            draft.manualName = account.name
+            draft.manualGroup = account.group ?? ""
+            draft.manualNotes = account.notes ?? ""
+
+        case .exchange:
+            draft.selectedTab = .exchange
+            draft.exchangeName = account.name
+            draft.exchangeType = account.exchangeType ?? .kraken
+            draft.exchangeGroup = account.group ?? ""
+            draft.exchangeNotes = account.notes ?? ""
+            draft.exchangeAPIKey = (try? secretStore.get(key: .exchangeAPIKey(account.id))) ?? ""
+            draft.exchangeAPISecret = (try? secretStore.get(key: .exchangeAPISecret(account.id))) ?? ""
+            draft.exchangePassphrase = (try? secretStore.get(key: .exchangePassphrase(account.id))) ?? ""
+        }
+
+        return draft
+    }
+
+    var canSave: Bool {
+        AccountsFeature.canSave(
+            tab: selectedTab.rawValue,
+            fields: AccountSaveFields(
+                chainName: chainName,
+                chainAddress: chainAddress,
+                manualName: manualName,
+                exchangeName: exchangeName,
+                exchangeAPIKey: exchangeAPIKey,
+                exchangeAPISecret: exchangeAPISecret))
+    }
+}
+
+enum AccountSheetSaveError: Error, LocalizedError, Equatable {
+    case missingEditedAccount
+    case editedAccountMismatch
+    case credentialSaveFailed(String)
+    case accountSaveFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingEditedAccount:
+            "The account being edited is no longer available."
+        case .editedAccountMismatch:
+            "The account being edited does not match the open sheet."
+        case let .credentialSaveFailed(message):
+            "Failed to save credentials: \(message)"
+        case let .accountSaveFailed(message):
+            "Failed to save account: \(message)"
+        }
+    }
+}
+
+enum AccountSheetSaveCoordinator {
+    @MainActor
+    static func save(
+        draft: AccountSheetDraft,
+        mode: AccountSheetMode,
+        editing account: Account?,
+        modelContext: ModelContext,
+        secretStore: any SecretStore = LocalSecretStore()) throws {
+        switch mode {
+        case .add:
+            try insertAccount(from: draft, modelContext: modelContext, secretStore: secretStore)
+
+        case let .edit(accountID):
+            guard let account else {
+                throw AccountSheetSaveError.missingEditedAccount
+            }
+            guard account.id == accountID else {
+                throw AccountSheetSaveError.editedAccountMismatch
+            }
+            try update(account, from: draft, modelContext: modelContext, secretStore: secretStore)
+        }
+    }
+
+    @MainActor
+    private static func insertAccount(
+        from draft: AccountSheetDraft,
+        modelContext: ModelContext,
+        secretStore: any SecretStore) throws {
+        switch draft.selectedTab {
+        case .chain:
+            let account = Account(
+                name: draft.chainName,
+                kind: .wallet,
+                dataSource: .zapper,
+                group: nilIfEmpty(draft.chainGroup),
+                notes: nilIfEmpty(draft.chainNotes))
+            account.addresses = [
+                WalletAddress(
+                    chain: draft.isEVM ? nil : draft.specificChain,
+                    address: draft.chainAddress,
+                    account: account)
+            ]
+            try insertAndSave(account, modelContext: modelContext)
+
+        case .manual:
+            let account = Account(
+                name: draft.manualName,
+                kind: .manual,
+                dataSource: .manual,
+                group: nilIfEmpty(draft.manualGroup),
+                notes: nilIfEmpty(draft.manualNotes))
+            try insertAndSave(account, modelContext: modelContext)
+
+        case .exchange:
+            let accountID = UUID()
+            let account = Account(
+                id: accountID,
+                name: draft.exchangeName,
+                kind: .exchange,
+                exchangeType: draft.exchangeType,
+                dataSource: .exchange,
+                group: nilIfEmpty(draft.exchangeGroup),
+                notes: nilIfEmpty(draft.exchangeNotes))
+
+            do {
+                try saveExchangeCredentials(for: accountID, from: draft, secretStore: secretStore)
+            } catch {
+                deleteExchangeCredentials(accountID, secretStore: secretStore)
+                throw error
+            }
+
+            do {
+                try insertAndSave(account, modelContext: modelContext)
+            } catch {
+                deleteExchangeCredentials(accountID, secretStore: secretStore)
+                throw error
+            }
+        }
+    }
+
+    @MainActor
+    private static func update(
+        _ account: Account,
+        from draft: AccountSheetDraft,
+        modelContext: ModelContext,
+        secretStore: any SecretStore) throws {
+        switch account.kind {
+        case .wallet:
+            account.name = draft.chainName
+            account.group = nilIfEmpty(draft.chainGroup)
+            account.notes = nilIfEmpty(draft.chainNotes)
+            replaceWalletAddress(
+                for: account,
+                chain: draft.isEVM ? nil : draft.specificChain,
+                address: draft.chainAddress,
+                modelContext: modelContext)
+
+        case .manual:
+            account.name = draft.manualName
+            account.group = nilIfEmpty(draft.manualGroup)
+            account.notes = nilIfEmpty(draft.manualNotes)
+
+        case .exchange:
+            account.name = draft.exchangeName
+            account.exchangeType = draft.exchangeType
+            account.group = nilIfEmpty(draft.exchangeGroup)
+            account.notes = nilIfEmpty(draft.exchangeNotes)
+            try saveExchangeCredentials(for: account.id, from: draft, secretStore: secretStore)
+        }
+
+        do {
+            try modelContext.save()
+        } catch {
+            throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
+        }
+    }
+
+    @MainActor
+    private static func replaceWalletAddress(
+        for account: Account,
+        chain: Chain?,
+        address: String,
+        modelContext: ModelContext) {
+        let currentAddresses = account.addresses
+        if let first = currentAddresses.first {
+            first.chain = chain
+            first.address = address
+            first.account = account
+            account.addresses = [first]
+
+            for extra in currentAddresses.dropFirst() {
+                modelContext.delete(extra)
+            }
+        } else {
+            account.addresses = [WalletAddress(chain: chain, address: address, account: account)]
+        }
+    }
+
+    @MainActor
+    private static func insertAndSave(_ account: Account, modelContext: ModelContext) throws {
+        modelContext.insert(account)
+        do {
+            try modelContext.save()
+        } catch {
+            modelContext.delete(account)
+            throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
+        }
+    }
+
+    private static func saveExchangeCredentials(
+        for accountID: UUID,
+        from draft: AccountSheetDraft,
+        secretStore: any SecretStore) throws {
+        do {
+            try secretStore.set(key: .exchangeAPIKey(accountID), value: draft.exchangeAPIKey)
+            try secretStore.set(key: .exchangeAPISecret(accountID), value: draft.exchangeAPISecret)
+            if
+                let passphrase = AddAccountExchangeSecrets.persistedPassphrase(
+                    draft.exchangePassphrase,
+                    for: draft.exchangeType) {
+                try secretStore.set(key: .exchangePassphrase(accountID), value: passphrase)
+            } else {
+                try secretStore.delete(key: .exchangePassphrase(accountID))
+            }
+        } catch {
+            throw AccountSheetSaveError.credentialSaveFailed(error.localizedDescription)
+        }
+    }
+
+    private static func deleteExchangeCredentials(_ accountID: UUID, secretStore: any SecretStore) {
+        try? secretStore.delete(key: .exchangeAPIKey(accountID))
+        try? secretStore.delete(key: .exchangeAPISecret(accountID))
+        try? secretStore.delete(key: .exchangePassphrase(accountID))
+    }
+
+    private static func nilIfEmpty(_ value: String) -> String? {
+        value.isEmpty ? nil : value
+    }
+}

--- a/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
+++ b/Sources/Portu/Features/Accounts/AccountSheetDraft.swift
@@ -90,9 +90,12 @@ struct AccountSheetDraft: Equatable {
     /// an empty string) so the save path can avoid clobbering secrets it never loaded.
     mutating func loadExchangeCredentials(accountID: UUID, secretStore: any SecretStore) {
         do {
-            exchangeAPIKey = try secretStore.get(key: .exchangeAPIKey(accountID)) ?? ""
-            exchangeAPISecret = try secretStore.get(key: .exchangeAPISecret(accountID)) ?? ""
-            exchangePassphrase = try secretStore.get(key: .exchangePassphrase(accountID)) ?? ""
+            let apiKey = try secretStore.get(key: .exchangeAPIKey(accountID)) ?? ""
+            let apiSecret = try secretStore.get(key: .exchangeAPISecret(accountID)) ?? ""
+            let passphrase = try secretStore.get(key: .exchangePassphrase(accountID)) ?? ""
+            exchangeAPIKey = apiKey
+            exchangeAPISecret = apiSecret
+            exchangePassphrase = passphrase
             exchangeCredentialsLoaded = true
         } catch {
             exchangeCredentialsLoaded = false
@@ -181,13 +184,14 @@ enum AccountSheetSaveCoordinator {
                 dataSource: .zapper,
                 group: nilIfEmpty(draft.chainGroup),
                 notes: nilIfEmpty(draft.chainNotes))
-            account.addresses = [
-                WalletAddress(
-                    chain: draft.isEVM ? nil : draft.specificChain,
-                    address: draft.chainAddress,
-                    account: account)
-            ]
-            try insertAndSave(account, modelContext: modelContext)
+            modelContext.insert(account)
+            let walletAddress = WalletAddress(
+                chain: draft.isEVM ? nil : draft.specificChain,
+                address: draft.chainAddress,
+                account: account)
+            modelContext.insert(walletAddress)
+            account.addresses = [walletAddress]
+            try saveInsertedWalletAccount(account, walletAddress: walletAddress, modelContext: modelContext)
 
         case .manual:
             let account = Account(
@@ -208,9 +212,14 @@ enum AccountSheetSaveCoordinator {
                 dataSource: .exchange,
                 group: nilIfEmpty(draft.exchangeGroup),
                 notes: nilIfEmpty(draft.exchangeNotes))
+            let emptyCredentials = ExchangeCredentialSnapshot.empty
 
             do {
-                try saveExchangeCredentials(for: accountID, from: draft, secretStore: secretStore)
+                try saveExchangeCredentials(
+                    for: accountID,
+                    from: draft,
+                    secretStore: secretStore,
+                    rollbackTo: emptyCredentials)
             } catch {
                 deleteExchangeCredentials(accountID, secretStore: secretStore)
                 throw error
@@ -251,16 +260,31 @@ enum AccountSheetSaveCoordinator {
             // Persist credentials first. If the keychain write fails the model is left
             // untouched, so autosave can't flush a renamed account that still points at
             // the old secrets.
-            try saveExchangeCredentials(for: account.id, from: draft, secretStore: secretStore)
+            let previousCredentials = try readExchangeCredentials(for: account.id, secretStore: secretStore)
+            try saveExchangeCredentials(
+                for: account.id,
+                from: draft,
+                secretStore: secretStore,
+                rollbackTo: previousCredentials)
             account.name = draft.exchangeName
             account.exchangeType = draft.exchangeType
             account.group = nilIfEmpty(draft.exchangeGroup)
             account.notes = nilIfEmpty(draft.exchangeNotes)
+
+            do {
+                try modelContext.save()
+            } catch {
+                modelContext.rollback()
+                restoreExchangeCredentials(previousCredentials, for: account.id, secretStore: secretStore)
+                throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
+            }
+            return
         }
 
         do {
             try modelContext.save()
         } catch {
+            modelContext.rollback()
             throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
         }
     }
@@ -275,10 +299,27 @@ enum AccountSheetSaveCoordinator {
         // row in place reused its identity (stale position resolution after a chain
         // change) and relied on the non-deterministic order of an unordered to-many;
         // recreating is deterministic and handles the empty/multi-address cases alike.
-        for existing in account.addresses {
+        let existingAddresses = Array(account.addresses)
+        for existing in existingAddresses {
             modelContext.delete(existing)
         }
-        account.addresses = [WalletAddress(chain: chain, address: address, account: account)]
+        let newAddress = WalletAddress(chain: chain, address: address, account: account)
+        modelContext.insert(newAddress)
+        account.addresses = [newAddress]
+    }
+
+    @MainActor
+    private static func saveInsertedWalletAccount(
+        _ account: Account,
+        walletAddress: WalletAddress,
+        modelContext: ModelContext) throws {
+        do {
+            try modelContext.save()
+        } catch {
+            modelContext.delete(walletAddress)
+            modelContext.delete(account)
+            throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
+        }
     }
 
     @MainActor
@@ -292,10 +333,31 @@ enum AccountSheetSaveCoordinator {
         }
     }
 
+    @MainActor
+    static func deleteAccount(
+        _ account: Account,
+        modelContext: ModelContext,
+        secretStore: any SecretStore,
+        save: @MainActor (ModelContext) throws -> Void = { try $0.save() }) throws {
+        let accountID = account.id
+        let isExchange = account.kind == .exchange
+        modelContext.delete(account)
+        do {
+            try save(modelContext)
+        } catch {
+            modelContext.rollback()
+            throw AccountSheetSaveError.accountSaveFailed(error.localizedDescription)
+        }
+        if isExchange {
+            deleteExchangeCredentials(accountID, secretStore: secretStore)
+        }
+    }
+
     private static func saveExchangeCredentials(
         for accountID: UUID,
         from draft: AccountSheetDraft,
-        secretStore: any SecretStore) throws {
+        secretStore: any SecretStore,
+        rollbackTo previousCredentials: ExchangeCredentialSnapshot) throws {
         do {
             try secretStore.set(key: .exchangeAPIKey(accountID), value: draft.exchangeAPIKey)
             try secretStore.set(key: .exchangeAPISecret(accountID), value: draft.exchangeAPISecret)
@@ -310,7 +372,38 @@ enum AccountSheetSaveCoordinator {
                 try secretStore.delete(key: .exchangePassphrase(accountID))
             }
         } catch {
+            restoreExchangeCredentials(previousCredentials, for: accountID, secretStore: secretStore)
             throw AccountSheetSaveError.credentialSaveFailed(error.localizedDescription)
+        }
+    }
+
+    private static func readExchangeCredentials(
+        for accountID: UUID,
+        secretStore: any SecretStore) throws -> ExchangeCredentialSnapshot {
+        do {
+            return try ExchangeCredentialSnapshot(
+                apiKey: secretStore.get(key: .exchangeAPIKey(accountID)),
+                apiSecret: secretStore.get(key: .exchangeAPISecret(accountID)),
+                passphrase: secretStore.get(key: .exchangePassphrase(accountID)))
+        } catch {
+            throw AccountSheetSaveError.credentialSaveFailed(error.localizedDescription)
+        }
+    }
+
+    private static func restoreExchangeCredentials(
+        _ snapshot: ExchangeCredentialSnapshot,
+        for accountID: UUID,
+        secretStore: any SecretStore) {
+        restore(snapshot.apiKey, key: .exchangeAPIKey(accountID), secretStore: secretStore)
+        restore(snapshot.apiSecret, key: .exchangeAPISecret(accountID), secretStore: secretStore)
+        restore(snapshot.passphrase, key: .exchangePassphrase(accountID), secretStore: secretStore)
+    }
+
+    private static func restore(_ value: String?, key: KeychainKey, secretStore: any SecretStore) {
+        if let value {
+            try? secretStore.set(key: key, value: value)
+        } else {
+            try? secretStore.delete(key: key)
         }
     }
 
@@ -327,4 +420,12 @@ enum AccountSheetSaveCoordinator {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
+}
+
+private struct ExchangeCredentialSnapshot {
+    var apiKey: String?
+    var apiSecret: String?
+    var passphrase: String?
+
+    static let empty = Self(apiKey: nil, apiSecret: nil, passphrase: nil)
 }

--- a/Sources/Portu/Features/Accounts/AccountSheetSaveError.swift
+++ b/Sources/Portu/Features/Accounts/AccountSheetSaveError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum AccountSheetSaveError: Error, LocalizedError, Equatable {
+    case missingEditedAccount
+    case editedAccountMismatch
+    case credentialSaveFailed(String)
+    case accountSaveFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingEditedAccount:
+            "The account being edited is no longer available."
+        case .editedAccountMismatch:
+            "The account being edited does not match the open sheet."
+        case let .credentialSaveFailed(message):
+            "Failed to save credentials: \(message)"
+        case let .accountSaveFailed(message):
+            "Failed to save account: \(message)"
+        }
+    }
+}

--- a/Sources/Portu/Features/Accounts/AccountsFeature.swift
+++ b/Sources/Portu/Features/Accounts/AccountsFeature.swift
@@ -44,6 +44,36 @@ nonisolated struct AccountRowData: Identifiable {
     }
 }
 
+enum AccountRowActionPolicy {
+    static func syncDisabled(rowIsSyncable: Bool, globalSyncIsRunning: Bool) -> Bool {
+        !rowIsSyncable || globalSyncIsRunning
+    }
+
+    static func deleteDisabled(globalSyncIsRunning: Bool) -> Bool {
+        globalSyncIsRunning
+    }
+
+    static func syncHelp(
+        isActive: Bool,
+        dataSource: DataSource,
+        isSyncingThisAccount: Bool,
+        globalSyncIsRunning: Bool) -> String {
+        if isSyncingThisAccount {
+            return "Syncing this account..."
+        }
+        if globalSyncIsRunning {
+            return "Another sync is already running."
+        }
+        if isActive == false {
+            return "Inactive accounts cannot be synced."
+        }
+        if dataSource == .manual {
+            return "Manual accounts do not sync."
+        }
+        return "Sync this account."
+    }
+}
+
 // MARK: - AccountsFeature
 
 enum AccountSheetMode: Equatable, Identifiable {

--- a/Sources/Portu/Features/Accounts/AccountsFeature.swift
+++ b/Sources/Portu/Features/Accounts/AccountsFeature.swift
@@ -53,6 +53,10 @@ enum AccountRowActionPolicy {
         globalSyncIsRunning
     }
 
+    static func activationToggleDisabled(globalSyncIsRunning: Bool) -> Bool {
+        globalSyncIsRunning
+    }
+
     static func syncHelp(
         isActive: Bool,
         dataSource: DataSource,

--- a/Sources/Portu/Features/Accounts/AccountsFeature.swift
+++ b/Sources/Portu/Features/Accounts/AccountsFeature.swift
@@ -74,6 +74,33 @@ enum AccountRowActionPolicy {
     }
 }
 
+struct AccountSheetSyncState: Equatable {
+    let isSyncing: Bool
+    let isSyncBlocked: Bool
+}
+
+enum AccountSheetSyncPolicy {
+    static func state(
+        mode: AccountSheetMode,
+        syncStatus: SyncStatus,
+        syncingAccountID: UUID?) -> AccountSheetSyncState {
+        guard syncStatus.isSyncing else {
+            return AccountSheetSyncState(isSyncing: false, isSyncBlocked: false)
+        }
+
+        switch mode {
+        case .add:
+            return AccountSheetSyncState(isSyncing: false, isSyncBlocked: true)
+
+        case let .edit(accountID):
+            let isSyncingThisAccount = syncingAccountID == accountID
+            return AccountSheetSyncState(
+                isSyncing: isSyncingThisAccount,
+                isSyncBlocked: !isSyncingThisAccount)
+        }
+    }
+}
+
 // MARK: - AccountsFeature
 
 enum AccountSheetMode: Equatable, Identifiable {

--- a/Sources/Portu/Features/Accounts/AccountsFeature.swift
+++ b/Sources/Portu/Features/Accounts/AccountsFeature.swift
@@ -40,7 +40,7 @@ nonisolated struct AccountRowData: Identifiable {
     let lastSyncError: String?
 
     var isSyncable: Bool {
-        isActive && dataSource != .manual
+        AccountSyncEligibility.isSyncable(isActive: isActive, dataSource: dataSource)
     }
 }
 

--- a/Sources/Portu/Features/Accounts/AccountsFeature.swift
+++ b/Sources/Portu/Features/Accounts/AccountsFeature.swift
@@ -10,11 +10,21 @@ struct AccountInput: Equatable {
     let name: String
     let kind: AccountKind
     let exchangeType: ExchangeType?
+    let dataSource: DataSource
     let group: String?
     let isActive: Bool
     let lastSyncError: String?
     let totalBalance: Decimal
     let firstAddress: String?
+}
+
+struct AccountSaveFields: Equatable {
+    var chainName: String = ""
+    var chainAddress: String = ""
+    var manualName: String = ""
+    var exchangeName: String = ""
+    var exchangeAPIKey: String = ""
+    var exchangeAPISecret: String = ""
 }
 
 /// Row data for account table display.
@@ -25,11 +35,41 @@ nonisolated struct AccountRowData: Identifiable {
     let address: String
     let type: String
     let balance: Decimal
+    let dataSource: DataSource
     let isActive: Bool
     let lastSyncError: String?
+
+    var isSyncable: Bool {
+        isActive && dataSource != .manual
+    }
 }
 
 // MARK: - AccountsFeature
+
+enum AccountSheetMode: Equatable, Identifiable {
+    case add
+    case edit(UUID)
+
+    var id: String {
+        switch self {
+        case .add:
+            "add"
+        case let .edit(id):
+            "edit-\(id.uuidString)"
+        }
+    }
+
+    var editedAccountID: UUID? {
+        if case let .edit(id) = self {
+            return id
+        }
+        return nil
+    }
+
+    var isEditing: Bool {
+        editedAccountID != nil
+    }
+}
 
 @Reducer
 struct AccountsFeature {
@@ -38,14 +78,16 @@ struct AccountsFeature {
         var searchText: String = ""
         var filterGroup: String?
         var showInactive: Bool = false
-        var showAddSheet: Bool = false
+        var accountSheetMode: AccountSheetMode?
     }
 
     enum Action: Equatable {
         case searchTextChanged(String)
         case filterGroupChanged(String?)
         case showInactiveToggled
-        case addSheetPresented(Bool)
+        case addAccountTapped
+        case editAccountTapped(UUID)
+        case accountSheetDismissed
     }
 
     var body: some ReducerOf<Self> {
@@ -63,8 +105,16 @@ struct AccountsFeature {
                 state.showInactive.toggle()
                 return .none
 
-            case let .addSheetPresented(presented):
-                state.showAddSheet = presented
+            case .addAccountTapped:
+                state.accountSheetMode = .add
+                return .none
+
+            case let .editAccountTapped(id):
+                state.accountSheetMode = .edit(id)
+                return .none
+
+            case .accountSheetDismissed:
+                state.accountSheetMode = nil
                 return .none
             }
         }
@@ -78,17 +128,15 @@ struct AccountsFeature {
             let address = account.firstAddress
                 ?? account.exchangeType?.rawValue.capitalized
                 ?? "Manual"
-            let truncated = address.count > 16
-                ? String(address.prefix(16)) + "\u{2026}"
-                : address
 
             return AccountRowData(
                 id: account.id,
                 name: account.name,
                 group: account.group ?? "\u{2014}",
-                address: truncated,
+                address: address,
                 type: account.kind.rawValue.capitalized,
                 balance: account.totalBalance,
+                dataSource: account.dataSource,
                 isActive: account.isActive,
                 lastSyncError: account.lastSyncError)
         }
@@ -115,19 +163,14 @@ struct AccountsFeature {
     /// Validate whether the add-account form can be saved for the given tab.
     static func canSave(
         tab: Int,
-        chainName: String,
-        chainAddress: String,
-        manualName: String,
-        exchangeName: String,
-        exchangeAPIKey: String,
-        exchangeAPISecret: String) -> Bool {
+        fields: AccountSaveFields) -> Bool {
         func filled(_ value: String) -> Bool {
             !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         return switch tab {
-        case 0: filled(chainName) && filled(chainAddress)
-        case 1: filled(manualName)
-        case 2: filled(exchangeName) && filled(exchangeAPIKey) && filled(exchangeAPISecret)
+        case 0: filled(fields.chainName) && filled(fields.chainAddress)
+        case 1: filled(fields.manualName)
+        case 2: filled(fields.exchangeName) && filled(fields.exchangeAPIKey) && filled(fields.exchangeAPISecret)
         default: false
         }
     }

--- a/Sources/Portu/Features/Accounts/AccountsFeature.swift
+++ b/Sources/Portu/Features/Accounts/AccountsFeature.swift
@@ -155,20 +155,27 @@ struct AccountsFeature {
     /// Map account inputs to display rows.
     static func mapAccountRows(from accounts: [AccountInput]) -> [AccountRowData] {
         accounts.map { account in
-            let address = account.firstAddress
-                ?? account.exchangeType?.rawValue.capitalized
-                ?? "Manual"
-
-            return AccountRowData(
+            AccountRowData(
                 id: account.id,
                 name: account.name,
                 group: account.group ?? "\u{2014}",
-                address: address,
+                address: addressDisplay(for: account),
                 type: account.kind.rawValue.capitalized,
                 balance: account.totalBalance,
                 dataSource: account.dataSource,
                 isActive: account.isActive,
                 lastSyncError: account.lastSyncError)
+        }
+    }
+
+    private static func addressDisplay(for account: AccountInput) -> String {
+        switch account.kind {
+        case .wallet:
+            account.firstAddress ?? "\u{2014}"
+        case .exchange:
+            account.exchangeType?.rawValue.capitalized ?? "Exchange"
+        case .manual:
+            "Manual"
         }
     }
 

--- a/Sources/Portu/Features/Accounts/AccountsView.swift
+++ b/Sources/Portu/Features/Accounts/AccountsView.swift
@@ -13,6 +13,7 @@ struct AccountsView: View {
     @State private var sortOrder: [KeyPathComparator<AccountRowData>] = [
         KeyPathComparator(\.name)
     ]
+    @State private var accountActionError: String?
 
     private var accountInputs: [AccountInput] {
         accounts.map { account in
@@ -58,6 +59,13 @@ struct AccountsView: View {
             set: { if $0 == nil { store.send(.accounts(.accountSheetDismissed)) } })) { mode in
                 accountSheet(for: mode)
                     .environment(\.colorScheme, .dark)
+        }
+        .alert("Unable to Update Account", isPresented: Binding(
+            get: { accountActionError != nil },
+            set: { if !$0 { accountActionError = nil } })) {
+                Button("OK") { accountActionError = nil }
+        } message: {
+            Text(accountActionError ?? "")
         }
     }
 
@@ -231,11 +239,13 @@ struct AccountsView: View {
                 }
                 Divider()
                 Button("Delete", role: .destructive) {
-                    let isExchange = account.kind == .exchange
-                    modelContext.delete(account)
-                    try? modelContext.save()
-                    if isExchange {
-                        AccountSheetSaveCoordinator.deleteExchangeCredentials(id, secretStore: LocalSecretStore())
+                    do {
+                        try AccountSheetSaveCoordinator.deleteAccount(
+                            account,
+                            modelContext: modelContext,
+                            secretStore: LocalSecretStore())
+                    } catch {
+                        accountActionError = error.localizedDescription
                     }
                 }
             }

--- a/Sources/Portu/Features/Accounts/AccountsView.swift
+++ b/Sources/Portu/Features/Accounts/AccountsView.swift
@@ -113,18 +113,24 @@ struct AccountsView: View {
 
     @ViewBuilder
     private func accountSheet(for mode: AccountSheetMode) -> some View {
+        let syncState = AccountSheetSyncPolicy.state(
+            mode: mode,
+            syncStatus: store.syncStatus,
+            syncingAccountID: store.syncingAccountID)
         switch mode {
         case .add:
-            AddAccountSheet()
+            AddAccountSheet(
+                isSyncing: syncState.isSyncing,
+                isSyncBlocked: syncState.isSyncBlocked)
 
         case let .edit(accountID):
             if let account = accounts.first(where: { $0.id == accountID }) {
                 AddAccountSheet(
                     mode: mode,
                     account: account,
-                    isSyncing: accountIsSyncing(account.id),
+                    isSyncing: syncState.isSyncing,
                     canSync: account.isSyncable,
-                    isSyncBlocked: store.syncStatus.isSyncing && store.syncingAccountID != account.id,
+                    isSyncBlocked: syncState.isSyncBlocked,
                     onSync: { id in store.send(.accountSyncTapped(id)) })
             } else {
                 VStack(spacing: 12) {

--- a/Sources/Portu/Features/Accounts/AccountsView.swift
+++ b/Sources/Portu/Features/Accounts/AccountsView.swift
@@ -21,6 +21,7 @@ struct AccountsView: View {
                 name: account.name,
                 kind: account.kind,
                 exchangeType: account.exchangeType,
+                dataSource: account.dataSource,
                 group: account.group,
                 isActive: account.isActive,
                 lastSyncError: account.lastSyncError,
@@ -52,10 +53,10 @@ struct AccountsView: View {
         }
         .padding(DashboardStyle.pagePadding)
         .dashboardPage()
-        .sheet(isPresented: Binding(
-            get: { store.accounts.showAddSheet },
-            set: { store.send(.accounts(.addSheetPresented($0))) })) {
-                AddAccountSheet()
+        .sheet(item: Binding(
+            get: { store.accounts.accountSheetMode },
+            set: { if $0 == nil { store.send(.accounts(.accountSheetDismissed)) } })) { mode in
+                accountSheet(for: mode)
                     .environment(\.colorScheme, .dark)
         }
     }
@@ -95,11 +96,41 @@ struct AccountsView: View {
                 .dashboardControl()
 
             Button("Add Account", systemImage: "plus") {
-                store.send(.accounts(.addSheetPresented(true)))
+                store.send(.accounts(.addAccountTapped))
             }
             .dashboardControl()
         }
         .dashboardCard(horizontalPadding: 10, verticalPadding: 10)
+    }
+
+    @ViewBuilder
+    private func accountSheet(for mode: AccountSheetMode) -> some View {
+        switch mode {
+        case .add:
+            AddAccountSheet()
+
+        case let .edit(accountID):
+            if let account = accounts.first(where: { $0.id == accountID }) {
+                AddAccountSheet(
+                    mode: mode,
+                    account: account,
+                    isSyncing: accountIsSyncing(account.id),
+                    canSync: account.isActive && account.dataSource != .manual,
+                    isSyncBlocked: store.syncStatus.isSyncing && store.syncingAccountID != account.id,
+                    onSync: { id in store.send(.accountSyncTapped(id)) })
+            } else {
+                VStack(spacing: 12) {
+                    Text("Account not found")
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundStyle(PortuTheme.dashboardText)
+                    Button("Close") {
+                        store.send(.accounts(.accountSheetDismissed))
+                    }
+                }
+                .frame(width: 420, height: 180)
+                .background(PortuTheme.dashboardPanelBackground)
+            }
+        }
     }
 
     // MARK: - Table
@@ -125,8 +156,10 @@ struct AccountsView: View {
                 Text(row.address)
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(PortuTheme.dashboardSecondaryText)
+                    .textSelection(.enabled)
+                    .help(row.address)
             }
-            .width(min: 100, ideal: 160)
+            .width(min: 260, ideal: 420)
 
             TableColumn("Type") { row in
                 CapsuleBadge(row.type)
@@ -146,10 +179,49 @@ struct AccountsView: View {
                 }
             }
             .width(min: 80, ideal: 120)
+
+            TableColumn("Actions") { row in
+                HStack(spacing: 6) {
+                    Button {
+                        store.send(.accounts(.editAccountTapped(row.id)))
+                    } label: {
+                        Image(systemName: "pencil")
+                            .frame(width: 18, height: 18)
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Edit account")
+
+                    Button {
+                        store.send(.accountSyncTapped(row.id))
+                    } label: {
+                        if rowIsSyncing(row) {
+                            ProgressView()
+                                .controlSize(.small)
+                                .scaleEffect(0.62)
+                                .frame(width: 18, height: 18)
+                        } else {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .frame(width: 18, height: 18)
+                        }
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(rowSyncDisabled(row))
+                    .help(rowSyncHelp(row))
+                }
+            }
+            .width(min: 78, ideal: 92)
         }
         .dashboardTable()
         .contextMenu(forSelectionType: AccountRowData.ID.self) { selection in
             if let id = selection.first, let account = accounts.first(where: { $0.id == id }) {
+                Button("Edit") {
+                    store.send(.accounts(.editAccountTapped(id)))
+                }
+                Button("Sync") {
+                    store.send(.accountSyncTapped(id))
+                }
+                .disabled(account.dataSource == .manual || !account.isActive || store.syncStatus.isSyncing)
+                Divider()
                 Button(account.isActive ? "Deactivate" : "Activate") {
                     account.isActive.toggle()
                     try? modelContext.save()
@@ -161,5 +233,30 @@ struct AccountsView: View {
                 }
             }
         }
+    }
+
+    private func rowSyncDisabled(_ row: AccountRowData) -> Bool {
+        !row.isSyncable || store.syncStatus.isSyncing
+    }
+
+    private func rowIsSyncing(_ row: AccountRowData) -> Bool {
+        accountIsSyncing(row.id)
+    }
+
+    private func accountIsSyncing(_ accountID: UUID) -> Bool {
+        store.syncStatus.isSyncing && store.syncingAccountID == accountID
+    }
+
+    private func rowSyncHelp(_ row: AccountRowData) -> String {
+        if store.syncStatus.isSyncing {
+            return "Another sync is already running."
+        }
+        if row.isActive == false {
+            return "Inactive accounts cannot be synced."
+        }
+        if row.dataSource == .manual {
+            return "Manual accounts do not sync."
+        }
+        return "Sync this account."
     }
 }

--- a/Sources/Portu/Features/Accounts/AccountsView.swift
+++ b/Sources/Portu/Features/Accounts/AccountsView.swift
@@ -249,6 +249,7 @@ struct AccountsView: View {
                         accountActionError = error.localizedDescription
                     }
                 }
+                .disabled(AccountRowActionPolicy.activationToggleDisabled(globalSyncIsRunning: store.syncStatus.isSyncing))
                 Divider()
                 Button("Delete", role: .destructive) {
                     do {

--- a/Sources/Portu/Features/Accounts/AccountsView.swift
+++ b/Sources/Portu/Features/Accounts/AccountsView.swift
@@ -115,7 +115,7 @@ struct AccountsView: View {
                     mode: mode,
                     account: account,
                     isSyncing: accountIsSyncing(account.id),
-                    canSync: account.isActive && account.dataSource != .manual,
+                    canSync: account.isSyncable,
                     isSyncBlocked: store.syncStatus.isSyncing && store.syncingAccountID != account.id,
                     onSync: { id in store.send(.accountSyncTapped(id)) })
             } else {
@@ -190,6 +190,7 @@ struct AccountsView: View {
                     }
                     .buttonStyle(.borderless)
                     .help("Edit account")
+                    .accessibilityLabel("Edit account")
 
                     Button {
                         store.send(.accountSyncTapped(row.id))
@@ -198,6 +199,7 @@ struct AccountsView: View {
                             ProgressView()
                                 .controlSize(.small)
                                 .scaleEffect(0.62)
+                                .tint(PortuTheme.dashboardGold)
                                 .frame(width: 18, height: 18)
                         } else {
                             Image(systemName: "arrow.triangle.2.circlepath")
@@ -207,6 +209,7 @@ struct AccountsView: View {
                     .buttonStyle(.borderless)
                     .disabled(rowSyncDisabled(row))
                     .help(rowSyncHelp(row))
+                    .accessibilityLabel("Sync account")
                 }
             }
             .width(min: 78, ideal: 92)
@@ -220,7 +223,7 @@ struct AccountsView: View {
                 Button("Sync") {
                     store.send(.accountSyncTapped(id))
                 }
-                .disabled(account.dataSource == .manual || !account.isActive || store.syncStatus.isSyncing)
+                .disabled(!account.isSyncable || store.syncStatus.isSyncing)
                 Divider()
                 Button(account.isActive ? "Deactivate" : "Activate") {
                     account.isActive.toggle()
@@ -228,8 +231,12 @@ struct AccountsView: View {
                 }
                 Divider()
                 Button("Delete", role: .destructive) {
+                    let isExchange = account.kind == .exchange
                     modelContext.delete(account)
                     try? modelContext.save()
+                    if isExchange {
+                        AccountSheetSaveCoordinator.deleteExchangeCredentials(id, secretStore: LocalSecretStore())
+                    }
                 }
             }
         }

--- a/Sources/Portu/Features/Accounts/AccountsView.swift
+++ b/Sources/Portu/Features/Accounts/AccountsView.swift
@@ -234,8 +234,14 @@ struct AccountsView: View {
                 .disabled(!account.isSyncable || store.syncStatus.isSyncing)
                 Divider()
                 Button(account.isActive ? "Deactivate" : "Activate") {
-                    account.isActive.toggle()
-                    try? modelContext.save()
+                    do {
+                        try AccountSheetSaveCoordinator.setAccount(
+                            account,
+                            isActive: !account.isActive,
+                            modelContext: modelContext)
+                    } catch {
+                        accountActionError = error.localizedDescription
+                    }
                 }
                 Divider()
                 Button("Delete", role: .destructive) {
@@ -248,12 +254,15 @@ struct AccountsView: View {
                         accountActionError = error.localizedDescription
                     }
                 }
+                .disabled(AccountRowActionPolicy.deleteDisabled(globalSyncIsRunning: store.syncStatus.isSyncing))
             }
         }
     }
 
     private func rowSyncDisabled(_ row: AccountRowData) -> Bool {
-        !row.isSyncable || store.syncStatus.isSyncing
+        AccountRowActionPolicy.syncDisabled(
+            rowIsSyncable: row.isSyncable,
+            globalSyncIsRunning: store.syncStatus.isSyncing)
     }
 
     private func rowIsSyncing(_ row: AccountRowData) -> Bool {
@@ -265,15 +274,10 @@ struct AccountsView: View {
     }
 
     private func rowSyncHelp(_ row: AccountRowData) -> String {
-        if store.syncStatus.isSyncing {
-            return "Another sync is already running."
-        }
-        if row.isActive == false {
-            return "Inactive accounts cannot be synced."
-        }
-        if row.dataSource == .manual {
-            return "Manual accounts do not sync."
-        }
-        return "Sync this account."
+        AccountRowActionPolicy.syncHelp(
+            isActive: row.isActive,
+            dataSource: row.dataSource,
+            isSyncingThisAccount: accountIsSyncing(row.id),
+            globalSyncIsRunning: store.syncStatus.isSyncing)
     }
 }

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -118,7 +118,7 @@ struct AddAccountSheet: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel(AddAccountAccessibility.closeButtonLabel)
-            .accessibilityHint("Closes the add account sheet.")
+            .accessibilityHint(AddAccountAccessibility.closeButtonHint)
         }
         .padding(.horizontal, 20)
         .frame(height: 58)

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -7,30 +7,39 @@ struct AddAccountSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
 
-    @State private var selectedTab: AddAccountTab = .chain
+    private let mode: AccountSheetMode
+    private let account: Account?
+    private let isSyncing: Bool
+    private let canSync: Bool
+    private let isSyncBlocked: Bool
+    private let onSync: ((UUID) -> Void)?
+    private let secretStore: any SecretStore
 
-    // Chain account fields
-    @State private var chainName = ""
-    @State private var chainAddress = ""
-    @State private var chainGroup = ""
-    @State private var chainNotes = ""
-    @State private var isEVM = true
-    @State private var specificChain: Chain = .solana
-
-    // Manual account fields
-    @State private var manualName = ""
-    @State private var manualNotes = ""
-    @State private var manualGroup = ""
-
-    // Exchange account fields
-    @State private var exchangeName = ""
-    @State private var exchangeType: ExchangeType = .kraken
-    @State private var exchangeAPIKey = ""
-    @State private var exchangeAPISecret = ""
-    @State private var exchangePassphrase = ""
-    @State private var exchangeGroup = ""
-    @State private var exchangeNotes = ""
+    @State private var draft: AccountSheetDraft
     @State private var saveError: String?
+
+    init(
+        mode: AccountSheetMode = .add,
+        account: Account? = nil,
+        isSyncing: Bool = false,
+        canSync: Bool = false,
+        isSyncBlocked: Bool = false,
+        onSync: ((UUID) -> Void)? = nil,
+        secretStore: any SecretStore = LocalSecretStore()) {
+        self.mode = mode
+        self.account = account
+        self.isSyncing = isSyncing
+        self.canSync = canSync
+        self.isSyncBlocked = isSyncBlocked
+        self.onSync = onSync
+        self.secretStore = secretStore
+        let initialDraft = if mode.isEditing, let account {
+            AccountSheetDraft.editing(account: account, secretStore: secretStore)
+        } else {
+            AccountSheetDraft.adding()
+        }
+        _draft = State(initialValue: initialDraft)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -41,10 +50,14 @@ struct AddAccountSheet: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {
-                    AddAccountTabSelector(selection: $selectedTab)
+                    if mode.isEditing {
+                        lockedAccountTypeLabel
+                    } else {
+                        AddAccountTabSelector(selection: $draft.selectedTab)
+                    }
 
                     Group {
-                        switch selectedTab {
+                        switch draft.selectedTab {
                         case .chain:
                             chainAccountTab
                         case .manual:
@@ -53,7 +66,7 @@ struct AddAccountSheet: View {
                             exchangeAccountTab
                         }
                     }
-                    .animation(.snappy(duration: 0.18), value: selectedTab)
+                    .animation(.snappy(duration: 0.18), value: draft.selectedTab)
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
@@ -70,7 +83,7 @@ struct AddAccountSheet: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
         .environment(\.colorScheme, .dark)
-        .alert("Unable to Add Account", isPresented: Binding(
+        .alert(alertTitle, isPresented: Binding(
             get: { saveError != nil },
             set: { if !$0 { saveError = nil } })) {
                 Button("OK") { saveError = nil }
@@ -81,7 +94,7 @@ struct AddAccountSheet: View {
 
     private var header: some View {
         HStack(spacing: 12) {
-            Text("Add new account")
+            Text(mode.isEditing ? "Edit account" : "Add new account")
                 .font(.system(size: 19, weight: .medium))
                 .foregroundStyle(PortuTheme.dashboardText)
 
@@ -102,6 +115,36 @@ struct AddAccountSheet: View {
         }
         .padding(.horizontal, 20)
         .frame(height: 58)
+    }
+
+    private var lockedAccountTypeLabel: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(PortuTheme.dashboardSecondaryText)
+
+            Text(draft.selectedTab.title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(PortuTheme.dashboardText)
+
+            Spacer(minLength: 8)
+
+            Text("Type locked while editing")
+                .font(.system(size: 12))
+                .foregroundStyle(PortuTheme.dashboardTertiaryText)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 34)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(PortuTheme.dashboardPanelElevatedBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+    }
+
+    private var alertTitle: String {
+        mode.isEditing ? "Unable to Save Account" : "Unable to Add Account"
     }
 
     // MARK: - Chain Account Tab
@@ -126,7 +169,7 @@ struct AddAccountSheet: View {
                     AddAccountTextField(
                         title: "Account Address",
                         placeholder: "Paste wallet address",
-                        text: $chainAddress,
+                        text: $draft.chainAddress,
                         isRequired: true,
                         isMonospaced: true)
 
@@ -136,19 +179,19 @@ struct AddAccountSheet: View {
                 AddAccountTextField(
                     title: "Account Name",
                     placeholder: "Account Name",
-                    text: $chainName,
+                    text: $draft.chainName,
                     isRequired: true)
 
                 HStack(alignment: .top, spacing: 10) {
                     AddAccountTextField(
                         title: "Description",
                         placeholder: "Descriptive text",
-                        text: $chainNotes)
+                        text: $draft.chainNotes)
 
                     AddAccountTextField(
                         title: "Account group",
                         placeholder: "Select a group",
-                        text: $chainGroup)
+                        text: $draft.chainGroup)
                 }
 
                 InlineSourceNote(text: "Data source: Zapper API")
@@ -159,18 +202,18 @@ struct AddAccountSheet: View {
     private var chainTypePicker: some View {
         AddAccountMenuField(
             title: "Account Type",
-            value: isEVM ? "Ethereum & L2s (EVM)" : specificChain.addAccountTitle,
+            value: draft.isEVM ? "Ethereum & L2s (EVM)" : draft.specificChain.addAccountTitle,
             isRequired: true) {
                 Button("Ethereum & L2s (EVM)") {
-                    isEVM = true
+                    draft.isEVM = true
                 }
 
                 Divider()
 
                 ForEach([Chain.solana, .bitcoin], id: \.self) { chain in
                     Button(chain.addAccountTitle) {
-                        specificChain = chain
-                        isEVM = false
+                        draft.specificChain = chain
+                        draft.isEVM = false
                     }
                 }
             }
@@ -186,19 +229,19 @@ struct AddAccountSheet: View {
                 AddAccountTextField(
                     title: "Account Name",
                     placeholder: "Account Name",
-                    text: $manualName,
+                    text: $draft.manualName,
                     isRequired: true)
 
                 HStack(alignment: .top, spacing: 10) {
                     AddAccountTextField(
                         title: "Description",
                         placeholder: "Descriptive text",
-                        text: $manualNotes)
+                        text: $draft.manualNotes)
 
                     AddAccountTextField(
                         title: "Account group",
                         placeholder: "Select a group",
-                        text: $manualGroup)
+                        text: $draft.manualGroup)
                 }
             }
         }
@@ -225,7 +268,7 @@ struct AddAccountSheet: View {
                     AddAccountTextField(
                         title: "Name",
                         placeholder: "Account Name",
-                        text: $exchangeName,
+                        text: $draft.exchangeName,
                         isRequired: true)
                 }
 
@@ -235,33 +278,33 @@ struct AddAccountSheet: View {
                     AddAccountSecureField(
                         title: "API Key",
                         placeholder: "API Key",
-                        text: $exchangeAPIKey,
+                        text: $draft.exchangeAPIKey,
                         isRequired: true)
 
                     AddAccountSecureField(
                         title: "Private Key",
                         placeholder: "Private Key",
-                        text: $exchangeAPISecret,
+                        text: $draft.exchangeAPISecret,
                         isRequired: true)
                 }
 
-                if exchangeType == .coinbase {
+                if draft.exchangeType == .coinbase {
                     AddAccountSecureField(
                         title: "Passphrase",
                         placeholder: "Passphrase",
-                        text: $exchangePassphrase)
+                        text: $draft.exchangePassphrase)
                 }
 
                 HStack(alignment: .top, spacing: 10) {
                     AddAccountTextField(
                         title: "Description",
                         placeholder: "Descriptive text",
-                        text: $exchangeNotes)
+                        text: $draft.exchangeNotes)
 
                     AddAccountTextField(
                         title: "Account group",
                         placeholder: "Select a group",
-                        text: $exchangeGroup)
+                        text: $draft.exchangeGroup)
                 }
             }
         }
@@ -270,14 +313,14 @@ struct AddAccountSheet: View {
     private var exchangePicker: some View {
         AddAccountMenuField(
             title: "Exchange",
-            value: exchangeType.addAccountTitle,
+            value: draft.exchangeType.addAccountTitle,
             isRequired: true) {
                 ForEach(ExchangeType.allCases, id: \.self) { type in
                     Button(type.addAccountTitle) {
-                        exchangeType = type
-                        exchangePassphrase = AddAccountExchangeSecrets.passphraseAfterSelecting(
+                        draft.exchangeType = type
+                        draft.exchangePassphrase = AddAccountExchangeSecrets.passphraseAfterSelecting(
                             type,
-                            currentPassphrase: exchangePassphrase)
+                            currentPassphrase: draft.exchangePassphrase)
                     }
                 }
             }
@@ -309,10 +352,43 @@ struct AddAccountSheet: View {
 
                 Spacer()
 
+                if let accountID = mode.editedAccountID {
+                    Button {
+                        onSync?(accountID)
+                    } label: {
+                        HStack(spacing: 7) {
+                            Text("Sync")
+                            if isSyncing {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .scaleEffect(0.62)
+                                    .frame(width: 12, height: 12)
+                                    .tint(PortuTheme.dashboardGold)
+                            } else {
+                                Image(systemName: "arrow.triangle.2.circlepath")
+                                    .font(.system(size: 11, weight: .bold))
+                            }
+                        }
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(syncButtonEnabled ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                        .padding(.horizontal, 14)
+                        .frame(height: 34)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(PortuTheme.dashboardMutedPanelBackground))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!syncButtonEnabled)
+                    .help(syncHelpText)
+                }
+
                 Button {
                     saveAccount()
                 } label: {
-                    Text("Add Account")
+                    Text(mode.isEditing ? "Save Changes" : "Add Account")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(canSave ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
                         .padding(.horizontal, 18)
@@ -337,103 +413,35 @@ struct AddAccountSheet: View {
     // MARK: - Save
 
     private var canSave: Bool {
-        AccountsFeature.canSave(
-            tab: selectedTab.rawValue,
-            chainName: chainName,
-            chainAddress: chainAddress,
-            manualName: manualName,
-            exchangeName: exchangeName,
-            exchangeAPIKey: exchangeAPIKey,
-            exchangeAPISecret: exchangeAPISecret)
+        draft.canSave
+    }
+
+    private var syncButtonEnabled: Bool {
+        canSync && !isSyncing && !isSyncBlocked
+    }
+
+    private var syncHelpText: String {
+        if isSyncing || isSyncBlocked {
+            return "Another sync is already running."
+        }
+        if canSync == false {
+            return "This account cannot be synced."
+        }
+        return "Sync this account."
     }
 
     private func saveAccount() {
-        let didSave: Bool = switch selectedTab {
-        case .chain:
-            saveChainAccount()
-        case .manual:
-            saveManualAccount()
-        case .exchange:
-            saveExchangeAccount()
-        }
-
-        if didSave {
+        do {
+            try AccountSheetSaveCoordinator.save(
+                draft: draft,
+                mode: mode,
+                editing: account,
+                modelContext: modelContext,
+                secretStore: secretStore)
             dismiss()
-        }
-    }
-
-    private func saveChainAccount() -> Bool {
-        let account = Account(
-            name: chainName,
-            kind: .wallet,
-            dataSource: .zapper,
-            group: chainGroup.isEmpty ? nil : chainGroup,
-            notes: chainNotes.isEmpty ? nil : chainNotes)
-        let chain: Chain? = isEVM ? nil : specificChain
-        let addr = WalletAddress(chain: chain, address: chainAddress, account: account)
-        account.addresses = [addr]
-
-        return insertAndSave(account)
-    }
-
-    private func saveManualAccount() -> Bool {
-        let account = Account(
-            name: manualName,
-            kind: .manual,
-            dataSource: .manual,
-            group: manualGroup.isEmpty ? nil : manualGroup,
-            notes: manualNotes.isEmpty ? nil : manualNotes)
-        return insertAndSave(account)
-    }
-
-    private func saveExchangeAccount() -> Bool {
-        let accountId = UUID()
-        let account = Account(
-            id: accountId,
-            name: exchangeName,
-            kind: .exchange,
-            exchangeType: exchangeType,
-            dataSource: .exchange,
-            group: exchangeGroup.isEmpty ? nil : exchangeGroup,
-            notes: exchangeNotes.isEmpty ? nil : exchangeNotes)
-
-        let secretStore = LocalSecretStore()
-        do {
-            try secretStore.set(key: .exchangeAPIKey(accountId), value: exchangeAPIKey)
-            try secretStore.set(key: .exchangeAPISecret(accountId), value: exchangeAPISecret)
-            if let passphrase = AddAccountExchangeSecrets.persistedPassphrase(exchangePassphrase, for: exchangeType) {
-                try secretStore.set(key: .exchangePassphrase(accountId), value: passphrase)
-            }
         } catch {
-            deleteExchangeCredentials(accountId, secretStore: secretStore)
-            saveError = "Failed to save credentials: \(error.localizedDescription)"
-            return false
+            saveError = error.localizedDescription
         }
-
-        if insertAndSave(account) {
-            return true
-        }
-
-        deleteExchangeCredentials(accountId, secretStore: secretStore)
-        return false
-    }
-
-    private func insertAndSave(_ account: Account) -> Bool {
-        modelContext.insert(account)
-        do {
-            try modelContext.save()
-            return true
-        } catch {
-            modelContext.delete(account)
-            saveError = "Failed to save account: \(error.localizedDescription)"
-            return false
-        }
-    }
-
-    private func deleteExchangeCredentials(_ accountId: UUID, secretStore: any SecretStore) {
-        try? secretStore.delete(key: .exchangeAPIKey(accountId))
-        try? secretStore.delete(key: .exchangeAPISecret(accountId))
-        try? secretStore.delete(key: .exchangePassphrase(accountId))
     }
 }
 

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -16,6 +16,8 @@ struct AddAccountSheet: View {
     private let secretStore: any SecretStore
 
     @State private var draft: AccountSheetDraft
+    @State private var baselineDraft: AccountSheetDraft
+    @State private var didLoadCredentials = false
     @State private var saveError: String?
 
     init(
@@ -33,12 +35,15 @@ struct AddAccountSheet: View {
         self.isSyncBlocked = isSyncBlocked
         self.onSync = onSync
         self.secretStore = secretStore
+        // No keychain I/O here: the View struct is re-created on every parent render,
+        // so credentials are loaded once in `.onAppear` instead.
         let initialDraft = if mode.isEditing, let account {
-            AccountSheetDraft.editing(account: account, secretStore: secretStore)
+            AccountSheetDraft.editing(account: account)
         } else {
             AccountSheetDraft.adding()
         }
         _draft = State(initialValue: initialDraft)
+        _baselineDraft = State(initialValue: initialDraft)
     }
 
     var body: some View {
@@ -90,6 +95,15 @@ struct AddAccountSheet: View {
         } message: {
             Text(saveError ?? "")
         }
+        .onAppear { loadCredentialsIfNeeded() }
+    }
+
+    private func loadCredentialsIfNeeded() {
+        guard !didLoadCredentials, mode.isEditing, let account, account.kind == .exchange else { return }
+        didLoadCredentials = true
+        draft.loadExchangeCredentials(accountID: account.id, secretStore: secretStore)
+        // Re-baseline so loaded credentials don't read as unsaved user edits.
+        baselineDraft = draft
     }
 
     private var header: some View {
@@ -390,19 +404,19 @@ struct AddAccountSheet: View {
                 } label: {
                     Text(mode.isEditing ? "Save Changes" : "Add Account")
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(canSave ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                        .foregroundStyle(draft.canSave ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
                         .padding(.horizontal, 18)
                         .frame(height: 34)
                         .background(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(canSave ? PortuTheme.dashboardGoldMuted : PortuTheme.dashboardMutedPanelBackground))
+                                .fill(draft.canSave ? PortuTheme.dashboardGoldMuted : PortuTheme.dashboardMutedPanelBackground))
                         .overlay(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .stroke(canSave ? PortuTheme.dashboardMutedStroke : PortuTheme.dashboardStroke, lineWidth: 1))
+                                .stroke(draft.canSave ? PortuTheme.dashboardMutedStroke : PortuTheme.dashboardStroke, lineWidth: 1))
                 }
                 .buttonStyle(.plain)
                 .keyboardShortcut(.defaultAction)
-                .disabled(!canSave)
+                .disabled(!draft.canSave)
             }
             .padding(.horizontal, 20)
             .frame(height: 54)
@@ -412,16 +426,22 @@ struct AddAccountSheet: View {
 
     // MARK: - Save
 
-    private var canSave: Bool {
-        draft.canSave
+    private var hasUnsavedChanges: Bool {
+        draft != baselineDraft
     }
 
     private var syncButtonEnabled: Bool {
-        canSync && !isSyncing && !isSyncBlocked
+        canSync && !isSyncing && !isSyncBlocked && !hasUnsavedChanges
     }
 
     private var syncHelpText: String {
-        if isSyncing || isSyncBlocked {
+        if hasUnsavedChanges {
+            return "Save your changes before syncing."
+        }
+        if isSyncing {
+            return "Syncing this account\u{2026}"
+        }
+        if isSyncBlocked {
             return "Another sync is already running."
         }
         if canSync == false {

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -71,6 +71,7 @@ struct AddAccountSheet: View {
                             exchangeAccountTab
                         }
                     }
+                    .disabled(!fieldsEditable)
                     .animation(.snappy(duration: 0.18), value: draft.selectedTab)
                 }
                 .padding(.horizontal, 14)
@@ -441,6 +442,10 @@ private extension AddAccountSheet {
             draftCanSave: draft.canSave,
             isSyncing: isSyncing,
             isSyncBlocked: isSyncBlocked)
+    }
+
+    var fieldsEditable: Bool {
+        AddAccountSheetSavePolicy.canEditFields(isSyncing: isSyncing, isSyncBlocked: isSyncBlocked)
     }
 
     var syncHelpText: String {

--- a/Sources/Portu/Features/Accounts/AddAccountSheet.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheet.swift
@@ -98,14 +98,6 @@ struct AddAccountSheet: View {
         .onAppear { loadCredentialsIfNeeded() }
     }
 
-    private func loadCredentialsIfNeeded() {
-        guard !didLoadCredentials, mode.isEditing, let account, account.kind == .exchange else { return }
-        didLoadCredentials = true
-        draft.loadExchangeCredentials(accountID: account.id, secretStore: secretStore)
-        // Re-baseline so loaded credentials don't read as unsaved user edits.
-        baselineDraft = draft
-    }
-
     private var header: some View {
         HStack(spacing: 12) {
             Text(mode.isEditing ? "Edit account" : "Add new account")
@@ -155,10 +147,6 @@ struct AddAccountSheet: View {
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(PortuTheme.dashboardStroke, lineWidth: 1))
-    }
-
-    private var alertTitle: String {
-        mode.isEditing ? "Unable to Save Account" : "Unable to Add Account"
     }
 
     // MARK: - Chain Account Tab
@@ -404,37 +392,58 @@ struct AddAccountSheet: View {
                 } label: {
                     Text(mode.isEditing ? "Save Changes" : "Add Account")
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(draft.canSave ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
+                        .foregroundStyle(saveEnabled ? PortuTheme.dashboardText : PortuTheme.dashboardSecondaryText)
                         .padding(.horizontal, 18)
                         .frame(height: 34)
                         .background(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(draft.canSave ? PortuTheme.dashboardGoldMuted : PortuTheme.dashboardMutedPanelBackground))
+                                .fill(saveEnabled ? PortuTheme.dashboardGoldMuted : PortuTheme.dashboardMutedPanelBackground))
                         .overlay(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .stroke(draft.canSave ? PortuTheme.dashboardMutedStroke : PortuTheme.dashboardStroke, lineWidth: 1))
+                                .stroke(saveEnabled ? PortuTheme.dashboardMutedStroke : PortuTheme.dashboardStroke, lineWidth: 1))
                 }
                 .buttonStyle(.plain)
                 .keyboardShortcut(.defaultAction)
-                .disabled(!draft.canSave)
+                .disabled(!saveEnabled)
             }
             .padding(.horizontal, 20)
             .frame(height: 54)
             .background(PortuTheme.dashboardPanelBackground)
         }
     }
+}
 
-    // MARK: - Save
+// MARK: - Sheet State
 
-    private var hasUnsavedChanges: Bool {
+private extension AddAccountSheet {
+    func loadCredentialsIfNeeded() {
+        guard !didLoadCredentials, mode.isEditing, let account, account.kind == .exchange else { return }
+        didLoadCredentials = true
+        draft.loadExchangeCredentials(accountID: account.id, secretStore: secretStore)
+        // Re-baseline so loaded credentials don't read as unsaved user edits.
+        baselineDraft = draft
+    }
+
+    var alertTitle: String {
+        mode.isEditing ? "Unable to Save Account" : "Unable to Add Account"
+    }
+
+    var hasUnsavedChanges: Bool {
         draft != baselineDraft
     }
 
-    private var syncButtonEnabled: Bool {
+    var syncButtonEnabled: Bool {
         canSync && !isSyncing && !isSyncBlocked && !hasUnsavedChanges
     }
 
-    private var syncHelpText: String {
+    var saveEnabled: Bool {
+        AddAccountSheetSavePolicy.canSubmit(
+            draftCanSave: draft.canSave,
+            isSyncing: isSyncing,
+            isSyncBlocked: isSyncBlocked)
+    }
+
+    var syncHelpText: String {
         if hasUnsavedChanges {
             return "Save your changes before syncing."
         }
@@ -450,7 +459,8 @@ struct AddAccountSheet: View {
         return "Sync this account."
     }
 
-    private func saveAccount() {
+    func saveAccount() {
+        guard saveEnabled else { return }
         do {
             try AccountSheetSaveCoordinator.save(
                 draft: draft,
@@ -462,25 +472,5 @@ struct AddAccountSheet: View {
         } catch {
             saveError = error.localizedDescription
         }
-    }
-}
-
-enum AddAccountAccessibility {
-    static let closeButtonLabel = "Close"
-}
-
-enum AddAccountExchangeSecrets {
-    static func persistedPassphrase(_ passphrase: String, for exchangeType: ExchangeType) -> String? {
-        guard exchangeType == .coinbase, !passphrase.isEmpty else {
-            return nil
-        }
-
-        return passphrase
-    }
-
-    static func passphraseAfterSelecting(
-        _ exchangeType: ExchangeType,
-        currentPassphrase: String) -> String {
-        exchangeType == .coinbase ? currentPassphrase : ""
     }
 }

--- a/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
@@ -10,6 +10,10 @@ enum AddAccountSheetSavePolicy {
     static func canSubmit(draftCanSave: Bool, isSyncing: Bool, isSyncBlocked: Bool) -> Bool {
         draftCanSave && !isSyncing && !isSyncBlocked
     }
+
+    static func canEditFields(isSyncing: Bool, isSyncBlocked: Bool) -> Bool {
+        !isSyncing && !isSyncBlocked
+    }
 }
 
 enum AddAccountExchangeSecrets {

--- a/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 enum AddAccountAccessibility {
     static let closeButtonLabel = "Close"
+    static let closeButtonHint = "Closes the account sheet."
 }
 
 enum AddAccountSheetSavePolicy {

--- a/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
@@ -237,6 +237,8 @@ extension Chain {
         case .bsc: "BNB Smart Chain"
         case .degen: "Degen"
         case .gnosis: "Gnosis"
+        case .celo: "Celo"
+        case .opBNB: "opBNB"
         case .unichain: "Unichain"
         case .berachain: "Berachain"
         case .sonic: "Sonic"

--- a/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
+++ b/Sources/Portu/Features/Accounts/AddAccountSheetFields.swift
@@ -2,6 +2,32 @@ import PortuCore
 import PortuUI
 import SwiftUI
 
+enum AddAccountAccessibility {
+    static let closeButtonLabel = "Close"
+}
+
+enum AddAccountSheetSavePolicy {
+    static func canSubmit(draftCanSave: Bool, isSyncing: Bool, isSyncBlocked: Bool) -> Bool {
+        draftCanSave && !isSyncing && !isSyncBlocked
+    }
+}
+
+enum AddAccountExchangeSecrets {
+    static func persistedPassphrase(_ passphrase: String, for exchangeType: ExchangeType) -> String? {
+        guard exchangeType == .coinbase, !passphrase.isEmpty else {
+            return nil
+        }
+
+        return passphrase
+    }
+
+    static func passphraseAfterSelecting(
+        _ exchangeType: ExchangeType,
+        currentPassphrase: String) -> String {
+        exchangeType == .coinbase ? currentPassphrase : ""
+    }
+}
+
 struct AddAccountInfoRow: View {
     let icon: String
     var iconColor: Color = .blue.opacity(0.88)

--- a/Sources/Portu/Features/Accounts/ExchangeCredentialSnapshot.swift
+++ b/Sources/Portu/Features/Accounts/ExchangeCredentialSnapshot.swift
@@ -1,0 +1,7 @@
+struct ExchangeCredentialSnapshot: Equatable {
+    var apiKey: String?
+    var apiSecret: String?
+    var passphrase: String?
+
+    static let empty = Self(apiKey: nil, apiSecret: nil, passphrase: nil)
+}

--- a/Sources/Portu/Features/Shared/TokenIdentityMappingFeature.swift
+++ b/Sources/Portu/Features/Shared/TokenIdentityMappingFeature.swift
@@ -92,8 +92,8 @@ enum TokenIdentityMappingFeature {
         switch identity.chain {
         case .ethereum, .arbitrum, .optimism, .base, .unichain, .zksync, .linea, .blast, .taiko, .scroll, .zora, .mode:
             return "ethereum"
-        case .polygon, .bsc, .degen, .gnosis, .berachain, .sonic, .polygonZkEVM, .moonbeam, .ronin, .mantle, .immutableX,
-             .hyperEVM, .hyperliquid, .solana, .bitcoin, .avalanche, .monad, .katana:
+        case .polygon, .bsc, .degen, .gnosis, .celo, .opBNB, .berachain, .sonic, .polygonZkEVM, .moonbeam, .ronin,
+             .mantle, .immutableX, .hyperEVM, .hyperliquid, .solana, .bitcoin, .avalanche, .monad, .katana:
             return nil
         }
     }

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -42,16 +42,17 @@ final class SyncEngine: @unchecked Sendable {
 
         return try await sync(
             activeSyncable: [account],
-            activeManual: []) { try self.fetchActiveSyncableAccounts().count > 1 }
+            activeManual: [])
     }
 
     private func sync(
         activeSyncable: [Account],
-        activeManual: [Account],
-        forcePartialSnapshot: () throws -> Bool = { false }) async throws -> SyncResult {
+        activeManual: [Account]) async throws -> SyncResult {
         guard !activeSyncable.isEmpty || !activeManual.isEmpty else {
             throw SyncError.noActiveAccounts
         }
+
+        let attemptedSyncableAccountIDs = Set(activeSyncable.map(\.id))
 
         // ── Phase A: Per-account fetch + persist ──
         var failedAccounts: [String] = []
@@ -72,8 +73,10 @@ final class SyncEngine: @unchecked Sendable {
             throw SyncError.allAccountsFailed
         }
 
-        let isPartialSnapshot = try forcePartialSnapshot() || !failedAccounts.isEmpty
-        try createSnapshots(isPartial: isPartialSnapshot)
+        let isPartialSnapshot = try hasActiveSyncableAccounts(outside: attemptedSyncableAccountIDs) || !failedAccounts.isEmpty
+        try createSnapshots(
+            isPartial: isPartialSnapshot,
+            refreshedSyncableAccountIDs: attemptedSyncableAccountIDs)
 
         return SyncResult(failedAccounts: failedAccounts)
     }
@@ -266,7 +269,9 @@ final class SyncEngine: @unchecked Sendable {
 
     // MARK: - Phase B: Snapshots
 
-    private func createSnapshots(isPartial: Bool) throws {
+    private func createSnapshots(
+        isPartial: Bool,
+        refreshedSyncableAccountIDs: Set<UUID>) throws {
         let batchId = UUID()
         let batchTimestamp = Date.now
 
@@ -278,7 +283,11 @@ final class SyncEngine: @unchecked Sendable {
         let activeAccounts = try fetchAllActiveAccounts()
 
         createPortfolioSnapshot(batchId: batchId, timestamp: batchTimestamp, positions: allPositions, isPartial: isPartial)
-        createAccountSnapshots(batchId: batchId, timestamp: batchTimestamp, accounts: activeAccounts)
+        createAccountSnapshots(
+            batchId: batchId,
+            timestamp: batchTimestamp,
+            accounts: activeAccounts,
+            refreshedSyncableAccountIDs: refreshedSyncableAccountIDs)
         createAssetSnapshots(
             batchId: batchId,
             timestamp: batchTimestamp,
@@ -326,10 +335,15 @@ final class SyncEngine: @unchecked Sendable {
         modelContext.insert(snap)
     }
 
-    private func createAccountSnapshots(batchId: UUID, timestamp: Date, accounts: [Account]) {
+    private func createAccountSnapshots(
+        batchId: UUID,
+        timestamp: Date,
+        accounts: [Account],
+        refreshedSyncableAccountIDs: Set<UUID>) {
         for account in accounts {
             let accountTotal = account.positions.reduce(Decimal.zero) { $0 + $1.netUSDValue }
-            let isFresh = account.dataSource == .manual || account.lastSyncError == nil
+            let isFresh = account.dataSource == .manual ||
+                (refreshedSyncableAccountIDs.contains(account.id) && account.lastSyncError == nil)
 
             let snap = AccountSnapshot(
                 syncBatchId: batchId, timestamp: timestamp,
@@ -422,6 +436,10 @@ final class SyncEngine: @unchecked Sendable {
     private func fetchActiveSyncableAccounts() throws -> [Account] {
         let descriptor = FetchDescriptor<Account>()
         return try modelContext.fetch(descriptor).filter { $0.isActive && $0.dataSource != .manual }
+    }
+
+    private func hasActiveSyncableAccounts(outside accountIDs: Set<UUID>) throws -> Bool {
+        try fetchActiveSyncableAccounts().contains { accountIDs.contains($0.id) == false }
     }
 
     private func fetchActiveSyncableAccounts(scope: PortfolioSyncScope) throws -> [Account] {

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -40,10 +40,17 @@ final class SyncEngine: @unchecked Sendable {
             throw SyncError.accountNotSyncable
         }
 
-        return try await sync(activeSyncable: [account], activeManual: [])
+        let activeSyncableCount = try fetchActiveSyncableAccounts().count
+        return try await sync(
+            activeSyncable: [account],
+            activeManual: [],
+            forcePartialSnapshot: activeSyncableCount > 1)
     }
 
-    private func sync(activeSyncable: [Account], activeManual: [Account]) async throws -> SyncResult {
+    private func sync(
+        activeSyncable: [Account],
+        activeManual: [Account],
+        forcePartialSnapshot: Bool = false) async throws -> SyncResult {
         guard !activeSyncable.isEmpty || !activeManual.isEmpty else {
             throw SyncError.noActiveAccounts
         }
@@ -67,7 +74,7 @@ final class SyncEngine: @unchecked Sendable {
             throw SyncError.allAccountsFailed
         }
 
-        try createSnapshots(isPartial: !failedAccounts.isEmpty)
+        try createSnapshots(isPartial: forcePartialSnapshot || !failedAccounts.isEmpty)
 
         return SyncResult(failedAccounts: failedAccounts)
     }

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -31,6 +31,18 @@ final class SyncEngine: @unchecked Sendable {
         return try await sync(activeSyncable: activeSyncable, activeManual: [])
     }
 
+    func sync(accountID: UUID) async throws -> SyncResult {
+        let account = try fetchAccount(id: accountID)
+        guard account.isActive else {
+            throw SyncError.accountInactive
+        }
+        guard account.dataSource != .manual else {
+            throw SyncError.accountNotSyncable
+        }
+
+        return try await sync(activeSyncable: [account], activeManual: [])
+    }
+
     private func sync(activeSyncable: [Account], activeManual: [Account]) async throws -> SyncResult {
         guard !activeSyncable.isEmpty || !activeManual.isEmpty else {
             throw SyncError.noActiveAccounts
@@ -427,6 +439,14 @@ final class SyncEngine: @unchecked Sendable {
         return try modelContext.fetch(descriptor)
     }
 
+    private func fetchAccount(id: UUID) throws -> Account {
+        let descriptor = FetchDescriptor<Account>()
+        guard let account = try modelContext.fetch(descriptor).first(where: { $0.id == id }) else {
+            throw SyncError.accountNotFound
+        }
+        return account
+    }
+
     private func makeAssetLookup() throws -> AssetLookupCache {
         try AssetLookupCache(assets: modelContext.fetch(FetchDescriptor<Asset>()))
     }
@@ -435,54 +455,5 @@ final class SyncEngine: @unchecked Sendable {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
-    }
-}
-
-/// Plain-value staging for syncAccount's build phase. Holding @Model instances
-/// (Position/PositionToken) here would cause SwiftData to auto-register them
-/// when their relationships are assigned to already-managed objects, defeating
-/// the build-phase isolation. Pure structs keep the staging side-effect-free.
-private struct StagedPosition {
-    let positionType: PositionType
-    let chain: Chain?
-    let protocolId: String?
-    let protocolName: String?
-    let protocolLogoURL: String?
-    let healthFactor: Double?
-    let netUSDValue: Decimal
-    let tokens: [StagedToken]
-}
-
-private struct StagedToken {
-    let role: TokenRole
-    let amount: Decimal
-    let usdValue: Decimal
-    /// Reference to the already-resolved (managed) Asset. Storing a pointer in
-    /// a value type does not trigger SwiftData tracking.
-    let asset: Asset
-}
-
-private struct AssetSnapshotAccumulator {
-    var accountId: UUID
-    var assetId: UUID
-    var symbol: String
-    var category: AssetCategory
-    var grossAmount: Decimal = 0
-    var grossUsdValue: Decimal = 0
-    var borrowAmount: Decimal = 0
-    var borrowUsdValue: Decimal = 0
-}
-
-enum SyncError: Error, LocalizedError, Equatable {
-    case missingAPIKey(String)
-    case noActiveAccounts
-    case allAccountsFailed
-
-    var errorDescription: String? {
-        switch self {
-        case let .missingAPIKey(msg): msg
-        case .noActiveAccounts: "No active accounts"
-        case .allAccountsFailed: "All accounts failed to sync"
-        }
     }
 }

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -56,10 +56,12 @@ final class SyncEngine: @unchecked Sendable {
 
         // ── Phase A: Per-account fetch + persist ──
         var failedAccounts: [String] = []
+        var refreshedSyncableAccountIDs: Set<UUID> = []
 
         for account in activeSyncable {
             do {
                 try await syncAccount(account)
+                refreshedSyncableAccountIDs.insert(account.id)
             } catch {
                 account.lastSyncError = error.localizedDescription
                 failedAccounts.append(account.name)
@@ -76,7 +78,7 @@ final class SyncEngine: @unchecked Sendable {
         let isPartialSnapshot = try hasActiveSyncableAccounts(outside: attemptedSyncableAccountIDs) || !failedAccounts.isEmpty
         try createSnapshots(
             isPartial: isPartialSnapshot,
-            refreshedSyncableAccountIDs: attemptedSyncableAccountIDs)
+            refreshedSyncableAccountIDs: refreshedSyncableAccountIDs)
 
         return SyncResult(failedAccounts: failedAccounts)
     }
@@ -291,7 +293,8 @@ final class SyncEngine: @unchecked Sendable {
         createAssetSnapshots(
             batchId: batchId,
             timestamp: batchTimestamp,
-            positions: allPositions)
+            positions: allPositions,
+            refreshedSyncableAccountIDs: refreshedSyncableAccountIDs)
 
         pruneSnapshots()
         try modelContext.save()
@@ -355,11 +358,16 @@ final class SyncEngine: @unchecked Sendable {
     private func createAssetSnapshots(
         batchId: UUID,
         timestamp: Date,
-        positions: [Position]) {
+        positions: [Position],
+        refreshedSyncableAccountIDs: Set<UUID>) {
         var accumulators: [String: AssetSnapshotAccumulator] = [:]
 
         for pos in positions {
-            guard let accountId = pos.account?.id else { continue }
+            guard let account = pos.account else { continue }
+            if account.dataSource != .manual, refreshedSyncableAccountIDs.contains(account.id) == false {
+                continue
+            }
+            let accountId = account.id
 
             for token in pos.tokens {
                 guard let asset = token.asset else { continue }

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -440,8 +440,9 @@ final class SyncEngine: @unchecked Sendable {
     }
 
     private func fetchAccount(id: UUID) throws -> Account {
-        let descriptor = FetchDescriptor<Account>()
-        guard let account = try modelContext.fetch(descriptor).first(where: { $0.id == id }) else {
+        var descriptor = FetchDescriptor<Account>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        guard let account = try modelContext.fetch(descriptor).first else {
             throw SyncError.accountNotFound
         }
         return account

--- a/Sources/Portu/Sync/SyncEngine.swift
+++ b/Sources/Portu/Sync/SyncEngine.swift
@@ -40,17 +40,15 @@ final class SyncEngine: @unchecked Sendable {
             throw SyncError.accountNotSyncable
         }
 
-        let activeSyncableCount = try fetchActiveSyncableAccounts().count
         return try await sync(
             activeSyncable: [account],
-            activeManual: [],
-            forcePartialSnapshot: activeSyncableCount > 1)
+            activeManual: []) { try self.fetchActiveSyncableAccounts().count > 1 }
     }
 
     private func sync(
         activeSyncable: [Account],
         activeManual: [Account],
-        forcePartialSnapshot: Bool = false) async throws -> SyncResult {
+        forcePartialSnapshot: () throws -> Bool = { false }) async throws -> SyncResult {
         guard !activeSyncable.isEmpty || !activeManual.isEmpty else {
             throw SyncError.noActiveAccounts
         }
@@ -74,7 +72,8 @@ final class SyncEngine: @unchecked Sendable {
             throw SyncError.allAccountsFailed
         }
 
-        try createSnapshots(isPartial: forcePartialSnapshot || !failedAccounts.isEmpty)
+        let isPartialSnapshot = try forcePartialSnapshot() || !failedAccounts.isEmpty
+        try createSnapshots(isPartial: isPartialSnapshot)
 
         return SyncResult(failedAccounts: failedAccounts)
     }

--- a/Sources/Portu/Sync/SyncEngineSupport.swift
+++ b/Sources/Portu/Sync/SyncEngineSupport.swift
@@ -1,0 +1,57 @@
+import Foundation
+import PortuCore
+
+/// Plain-value staging for syncAccount's build phase. Holding @Model instances
+/// (Position/PositionToken) here would cause SwiftData to auto-register them
+/// when their relationships are assigned to already-managed objects, defeating
+/// the build-phase isolation. Pure structs keep the staging side-effect-free.
+struct StagedPosition {
+    let positionType: PositionType
+    let chain: Chain?
+    let protocolId: String?
+    let protocolName: String?
+    let protocolLogoURL: String?
+    let healthFactor: Double?
+    let netUSDValue: Decimal
+    let tokens: [StagedToken]
+}
+
+struct StagedToken {
+    let role: TokenRole
+    let amount: Decimal
+    let usdValue: Decimal
+    /// Reference to the already-resolved managed asset. Storing a pointer in a
+    /// value type does not trigger SwiftData tracking.
+    let asset: Asset
+}
+
+struct AssetSnapshotAccumulator {
+    var accountId: UUID
+    var assetId: UUID
+    var symbol: String
+    var category: AssetCategory
+    var grossAmount: Decimal = 0
+    var grossUsdValue: Decimal = 0
+    var borrowAmount: Decimal = 0
+    var borrowUsdValue: Decimal = 0
+}
+
+enum SyncError: Error, LocalizedError, Equatable {
+    case missingAPIKey(String)
+    case noActiveAccounts
+    case allAccountsFailed
+    case accountNotFound
+    case accountNotSyncable
+    case accountInactive
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingAPIKey(message): message
+        case .noActiveAccounts: "No active accounts"
+        case .allAccountsFailed: "All accounts failed to sync"
+        case .accountNotFound: "Account not found"
+        case .accountNotSyncable: "Account is not syncable"
+        case .accountInactive: "Inactive accounts cannot be synced"
+        }
+    }
+}

--- a/Tests/PortuTests/AccountSheetDraftTests.swift
+++ b/Tests/PortuTests/AccountSheetDraftTests.swift
@@ -322,6 +322,33 @@ struct AccountSheetDraftTests {
         #expect(try context.fetch(FetchDescriptor<Account>()).count == 1)
     }
 
+    @Test func `delete exchange account keeps account and credentials when credential deletion fails`() throws {
+        let context = try makeModelContext()
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "key"
+        store.storage[.exchangeAPISecret(accountID)] = "secret"
+        store.storage[.exchangePassphrase(accountID)] = "passphrase"
+        store.throwOnDeleteKeys = [.exchangeAPISecret(accountID)]
+        let account = Account(
+            id: accountID,
+            name: "Kraken",
+            kind: .exchange,
+            exchangeType: .kraken,
+            dataSource: .exchange)
+        context.insert(account)
+        try context.save()
+
+        #expect(throws: AccountSheetSaveError.self) {
+            try AccountSheetSaveCoordinator.deleteAccount(account, modelContext: context, secretStore: store)
+        }
+
+        #expect(store.storage[.exchangeAPIKey(accountID)] == "key")
+        #expect(store.storage[.exchangeAPISecret(accountID)] == "secret")
+        #expect(store.storage[.exchangePassphrase(accountID)] == "passphrase")
+        #expect(try context.fetch(FetchDescriptor<Account>()).count == 1)
+    }
+
     @Test func `set account active saves the account state`() throws {
         let context = try makeModelContext()
         let account = Account(name: "Archived", kind: .wallet, dataSource: .zapper, isActive: false)
@@ -395,14 +422,14 @@ struct AccountSheetDraftTests {
         #expect(updated.notes == nil)
     }
 
-    @Test func `deleting exchange credentials removes all stored keys`() {
+    @Test func `deleting exchange credentials removes all stored keys`() throws {
         let accountID = UUID()
         let store = InMemorySecretStore()
         store.storage[.exchangeAPIKey(accountID)] = "k"
         store.storage[.exchangeAPISecret(accountID)] = "s"
         store.storage[.exchangePassphrase(accountID)] = "p"
 
-        AccountSheetSaveCoordinator.deleteExchangeCredentials(accountID, secretStore: store)
+        try AccountSheetSaveCoordinator.deleteExchangeCredentials(accountID, secretStore: store)
 
         #expect(store.storage[.exchangeAPIKey(accountID)] == nil)
         #expect(store.storage[.exchangeAPISecret(accountID)] == nil)

--- a/Tests/PortuTests/AccountSheetDraftTests.swift
+++ b/Tests/PortuTests/AccountSheetDraftTests.swift
@@ -386,6 +386,12 @@ struct AccountSheetDraftTests {
         #expect(!AddAccountSheetSavePolicy.canSubmit(draftCanSave: true, isSyncing: false, isSyncBlocked: true))
     }
 
+    @Test func `save policy blocks field editing while syncing`() {
+        #expect(AddAccountSheetSavePolicy.canEditFields(isSyncing: false, isSyncBlocked: false))
+        #expect(!AddAccountSheetSavePolicy.canEditFields(isSyncing: true, isSyncBlocked: false))
+        #expect(!AddAccountSheetSavePolicy.canEditFields(isSyncing: false, isSyncBlocked: true))
+    }
+
     private func makeModelContext() throws -> ModelContext {
         let schema = Schema([
             Account.self,

--- a/Tests/PortuTests/AccountSheetDraftTests.swift
+++ b/Tests/PortuTests/AccountSheetDraftTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+@testable import Portu
+import PortuCore
+import SwiftData
+import Testing
+
+@MainActor
+struct AccountSheetDraftTests {
+    @Test func `wallet edit draft pre-fills account data and chain`() {
+        let account = Account(
+            name: "Hardware Wallet",
+            kind: .wallet,
+            dataSource: .zapper,
+            group: "Cold",
+            notes: "Long-term storage")
+        account.addresses = [WalletAddress(chain: .solana, address: "So11111111111111111111111111111111111111112", account: account)]
+
+        let draft = AccountSheetDraft.editing(account: account)
+
+        #expect(draft.selectedTab == .chain)
+        #expect(draft.chainName == "Hardware Wallet")
+        #expect(draft.chainAddress == "So11111111111111111111111111111111111111112")
+        #expect(draft.chainGroup == "Cold")
+        #expect(draft.chainNotes == "Long-term storage")
+        #expect(draft.isEVM == false)
+        #expect(draft.specificChain == .solana)
+    }
+
+    @Test func `exchange edit draft pre-fills saved credentials`() throws {
+        let suiteName = "AccountSheetDraftTests-\(UUID().uuidString)"
+        let store = LocalSecretStore(suiteName: suiteName)
+        defer { UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName) }
+
+        let accountID = UUID()
+        try store.set(key: .exchangeAPIKey(accountID), value: "api-key")
+        try store.set(key: .exchangeAPISecret(accountID), value: "api-secret")
+        try store.set(key: .exchangePassphrase(accountID), value: "passphrase")
+        let account = Account(
+            id: accountID,
+            name: "Coinbase",
+            kind: .exchange,
+            exchangeType: .coinbase,
+            dataSource: .exchange,
+            group: "CEX",
+            notes: "Read-only")
+
+        let draft = AccountSheetDraft.editing(account: account, secretStore: store)
+
+        #expect(draft.selectedTab == .exchange)
+        #expect(draft.exchangeName == "Coinbase")
+        #expect(draft.exchangeType == .coinbase)
+        #expect(draft.exchangeAPIKey == "api-key")
+        #expect(draft.exchangeAPISecret == "api-secret")
+        #expect(draft.exchangePassphrase == "passphrase")
+        #expect(draft.exchangeGroup == "CEX")
+        #expect(draft.exchangeNotes == "Read-only")
+    }
+
+    @Test func `saving edit mode mutates existing account instead of inserting`() throws {
+        let context = try makeModelContext()
+        let account = Account(
+            name: "Manual",
+            kind: .manual,
+            dataSource: .manual,
+            group: "Old",
+            notes: "Before")
+        context.insert(account)
+        try context.save()
+
+        var draft = AccountSheetDraft.editing(account: account)
+        draft.manualName = "Manual Updated"
+        draft.manualGroup = "New"
+        draft.manualNotes = "After"
+
+        try AccountSheetSaveCoordinator.save(
+            draft: draft,
+            mode: .edit(account.id),
+            editing: account,
+            modelContext: context,
+            secretStore: LocalSecretStore(suiteName: "AccountSheetDraftTests-\(UUID().uuidString)"))
+
+        let accounts = try context.fetch(FetchDescriptor<Account>())
+        let updated = try #require(accounts.first)
+        #expect(accounts.count == 1)
+        #expect(updated.id == account.id)
+        #expect(updated.name == "Manual Updated")
+        #expect(updated.group == "New")
+        #expect(updated.notes == "After")
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let schema = Schema([
+            Account.self,
+            WalletAddress.self,
+            Position.self,
+            PositionToken.self,
+            Asset.self,
+            TokenPricingOverride.self,
+            TokenIdentityMapping.self,
+            HistoricalPricePoint.self,
+            PortfolioCategory.self,
+            CategorySymbolRule.self,
+            PortfolioSnapshot.self,
+            AccountSnapshot.self,
+            AssetSnapshot.self
+        ])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        return ModelContext(container)
+    }
+}

--- a/Tests/PortuTests/AccountSheetDraftTests.swift
+++ b/Tests/PortuTests/AccountSheetDraftTests.swift
@@ -88,6 +88,165 @@ struct AccountSheetDraftTests {
         #expect(updated.notes == "After")
     }
 
+    @Test func `exchange edit credential save failure leaves the account unmutated`() throws {
+        let context = try makeModelContext()
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "old-key"
+        store.storage[.exchangeAPISecret(accountID)] = "old-secret"
+        let account = Account(
+            id: accountID,
+            name: "Kraken",
+            kind: .exchange,
+            exchangeType: .kraken,
+            dataSource: .exchange,
+            group: "CEX")
+        context.insert(account)
+        try context.save()
+
+        var draft = AccountSheetDraft.editing(account: account, secretStore: store)
+        draft.exchangeName = "Renamed"
+        draft.exchangeAPIKey = "new-key"
+        draft.exchangeAPISecret = "new-secret"
+        store.throwOnSet = true
+
+        #expect(throws: AccountSheetSaveError.self) {
+            try AccountSheetSaveCoordinator.save(
+                draft: draft,
+                mode: .edit(accountID),
+                editing: account,
+                modelContext: context,
+                secretStore: store)
+        }
+
+        // Credentials are written before the model is mutated, so a keychain failure
+        // leaves the account name untouched (nothing for autosave to flush).
+        let reloaded = try #require(try context.fetch(FetchDescriptor<Account>()).first)
+        #expect(reloaded.name == "Kraken")
+    }
+
+    @Test func `exchange edit with a failed credential read preserves the stored passphrase`() throws {
+        let context = try makeModelContext()
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "real-key"
+        store.storage[.exchangeAPISecret(accountID)] = "real-secret"
+        store.storage[.exchangePassphrase(accountID)] = "real-passphrase"
+        let account = Account(
+            id: accountID,
+            name: "Coinbase",
+            kind: .exchange,
+            exchangeType: .coinbase,
+            dataSource: .exchange)
+        context.insert(account)
+        try context.save()
+
+        store.throwOnGet = true
+        var draft = AccountSheetDraft.editing(account: account, secretStore: store)
+        #expect(draft.exchangeCredentialsLoaded == false)
+
+        // User supplies fresh required fields but leaves the passphrase blank.
+        draft.exchangeAPIKey = "typed-key"
+        draft.exchangeAPISecret = "typed-secret"
+        store.throwOnGet = false
+
+        try AccountSheetSaveCoordinator.save(
+            draft: draft,
+            mode: .edit(accountID),
+            editing: account,
+            modelContext: context,
+            secretStore: store)
+
+        // The blank passphrase must not be mistaken for "cleared" — it was never loaded.
+        #expect(store.storage[.exchangePassphrase(accountID)] == "real-passphrase")
+        #expect(store.storage[.exchangeAPIKey(accountID)] == "typed-key")
+    }
+
+    @Test func `wallet edit replaces all addresses with a single row`() throws {
+        let context = try makeModelContext()
+        let account = Account(name: "Multi", kind: .wallet, dataSource: .zapper)
+        account.addresses = [
+            WalletAddress(chain: nil, address: "0xaaa", account: account),
+            WalletAddress(chain: .solana, address: "sol111", account: account)
+        ]
+        context.insert(account)
+        try context.save()
+        #expect(try context.fetch(FetchDescriptor<WalletAddress>()).count == 2)
+
+        var draft = AccountSheetDraft.editing(account: account)
+        draft.isEVM = true
+        draft.chainAddress = "0xnew"
+
+        try AccountSheetSaveCoordinator.save(
+            draft: draft,
+            mode: .edit(account.id),
+            editing: account,
+            modelContext: context,
+            secretStore: InMemorySecretStore())
+
+        let addresses = try context.fetch(FetchDescriptor<WalletAddress>())
+        #expect(addresses.count == 1)
+        #expect(addresses.first?.address == "0xnew")
+        #expect(addresses.first?.chain == nil)
+    }
+
+    @Test func `editing a deleted account throws missingEditedAccount`() throws {
+        let context = try makeModelContext()
+        let account = Account(name: "Doomed", kind: .manual, dataSource: .manual)
+        context.insert(account)
+        try context.save()
+        let id = account.id
+        let draft = AccountSheetDraft.editing(account: account)
+
+        context.delete(account)
+        try context.save()
+
+        #expect(throws: AccountSheetSaveError.missingEditedAccount) {
+            try AccountSheetSaveCoordinator.save(
+                draft: draft,
+                mode: .edit(id),
+                editing: account,
+                modelContext: context,
+                secretStore: InMemorySecretStore())
+        }
+    }
+
+    @Test func `whitespace-only group and notes persist as nil`() throws {
+        let context = try makeModelContext()
+        let account = Account(name: "M", kind: .manual, dataSource: .manual, group: "x", notes: "y")
+        context.insert(account)
+        try context.save()
+
+        var draft = AccountSheetDraft.editing(account: account)
+        draft.manualGroup = "   "
+        draft.manualNotes = "\n\t "
+
+        try AccountSheetSaveCoordinator.save(
+            draft: draft,
+            mode: .edit(account.id),
+            editing: account,
+            modelContext: context,
+            secretStore: InMemorySecretStore())
+
+        let updated = try #require(try context.fetch(FetchDescriptor<Account>()).first)
+        #expect(updated.group == nil)
+        #expect(updated.notes == nil)
+    }
+
+    @Test func `deleting exchange credentials removes all stored keys`() {
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "k"
+        store.storage[.exchangeAPISecret(accountID)] = "s"
+        store.storage[.exchangePassphrase(accountID)] = "p"
+
+        AccountSheetSaveCoordinator.deleteExchangeCredentials(accountID, secretStore: store)
+
+        #expect(store.storage[.exchangeAPIKey(accountID)] == nil)
+        #expect(store.storage[.exchangeAPISecret(accountID)] == nil)
+        #expect(store.storage[.exchangePassphrase(accountID)] == nil)
+    }
+
     private func makeModelContext() throws -> ModelContext {
         let schema = Schema([
             Account.self,
@@ -107,5 +266,26 @@ struct AccountSheetDraftTests {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: [config])
         return ModelContext(container)
+    }
+}
+
+/// In-memory `SecretStore` test double with configurable failure injection.
+final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+    var storage: [KeychainKey: String] = [:]
+    var throwOnGet = false
+    var throwOnSet = false
+
+    func get(key: KeychainKey) throws(KeychainError) -> String? {
+        if throwOnGet { throw .interactionNotAllowed }
+        return storage[key]
+    }
+
+    func set(key: KeychainKey, value: String) throws(KeychainError) {
+        if throwOnSet { throw .interactionNotAllowed }
+        storage[key] = value
+    }
+
+    func delete(key: KeychainKey) throws(KeychainError) {
+        storage[key] = nil
     }
 }

--- a/Tests/PortuTests/AccountSheetDraftTests.swift
+++ b/Tests/PortuTests/AccountSheetDraftTests.swift
@@ -322,6 +322,36 @@ struct AccountSheetDraftTests {
         #expect(try context.fetch(FetchDescriptor<Account>()).count == 1)
     }
 
+    @Test func `set account active saves the account state`() throws {
+        let context = try makeModelContext()
+        let account = Account(name: "Archived", kind: .wallet, dataSource: .zapper, isActive: false)
+        context.insert(account)
+        try context.save()
+
+        try AccountSheetSaveCoordinator.setAccount(account, isActive: true, modelContext: context)
+
+        let reloaded = try #require(try context.fetch(FetchDescriptor<Account>()).first)
+        #expect(reloaded.isActive == true)
+    }
+
+    @Test func `set account active rolls back when save fails`() throws {
+        let context = try makeModelContext()
+        let account = Account(name: "Active", kind: .wallet, dataSource: .zapper, isActive: true)
+        context.insert(account)
+        try context.save()
+
+        #expect(throws: AccountSheetSaveError.self) {
+            try AccountSheetSaveCoordinator.setAccount(
+                account,
+                isActive: false,
+                modelContext: context,
+                save: { _ in throw KeychainError.interactionNotAllowed })
+        }
+
+        let reloaded = try #require(try context.fetch(FetchDescriptor<Account>()).first)
+        #expect(reloaded.isActive == true)
+    }
+
     @Test func `editing a deleted account throws missingEditedAccount`() throws {
         let context = try makeModelContext()
         let account = Account(name: "Doomed", kind: .manual, dataSource: .manual)

--- a/Tests/PortuTests/AccountSheetDraftTests.swift
+++ b/Tests/PortuTests/AccountSheetDraftTests.swift
@@ -96,7 +96,7 @@ struct AccountSheetDraftTests {
             mode: .edit(account.id),
             editing: account,
             modelContext: context,
-            secretStore: LocalSecretStore(suiteName: "AccountSheetDraftTests-\(UUID().uuidString)"))
+            secretStore: InMemorySecretStore())
 
         let accounts = try context.fetch(FetchDescriptor<Account>())
         let updated = try #require(accounts.first)

--- a/Tests/PortuTests/AccountSheetDraftTests.swift
+++ b/Tests/PortuTests/AccountSheetDraftTests.swift
@@ -56,6 +56,25 @@ struct AccountSheetDraftTests {
         #expect(draft.exchangeNotes == "Read-only")
     }
 
+    @Test func `partial exchange credential load does not mutate draft fields`() {
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "stored-key"
+        store.storage[.exchangeAPISecret(accountID)] = "stored-secret"
+        store.throwOnGetKeys = [.exchangePassphrase(accountID)]
+        var draft = AccountSheetDraft()
+        draft.exchangeAPIKey = "typed-key"
+        draft.exchangeAPISecret = "typed-secret"
+        draft.exchangePassphrase = "typed-passphrase"
+
+        draft.loadExchangeCredentials(accountID: accountID, secretStore: store)
+
+        #expect(draft.exchangeCredentialsLoaded == false)
+        #expect(draft.exchangeAPIKey == "typed-key")
+        #expect(draft.exchangeAPISecret == "typed-secret")
+        #expect(draft.exchangePassphrase == "typed-passphrase")
+    }
+
     @Test func `saving edit mode mutates existing account instead of inserting`() throws {
         let context = try makeModelContext()
         let account = Account(
@@ -125,6 +144,43 @@ struct AccountSheetDraftTests {
         #expect(reloaded.name == "Kraken")
     }
 
+    @Test func `exchange edit credential write failure restores previous credentials`() throws {
+        let context = try makeModelContext()
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "old-key"
+        store.storage[.exchangeAPISecret(accountID)] = "old-secret"
+        store.storage[.exchangePassphrase(accountID)] = "old-passphrase"
+        let account = Account(
+            id: accountID,
+            name: "Coinbase",
+            kind: .exchange,
+            exchangeType: .coinbase,
+            dataSource: .exchange)
+        context.insert(account)
+        try context.save()
+
+        var draft = AccountSheetDraft.editing(account: account, secretStore: store)
+        draft.exchangeName = "Coinbase Prime"
+        draft.exchangeAPIKey = "new-key"
+        draft.exchangeAPISecret = "new-secret"
+        draft.exchangePassphrase = "new-passphrase"
+        store.throwOnSetKeys = [.exchangeAPISecret(accountID)]
+
+        #expect(throws: AccountSheetSaveError.self) {
+            try AccountSheetSaveCoordinator.save(
+                draft: draft,
+                mode: .edit(accountID),
+                editing: account,
+                modelContext: context,
+                secretStore: store)
+        }
+
+        #expect(store.storage[.exchangeAPIKey(accountID)] == "old-key")
+        #expect(store.storage[.exchangeAPISecret(accountID)] == "old-secret")
+        #expect(store.storage[.exchangePassphrase(accountID)] == "old-passphrase")
+    }
+
     @Test func `exchange edit with a failed credential read preserves the stored passphrase`() throws {
         let context = try makeModelContext()
         let accountID = UUID()
@@ -190,6 +246,82 @@ struct AccountSheetDraftTests {
         #expect(addresses.first?.chain == nil)
     }
 
+    @Test func `wallet add persists a managed address row`() throws {
+        let context = try makeModelContext()
+        var draft = AccountSheetDraft.adding()
+        draft.selectedTab = .chain
+        draft.chainName = "Wallet"
+        draft.chainAddress = "0xabc"
+        draft.isEVM = false
+        draft.specificChain = .base
+
+        try AccountSheetSaveCoordinator.save(
+            draft: draft,
+            mode: .add,
+            editing: nil,
+            modelContext: context,
+            secretStore: InMemorySecretStore())
+
+        let account = try #require(try context.fetch(FetchDescriptor<Account>()).first)
+        let address = try #require(try context.fetch(FetchDescriptor<WalletAddress>()).first)
+        #expect(account.addresses.map(\.id) == [address.id])
+        #expect(address.account?.id == account.id)
+        #expect(address.chain == .base)
+        #expect(address.address == "0xabc")
+    }
+
+    @Test func `delete exchange account removes credentials after successful save`() throws {
+        let context = try makeModelContext()
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "key"
+        store.storage[.exchangeAPISecret(accountID)] = "secret"
+        store.storage[.exchangePassphrase(accountID)] = "passphrase"
+        let account = Account(
+            id: accountID,
+            name: "Kraken",
+            kind: .exchange,
+            exchangeType: .kraken,
+            dataSource: .exchange)
+        context.insert(account)
+        try context.save()
+
+        try AccountSheetSaveCoordinator.deleteAccount(account, modelContext: context, secretStore: store)
+
+        #expect(try context.fetch(FetchDescriptor<Account>()).isEmpty)
+        #expect(store.storage[.exchangeAPIKey(accountID)] == nil)
+        #expect(store.storage[.exchangeAPISecret(accountID)] == nil)
+        #expect(store.storage[.exchangePassphrase(accountID)] == nil)
+    }
+
+    @Test func `delete exchange account keeps credentials when save fails`() throws {
+        let context = try makeModelContext()
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "key"
+        store.storage[.exchangeAPISecret(accountID)] = "secret"
+        let account = Account(
+            id: accountID,
+            name: "Kraken",
+            kind: .exchange,
+            exchangeType: .kraken,
+            dataSource: .exchange)
+        context.insert(account)
+        try context.save()
+
+        #expect(throws: AccountSheetSaveError.self) {
+            try AccountSheetSaveCoordinator.deleteAccount(
+                account,
+                modelContext: context,
+                secretStore: store,
+                save: { _ in throw KeychainError.interactionNotAllowed })
+        }
+
+        #expect(store.storage[.exchangeAPIKey(accountID)] == "key")
+        #expect(store.storage[.exchangeAPISecret(accountID)] == "secret")
+        #expect(try context.fetch(FetchDescriptor<Account>()).count == 1)
+    }
+
     @Test func `editing a deleted account throws missingEditedAccount`() throws {
         let context = try makeModelContext()
         let account = Account(name: "Doomed", kind: .manual, dataSource: .manual)
@@ -247,6 +379,13 @@ struct AccountSheetDraftTests {
         #expect(store.storage[.exchangePassphrase(accountID)] == nil)
     }
 
+    @Test func `save policy blocks submit while syncing`() {
+        #expect(AddAccountSheetSavePolicy.canSubmit(draftCanSave: true, isSyncing: false, isSyncBlocked: false))
+        #expect(!AddAccountSheetSavePolicy.canSubmit(draftCanSave: false, isSyncing: false, isSyncBlocked: false))
+        #expect(!AddAccountSheetSavePolicy.canSubmit(draftCanSave: true, isSyncing: true, isSyncBlocked: false))
+        #expect(!AddAccountSheetSavePolicy.canSubmit(draftCanSave: true, isSyncing: false, isSyncBlocked: true))
+    }
+
     private func makeModelContext() throws -> ModelContext {
         let schema = Schema([
             Account.self,
@@ -273,19 +412,23 @@ struct AccountSheetDraftTests {
 final class InMemorySecretStore: SecretStore, @unchecked Sendable {
     var storage: [KeychainKey: String] = [:]
     var throwOnGet = false
+    var throwOnGetKeys: Set<KeychainKey> = []
     var throwOnSet = false
+    var throwOnSetKeys: Set<KeychainKey> = []
+    var throwOnDeleteKeys: Set<KeychainKey> = []
 
     func get(key: KeychainKey) throws(KeychainError) -> String? {
-        if throwOnGet { throw .interactionNotAllowed }
+        if throwOnGet || throwOnGetKeys.contains(key) { throw .interactionNotAllowed }
         return storage[key]
     }
 
     func set(key: KeychainKey, value: String) throws(KeychainError) {
-        if throwOnSet { throw .interactionNotAllowed }
+        if throwOnSet || throwOnSetKeys.contains(key) { throw .interactionNotAllowed }
         storage[key] = value
     }
 
     func delete(key: KeychainKey) throws(KeychainError) {
+        if throwOnDeleteKeys.contains(key) { throw .interactionNotAllowed }
         storage[key] = nil
     }
 }

--- a/Tests/PortuTests/AccountSheetInvalidationTests.swift
+++ b/Tests/PortuTests/AccountSheetInvalidationTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+@testable import Portu
+import PortuCore
+import SwiftData
+import Testing
+
+@MainActor
+struct AccountSheetInvalidationTests {
+    @Test func `wallet edit clears synced positions when wallet identity changes`() throws {
+        let context = try makeModelContext()
+        let account = Account(
+            name: "Wallet",
+            kind: .wallet,
+            dataSource: .zapper,
+            lastSyncedAt: Date(timeIntervalSince1970: 1000),
+            lastSyncError: "old failure")
+        context.insert(account)
+        let address = WalletAddress(chain: nil, address: "0xold", account: account)
+        context.insert(address)
+        account.addresses = [address]
+        insertSyncedPosition(for: account, in: context)
+        try context.save()
+        #expect(try context.fetch(FetchDescriptor<Position>()).count == 1)
+
+        var draft = AccountSheetDraft.editing(account: account)
+        draft.chainAddress = "0xnew"
+
+        try AccountSheetSaveCoordinator.save(
+            draft: draft,
+            mode: .edit(account.id),
+            editing: account,
+            modelContext: context,
+            secretStore: InMemorySecretStore())
+
+        let updated = try #require(try context.fetch(FetchDescriptor<Account>()).first)
+        #expect(updated.positions.isEmpty)
+        #expect(updated.lastSyncedAt == nil)
+        #expect(updated.lastSyncError == nil)
+        #expect(try context.fetch(FetchDescriptor<Position>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<PositionToken>()).isEmpty)
+    }
+
+    @Test func `exchange edit clears synced positions when credentials change`() throws {
+        let context = try makeModelContext()
+        let accountID = UUID()
+        let store = InMemorySecretStore()
+        store.storage[.exchangeAPIKey(accountID)] = "old-key"
+        store.storage[.exchangeAPISecret(accountID)] = "old-secret"
+        store.storage[.exchangePassphrase(accountID)] = "old-passphrase"
+        let account = Account(
+            id: accountID,
+            name: "Coinbase",
+            kind: .exchange,
+            exchangeType: .coinbase,
+            dataSource: .exchange,
+            lastSyncedAt: Date(timeIntervalSince1970: 1000),
+            lastSyncError: "old failure")
+        context.insert(account)
+        insertSyncedPosition(for: account, in: context)
+        try context.save()
+        #expect(try context.fetch(FetchDescriptor<Position>()).count == 1)
+
+        var draft = AccountSheetDraft.editing(account: account, secretStore: store)
+        draft.exchangeAPIKey = "new-key"
+
+        try AccountSheetSaveCoordinator.save(
+            draft: draft,
+            mode: .edit(accountID),
+            editing: account,
+            modelContext: context,
+            secretStore: store)
+
+        let updated = try #require(try context.fetch(FetchDescriptor<Account>()).first)
+        #expect(updated.positions.isEmpty)
+        #expect(updated.lastSyncedAt == nil)
+        #expect(updated.lastSyncError == nil)
+        #expect(store.storage[.exchangeAPIKey(accountID)] == "new-key")
+        #expect(try context.fetch(FetchDescriptor<Position>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<PositionToken>()).isEmpty)
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let schema = Schema([
+            Account.self,
+            WalletAddress.self,
+            Position.self,
+            PositionToken.self,
+            Asset.self,
+            TokenPricingOverride.self,
+            TokenIdentityMapping.self,
+            HistoricalPricePoint.self,
+            PortfolioCategory.self,
+            CategorySymbolRule.self,
+            PortfolioSnapshot.self,
+            AccountSnapshot.self,
+            AssetSnapshot.self
+        ])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        return ModelContext(container)
+    }
+
+    private func insertSyncedPosition(for account: Account, in context: ModelContext) {
+        let position = Position(
+            positionType: .idle,
+            netUSDValue: 100,
+            syncedAt: Date(timeIntervalSince1970: 900))
+        context.insert(position)
+        position.account = account
+        let token = PositionToken(role: .balance, amount: 1, usdValue: 100)
+        context.insert(token)
+        token.position = position
+    }
+}

--- a/Tests/PortuTests/AccountsFeatureTests.swift
+++ b/Tests/PortuTests/AccountsFeatureTests.swift
@@ -393,3 +393,28 @@ struct AccountSyncEligibilityTests {
         #expect(inactive.isSyncable == false)
     }
 }
+
+// MARK: - Row Action Policy
+
+struct AccountRowActionPolicyTests {
+    @Test func `sync help prioritizes the selected syncing row`() {
+        #expect(AccountRowActionPolicy.syncHelp(
+            isActive: true,
+            dataSource: .zapper,
+            isSyncingThisAccount: true,
+            globalSyncIsRunning: true) == "Syncing this account...")
+    }
+
+    @Test func `sync help reports another sync for different row`() {
+        #expect(AccountRowActionPolicy.syncHelp(
+            isActive: true,
+            dataSource: .zapper,
+            isSyncingThisAccount: false,
+            globalSyncIsRunning: true) == "Another sync is already running.")
+    }
+
+    @Test func `delete is disabled while any sync is running`() {
+        #expect(!AccountRowActionPolicy.deleteDisabled(globalSyncIsRunning: false))
+        #expect(AccountRowActionPolicy.deleteDisabled(globalSyncIsRunning: true))
+    }
+}

--- a/Tests/PortuTests/AccountsFeatureTests.swift
+++ b/Tests/PortuTests/AccountsFeatureTests.swift
@@ -53,18 +53,29 @@ struct AccountsFeatureTests {
         }
     }
 
-    // MARK: - Show Add Sheet
+    // MARK: - Account Sheet Presentation
 
-    @Test func `add sheet presentation updates state`() async {
+    @Test func `add account action presents add sheet`() async {
         let store = TestStore(initialState: AccountsFeature.State()) {
             AccountsFeature()
         }
 
-        await store.send(.addSheetPresented(true)) {
-            $0.showAddSheet = true
+        await store.send(.addAccountTapped) {
+            $0.accountSheetMode = .add
         }
-        await store.send(.addSheetPresented(false)) {
-            $0.showAddSheet = false
+        await store.send(.accountSheetDismissed) {
+            $0.accountSheetMode = nil
+        }
+    }
+
+    @Test func `edit account action presents edit sheet for account id`() async {
+        let accountID = UUID()
+        let store = TestStore(initialState: AccountsFeature.State()) {
+            AccountsFeature()
+        }
+
+        await store.send(.editAccountTapped(accountID)) {
+            $0.accountSheetMode = .edit(accountID)
         }
     }
 }
@@ -72,10 +83,10 @@ struct AccountsFeatureTests {
 // MARK: - Account Row Mapping
 
 struct AccountRowMappingTests {
-    @Test func `maps wallet account with truncated address`() {
+    @Test func `maps wallet account with full address`() {
         let input = AccountInput(
             id: UUID(), name: "My Wallet", kind: .wallet,
-            exchangeType: nil, group: "DeFi", isActive: true,
+            exchangeType: nil, dataSource: .zapper, group: "DeFi", isActive: true,
             lastSyncError: nil, totalBalance: 50000,
             firstAddress: "0x1234567890abcdef1234567890abcdef12345678")
 
@@ -84,16 +95,17 @@ struct AccountRowMappingTests {
         #expect(rows.count == 1)
         #expect(rows[0].name == "My Wallet")
         #expect(rows[0].group == "DeFi")
-        #expect(rows[0].address == "0x1234567890abcd\u{2026}") // 16 chars + ellipsis
+        #expect(rows[0].address == "0x1234567890abcdef1234567890abcdef12345678")
         #expect(rows[0].type == "Wallet")
         #expect(rows[0].balance == 50000)
         #expect(rows[0].isActive == true)
+        #expect(rows[0].isSyncable == true)
     }
 
     @Test func `maps exchange account with exchange type as address`() {
         let input = AccountInput(
             id: UUID(), name: "My Kraken", kind: .exchange,
-            exchangeType: .kraken, group: nil, isActive: true,
+            exchangeType: .kraken, dataSource: .exchange, group: nil, isActive: true,
             lastSyncError: nil, totalBalance: 10000,
             firstAddress: nil)
 
@@ -101,12 +113,13 @@ struct AccountRowMappingTests {
 
         #expect(rows[0].address == "Kraken")
         #expect(rows[0].group == "\u{2014}") // em dash for nil group
+        #expect(rows[0].isSyncable == true)
     }
 
     @Test func `maps manual account with Manual as address`() {
         let input = AccountInput(
             id: UUID(), name: "Cash Stash", kind: .manual,
-            exchangeType: nil, group: nil, isActive: true,
+            exchangeType: nil, dataSource: .manual, group: nil, isActive: true,
             lastSyncError: nil, totalBalance: 0,
             firstAddress: nil)
 
@@ -114,12 +127,25 @@ struct AccountRowMappingTests {
 
         #expect(rows[0].address == "Manual")
         #expect(rows[0].type == "Manual")
+        #expect(rows[0].isSyncable == false)
+    }
+
+    @Test func `inactive syncable source is not row syncable`() {
+        let input = AccountInput(
+            id: UUID(), name: "Inactive", kind: .wallet,
+            exchangeType: nil, dataSource: .zapper, group: nil, isActive: false,
+            lastSyncError: nil, totalBalance: 0,
+            firstAddress: "0x123")
+
+        let rows = AccountsFeature.mapAccountRows(from: [input])
+
+        #expect(rows[0].isSyncable == false)
     }
 
     @Test func `short address not truncated`() {
         let input = AccountInput(
             id: UUID(), name: "Short", kind: .wallet,
-            exchangeType: nil, group: nil, isActive: true,
+            exchangeType: nil, dataSource: .zapper, group: nil, isActive: true,
             lastSyncError: nil, totalBalance: 0,
             firstAddress: "abc123")
 
@@ -131,7 +157,7 @@ struct AccountRowMappingTests {
     @Test func `preserves sync error`() {
         let input = AccountInput(
             id: UUID(), name: "Broken", kind: .exchange,
-            exchangeType: .binance, group: nil, isActive: true,
+            exchangeType: .binance, dataSource: .exchange, group: nil, isActive: true,
             lastSyncError: "API rate limit", totalBalance: 0,
             firstAddress: nil)
 
@@ -147,11 +173,11 @@ struct AccountRowFilteringTests {
     private let activeRow = AccountRowData(
         id: UUID(), name: "Active Wallet", group: "DeFi",
         address: "0x123", type: "Wallet", balance: 5000,
-        isActive: true, lastSyncError: nil)
+        dataSource: .zapper, isActive: true, lastSyncError: nil)
     private let inactiveRow = AccountRowData(
         id: UUID(), name: "Old Exchange", group: "CEX",
         address: "Kraken", type: "Exchange", balance: 0,
-        isActive: false, lastSyncError: nil)
+        dataSource: .exchange, isActive: false, lastSyncError: nil)
 
     @Test func `hides inactive when showInactive is false`() {
         let filtered = AccountsFeature.filterAccountRows(
@@ -200,7 +226,7 @@ struct AccountRowFilteringTests {
         let defiRow = AccountRowData(
             id: UUID(), name: "DeFi Wallet 2", group: "DeFi",
             address: "0x456", type: "Wallet", balance: 3000,
-            isActive: true, lastSyncError: nil)
+            dataSource: .zapper, isActive: true, lastSyncError: nil)
 
         let filtered = AccountsFeature.filterAccountRows(
             [activeRow, inactiveRow, defiRow],
@@ -220,6 +246,7 @@ struct AccountGroupExtractionTests {
                 name: "A",
                 kind: .wallet,
                 exchangeType: nil,
+                dataSource: .zapper,
                 group: "DeFi",
                 isActive: true,
                 lastSyncError: nil,
@@ -230,6 +257,7 @@ struct AccountGroupExtractionTests {
                 name: "B",
                 kind: .exchange,
                 exchangeType: .kraken,
+                dataSource: .exchange,
                 group: "CEX",
                 isActive: true,
                 lastSyncError: nil,
@@ -240,6 +268,7 @@ struct AccountGroupExtractionTests {
                 name: "C",
                 kind: .wallet,
                 exchangeType: nil,
+                dataSource: .zapper,
                 group: "DeFi",
                 isActive: true,
                 lastSyncError: nil,
@@ -250,6 +279,7 @@ struct AccountGroupExtractionTests {
                 name: "D",
                 kind: .manual,
                 exchangeType: nil,
+                dataSource: .manual,
                 group: nil,
                 isActive: true,
                 lastSyncError: nil,
@@ -269,6 +299,7 @@ struct AccountGroupExtractionTests {
                 name: "A",
                 kind: .manual,
                 exchangeType: nil,
+                dataSource: .manual,
                 group: nil,
                 isActive: true,
                 lastSyncError: nil,
@@ -288,84 +319,52 @@ struct AccountFormValidationTests {
     @Test func `chain tab requires name and address`() {
         #expect(AccountsFeature.canSave(
             tab: 0,
-            chainName: "W",
-            chainAddress: "0x1",
-            manualName: "",
-            exchangeName: "",
-            exchangeAPIKey: "",
-            exchangeAPISecret: "") == true)
+            fields: AccountSaveFields(chainName: "W", chainAddress: "0x1")) == true)
         #expect(AccountsFeature.canSave(
             tab: 0,
-            chainName: "",
-            chainAddress: "0x1",
-            manualName: "",
-            exchangeName: "",
-            exchangeAPIKey: "",
-            exchangeAPISecret: "") == false)
+            fields: AccountSaveFields(chainAddress: "0x1")) == false)
         #expect(AccountsFeature.canSave(
             tab: 0,
-            chainName: "W",
-            chainAddress: "",
-            manualName: "",
-            exchangeName: "",
-            exchangeAPIKey: "",
-            exchangeAPISecret: "") == false)
+            fields: AccountSaveFields(chainName: "W")) == false)
     }
 
     @Test func `manual tab requires name`() {
         #expect(AccountsFeature.canSave(
             tab: 1,
-            chainName: "",
-            chainAddress: "",
-            manualName: "Cash",
-            exchangeName: "",
-            exchangeAPIKey: "",
-            exchangeAPISecret: "") == true)
+            fields: AccountSaveFields(manualName: "Cash")) == true)
         #expect(AccountsFeature.canSave(
             tab: 1,
-            chainName: "",
-            chainAddress: "",
-            manualName: "",
-            exchangeName: "",
-            exchangeAPIKey: "",
-            exchangeAPISecret: "") == false)
+            fields: AccountSaveFields()) == false)
     }
 
     @Test func `exchange tab requires name and both keys`() {
         #expect(AccountsFeature.canSave(
             tab: 2,
-            chainName: "",
-            chainAddress: "",
-            manualName: "",
-            exchangeName: "Kraken",
-            exchangeAPIKey: "key",
-            exchangeAPISecret: "secret") == true)
+            fields: AccountSaveFields(
+                exchangeName: "Kraken",
+                exchangeAPIKey: "key",
+                exchangeAPISecret: "secret")) == true)
         #expect(AccountsFeature.canSave(
             tab: 2,
-            chainName: "",
-            chainAddress: "",
-            manualName: "",
-            exchangeName: "Kraken",
-            exchangeAPIKey: "",
-            exchangeAPISecret: "secret") == false)
+            fields: AccountSaveFields(
+                exchangeName: "Kraken",
+                exchangeAPISecret: "secret")) == false)
         #expect(AccountsFeature.canSave(
             tab: 2,
-            chainName: "",
-            chainAddress: "",
-            manualName: "",
-            exchangeName: "",
-            exchangeAPIKey: "key",
-            exchangeAPISecret: "secret") == false)
+            fields: AccountSaveFields(
+                exchangeAPIKey: "key",
+                exchangeAPISecret: "secret")) == false)
     }
 
     @Test func `unknown tab returns false`() {
         #expect(AccountsFeature.canSave(
             tab: 99,
-            chainName: "x",
-            chainAddress: "x",
-            manualName: "x",
-            exchangeName: "x",
-            exchangeAPIKey: "x",
-            exchangeAPISecret: "x") == false)
+            fields: AccountSaveFields(
+                chainName: "x",
+                chainAddress: "x",
+                manualName: "x",
+                exchangeName: "x",
+                exchangeAPIKey: "x",
+                exchangeAPISecret: "x")) == false)
     }
 }

--- a/Tests/PortuTests/AccountsFeatureTests.swift
+++ b/Tests/PortuTests/AccountsFeatureTests.swift
@@ -444,3 +444,44 @@ struct AccountRowActionPolicyTests {
         #expect(AccountRowActionPolicy.deleteDisabled(globalSyncIsRunning: true))
     }
 }
+
+// MARK: - Sheet Sync Policy
+
+struct AccountSheetSyncPolicyTests {
+    @Test func `add sheet is blocked during any sync`() {
+        let policy = AccountSheetSyncPolicy.state(
+            mode: .add,
+            syncStatus: .syncing(progress: 0.4),
+            syncingAccountID: UUID())
+
+        #expect(policy.isSyncing == false)
+        #expect(policy.isSyncBlocked == true)
+    }
+
+    @Test func `edit sheet marks selected syncing account separately from blocked accounts`() {
+        let accountID = UUID()
+        let selectedPolicy = AccountSheetSyncPolicy.state(
+            mode: .edit(accountID),
+            syncStatus: .syncing(progress: 0.4),
+            syncingAccountID: accountID)
+        let blockedPolicy = AccountSheetSyncPolicy.state(
+            mode: .edit(UUID()),
+            syncStatus: .syncing(progress: 0.4),
+            syncingAccountID: accountID)
+
+        #expect(selectedPolicy.isSyncing == true)
+        #expect(selectedPolicy.isSyncBlocked == false)
+        #expect(blockedPolicy.isSyncing == false)
+        #expect(blockedPolicy.isSyncBlocked == true)
+    }
+
+    @Test func `sheet is editable while sync is idle`() {
+        let policy = AccountSheetSyncPolicy.state(
+            mode: .add,
+            syncStatus: .idle,
+            syncingAccountID: nil)
+
+        #expect(policy.isSyncing == false)
+        #expect(policy.isSyncBlocked == false)
+    }
+}

--- a/Tests/PortuTests/AccountsFeatureTests.swift
+++ b/Tests/PortuTests/AccountsFeatureTests.swift
@@ -130,6 +130,32 @@ struct AccountRowMappingTests {
         #expect(rows[0].isSyncable == false)
     }
 
+    @Test func `maps missing wallet address as em dash`() {
+        let input = AccountInput(
+            id: UUID(), name: "Addressless Wallet", kind: .wallet,
+            exchangeType: nil, dataSource: .zapper, group: nil, isActive: true,
+            lastSyncError: nil, totalBalance: 0,
+            firstAddress: nil)
+
+        let rows = AccountsFeature.mapAccountRows(from: [input])
+
+        #expect(rows[0].address == "\u{2014}")
+        #expect(rows[0].type == "Wallet")
+    }
+
+    @Test func `maps missing exchange type as exchange`() {
+        let input = AccountInput(
+            id: UUID(), name: "Exchange", kind: .exchange,
+            exchangeType: nil, dataSource: .exchange, group: nil, isActive: true,
+            lastSyncError: nil, totalBalance: 0,
+            firstAddress: nil)
+
+        let rows = AccountsFeature.mapAccountRows(from: [input])
+
+        #expect(rows[0].address == "Exchange")
+        #expect(rows[0].type == "Exchange")
+    }
+
     @Test func `inactive syncable source is not row syncable`() {
         let input = AccountInput(
             id: UUID(), name: "Inactive", kind: .wallet,

--- a/Tests/PortuTests/AccountsFeatureTests.swift
+++ b/Tests/PortuTests/AccountsFeatureTests.swift
@@ -368,3 +368,28 @@ struct AccountFormValidationTests {
                 exchangeAPISecret: "x")) == false)
     }
 }
+
+// MARK: - Sync Eligibility
+
+struct AccountSyncEligibilityTests {
+    @Test func `active non-manual accounts are syncable`() {
+        #expect(AccountSyncEligibility.isSyncable(isActive: true, dataSource: .zapper))
+        #expect(AccountSyncEligibility.isSyncable(isActive: true, dataSource: .exchange))
+    }
+
+    @Test func `inactive or manual accounts are not syncable`() {
+        #expect(AccountSyncEligibility.isSyncable(isActive: false, dataSource: .zapper) == false)
+        #expect(AccountSyncEligibility.isSyncable(isActive: false, dataSource: .exchange) == false)
+        #expect(AccountSyncEligibility.isSyncable(isActive: true, dataSource: .manual) == false)
+    }
+
+    @MainActor
+    @Test func `account isSyncable mirrors the shared rule`() {
+        let syncable = Account(name: "W", kind: .wallet, dataSource: .zapper)
+        let manual = Account(name: "M", kind: .manual, dataSource: .manual)
+        let inactive = Account(name: "I", kind: .wallet, dataSource: .zapper, isActive: false)
+        #expect(syncable.isSyncable)
+        #expect(manual.isSyncable == false)
+        #expect(inactive.isSyncable == false)
+    }
+}

--- a/Tests/PortuTests/AccountsFeatureTests.swift
+++ b/Tests/PortuTests/AccountsFeatureTests.swift
@@ -443,6 +443,11 @@ struct AccountRowActionPolicyTests {
         #expect(!AccountRowActionPolicy.deleteDisabled(globalSyncIsRunning: false))
         #expect(AccountRowActionPolicy.deleteDisabled(globalSyncIsRunning: true))
     }
+
+    @Test func `activation toggle is disabled while any sync is running`() {
+        #expect(AccountRowActionPolicy.activationToggleDisabled(globalSyncIsRunning: false) == false)
+        #expect(AccountRowActionPolicy.activationToggleDisabled(globalSyncIsRunning: true))
+    }
 }
 
 // MARK: - Sheet Sync Policy

--- a/Tests/PortuTests/AddAccountSheetReviewTests.swift
+++ b/Tests/PortuTests/AddAccountSheetReviewTests.swift
@@ -21,4 +21,8 @@ struct AddAccountAccessibilityTests {
     @Test func `close icon button has explicit accessible label`() {
         #expect(AddAccountAccessibility.closeButtonLabel == "Close")
     }
+
+    @Test func `close icon button uses mode agnostic accessible hint`() {
+        #expect(AddAccountAccessibility.closeButtonHint == "Closes the account sheet.")
+    }
 }

--- a/Tests/PortuTests/AppFeatureAccountSyncTests.swift
+++ b/Tests/PortuTests/AppFeatureAccountSyncTests.swift
@@ -29,7 +29,7 @@ struct AppFeatureAccountSyncTests {
         #expect(syncedAccountIDs == [accountID])
     }
 
-    @Test func `account sync failure updates sync status error`() async {
+    @Test func `account sync failure resets to idle without a global error`() async {
         struct AccountSyncFailed: Error, LocalizedError {
             var errorDescription: String? {
                 "Account sync failed"
@@ -47,8 +47,10 @@ struct AppFeatureAccountSyncTests {
             $0.syncStatus = .syncing(progress: 0)
             $0.syncingAccountID = accountID
         }
+        // A single-account failure is surfaced on the row's lastSyncError, not as a
+        // global error banner — global status returns to idle.
         await store.receive(\.accountSyncCompleted) {
-            $0.syncStatus = .error("Account sync failed")
+            $0.syncStatus = .idle
             $0.syncingAccountID = nil
         }
     }

--- a/Tests/PortuTests/AppFeatureAccountSyncTests.swift
+++ b/Tests/PortuTests/AppFeatureAccountSyncTests.swift
@@ -1,0 +1,76 @@
+import ComposableArchitecture
+import Foundation
+@testable import Portu
+import PortuNetwork
+import Testing
+
+@MainActor
+struct AppFeatureAccountSyncTests {
+    @Test func `account sync happy path syncs requested account`() async {
+        let accountID = UUID()
+        nonisolated(unsafe) var syncedAccountIDs: [UUID] = []
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine.syncAccount = { id in
+                syncedAccountIDs.append(id)
+                return SyncResult(failedAccounts: [])
+            }
+        }
+
+        await store.send(.accountSyncTapped(accountID)) {
+            $0.syncStatus = .syncing(progress: 0)
+            $0.syncingAccountID = accountID
+        }
+        await store.receive(\.accountSyncCompleted) {
+            $0.syncStatus = .idle
+            $0.syncingAccountID = nil
+        }
+        #expect(syncedAccountIDs == [accountID])
+    }
+
+    @Test func `account sync failure updates sync status error`() async {
+        struct AccountSyncFailed: Error, LocalizedError {
+            var errorDescription: String? {
+                "Account sync failed"
+            }
+        }
+
+        let accountID = UUID()
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine.syncAccount = { _ in throw AccountSyncFailed() }
+        }
+
+        await store.send(.accountSyncTapped(accountID)) {
+            $0.syncStatus = .syncing(progress: 0)
+            $0.syncingAccountID = accountID
+        }
+        await store.receive(\.accountSyncCompleted) {
+            $0.syncStatus = .error("Account sync failed")
+            $0.syncingAccountID = nil
+        }
+    }
+
+    @Test func `account sync guards against double tap`() async {
+        let accountID = UUID()
+        let syncingAccountID = UUID()
+        nonisolated(unsafe) var syncCount = 0
+        let store = TestStore(
+            initialState: AppFeature.State(
+                syncStatus: .syncing(progress: 0.5),
+                syncingAccountID: syncingAccountID)) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine.syncAccount = { _ in
+                syncCount += 1
+                return SyncResult(failedAccounts: [])
+            }
+        }
+
+        await store.send(.accountSyncTapped(accountID))
+        #expect(store.state.syncingAccountID == syncingAccountID)
+        #expect(syncCount == 0)
+    }
+}

--- a/Tests/PortuTests/AppFeatureAccountSyncTests.swift
+++ b/Tests/PortuTests/AppFeatureAccountSyncTests.swift
@@ -1,7 +1,6 @@
 import ComposableArchitecture
 import Foundation
 @testable import Portu
-import PortuNetwork
 import Synchronization
 import Testing
 

--- a/Tests/PortuTests/AppFeatureAccountSyncTests.swift
+++ b/Tests/PortuTests/AppFeatureAccountSyncTests.swift
@@ -29,18 +29,12 @@ struct AppFeatureAccountSyncTests {
         #expect(syncedAccountIDs == [accountID])
     }
 
-    @Test func `account sync failure resets to idle without a global error`() async {
-        struct AccountSyncFailed: Error, LocalizedError {
-            var errorDescription: String? {
-                "Account sync failed"
-            }
-        }
-
+    @Test func `row recorded account sync failure resets to idle without a global error`() async {
         let accountID = UUID()
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
-            $0.syncEngine.syncAccount = { _ in throw AccountSyncFailed() }
+            $0.syncEngine.syncAccount = { _ in throw SyncError.allAccountsFailed }
         }
 
         await store.send(.accountSyncTapped(accountID)) {
@@ -51,6 +45,30 @@ struct AppFeatureAccountSyncTests {
         // global error banner — global status returns to idle.
         await store.receive(\.accountSyncCompleted) {
             $0.syncStatus = .idle
+            $0.syncingAccountID = nil
+        }
+    }
+
+    @Test func `non row account sync failure surfaces global error`() async {
+        struct SnapshotSaveFailed: Error, LocalizedError {
+            var errorDescription: String? {
+                "Snapshot save failed"
+            }
+        }
+
+        let accountID = UUID()
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.syncEngine.syncAccount = { _ in throw SnapshotSaveFailed() }
+        }
+
+        await store.send(.accountSyncTapped(accountID)) {
+            $0.syncStatus = .syncing(progress: 0)
+            $0.syncingAccountID = accountID
+        }
+        await store.receive(\.accountSyncCompleted) {
+            $0.syncStatus = .error("Snapshot save failed")
             $0.syncingAccountID = nil
         }
     }

--- a/Tests/PortuTests/AppFeatureAccountSyncTests.swift
+++ b/Tests/PortuTests/AppFeatureAccountSyncTests.swift
@@ -2,18 +2,19 @@ import ComposableArchitecture
 import Foundation
 @testable import Portu
 import PortuNetwork
+import Synchronization
 import Testing
 
 @MainActor
 struct AppFeatureAccountSyncTests {
     @Test func `account sync happy path syncs requested account`() async {
         let accountID = UUID()
-        nonisolated(unsafe) var syncedAccountIDs: [UUID] = []
+        let syncedAccountIDs = Mutex<[UUID]>([])
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
             $0.syncEngine.syncAccount = { id in
-                syncedAccountIDs.append(id)
+                syncedAccountIDs.withLock { $0.append(id) }
                 return SyncResult(failedAccounts: [])
             }
         }
@@ -26,7 +27,7 @@ struct AppFeatureAccountSyncTests {
             $0.syncStatus = .idle
             $0.syncingAccountID = nil
         }
-        #expect(syncedAccountIDs == [accountID])
+        #expect(syncedAccountIDs.withLock { $0 } == [accountID])
     }
 
     @Test func `row recorded account sync failure resets to idle without a global error`() async {
@@ -76,7 +77,7 @@ struct AppFeatureAccountSyncTests {
     @Test func `account sync guards against double tap`() async {
         let accountID = UUID()
         let syncingAccountID = UUID()
-        nonisolated(unsafe) var syncCount = 0
+        let syncCount = Mutex(0)
         let store = TestStore(
             initialState: AppFeature.State(
                 syncStatus: .syncing(progress: 0.5),
@@ -84,13 +85,13 @@ struct AppFeatureAccountSyncTests {
             AppFeature()
         } withDependencies: {
             $0.syncEngine.syncAccount = { _ in
-                syncCount += 1
+                syncCount.withLock { $0 += 1 }
                 return SyncResult(failedAccounts: [])
             }
         }
 
         await store.send(.accountSyncTapped(accountID))
         #expect(store.state.syncingAccountID == syncingAccountID)
-        #expect(syncCount == 0)
+        #expect(syncCount.withLock { $0 } == 0)
     }
 }

--- a/Tests/PortuTests/SyncEngineScopedTests.swift
+++ b/Tests/PortuTests/SyncEngineScopedTests.swift
@@ -106,6 +106,11 @@ struct SyncEngineScopedTests {
         #expect(other.lastSyncedAt == nil)
         #expect(result.failedAccounts.isEmpty)
         #expect(try context.fetch(FetchDescriptor<AccountSnapshot>()).count == 2)
+        let accountSnapshots = try context.fetch(FetchDescriptor<AccountSnapshot>())
+        let selectedSnapshot = try #require(accountSnapshots.first { $0.accountId == selected.id })
+        let otherSnapshot = try #require(accountSnapshots.first { $0.accountId == other.id })
+        #expect(selectedSnapshot.isFresh == true)
+        #expect(otherSnapshot.isFresh == false)
         let portfolioSnapshot = try #require(try context.fetch(FetchDescriptor<PortfolioSnapshot>()).first)
         #expect(portfolioSnapshot.isPartial == true)
     }
@@ -171,6 +176,45 @@ struct SyncEngineScopedTests {
 
         let portfolioSnapshot = try #require(try context.fetch(FetchDescriptor<PortfolioSnapshot>()).first)
         #expect(portfolioSnapshot.isPartial == true)
+    }
+
+    @Test func `account scoped sync stays partial when selected account is deactivated before snapshots`() async throws {
+        let context = try makeModelContext()
+        let provider = GatedScopedSyncStubProvider(balances: [
+            PositionDTO(
+                positionType: .idle,
+                chain: .ethereum,
+                protocolId: nil,
+                protocolName: nil,
+                protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
+        ])
+        let factory = ProviderFactory(resolver: { _, _ in provider })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        let selected = Account(name: "Selected", kind: .wallet, dataSource: .zapper)
+        selected.addresses = [WalletAddress(address: "0xselected", account: selected)]
+        let other = Account(name: "Other", kind: .wallet, dataSource: .zapper)
+        other.addresses = [WalletAddress(address: "0xother", account: other)]
+        context.insert(selected)
+        context.insert(other)
+        try context.save()
+
+        let syncTask = Task {
+            try await engine.sync(accountID: selected.id)
+        }
+        await provider.waitUntilFetchBalancesStarted()
+        selected.isActive = false
+        try context.save()
+        await provider.releaseFetchBalances()
+
+        _ = try await syncTask.value
+
+        let portfolioSnapshot = try #require(try context.fetch(FetchDescriptor<PortfolioSnapshot>()).first)
+        #expect(portfolioSnapshot.isPartial == true)
+        let accountSnapshot = try #require(try context.fetch(FetchDescriptor<AccountSnapshot>()).first)
+        #expect(accountSnapshot.accountId == other.id)
+        #expect(accountSnapshot.isFresh == false)
     }
 
     @Test func `account scoped sync rejects missing account`() async throws {

--- a/Tests/PortuTests/SyncEngineScopedTests.swift
+++ b/Tests/PortuTests/SyncEngineScopedTests.swift
@@ -137,6 +137,42 @@ struct SyncEngineScopedTests {
         #expect(portfolioSnapshot.isPartial == false)
     }
 
+    @Test func `account scoped sync recomputes snapshot partial state after provider awaits`() async throws {
+        let context = try makeModelContext()
+        let provider = GatedScopedSyncStubProvider(balances: [
+            PositionDTO(
+                positionType: .idle,
+                chain: .ethereum,
+                protocolId: nil,
+                protocolName: nil,
+                protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
+        ])
+        let factory = ProviderFactory(resolver: { _, _ in provider })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        let selected = Account(name: "Selected", kind: .wallet, dataSource: .zapper)
+        selected.addresses = [WalletAddress(address: "0xselected", account: selected)]
+        let other = Account(name: "Other", kind: .wallet, dataSource: .zapper, isActive: false)
+        other.addresses = [WalletAddress(address: "0xother", account: other)]
+        context.insert(selected)
+        context.insert(other)
+        try context.save()
+
+        let syncTask = Task {
+            try await engine.sync(accountID: selected.id)
+        }
+        await provider.waitUntilFetchBalancesStarted()
+        other.isActive = true
+        try context.save()
+        await provider.releaseFetchBalances()
+
+        _ = try await syncTask.value
+
+        let portfolioSnapshot = try #require(try context.fetch(FetchDescriptor<PortfolioSnapshot>()).first)
+        #expect(portfolioSnapshot.isPartial == true)
+    }
+
     @Test func `account scoped sync rejects missing account`() async throws {
         let context = try makeModelContext()
         let engine = SyncEngine(
@@ -239,5 +275,49 @@ private actor ScopedSyncStubProvider: PortfolioDataProvider {
 
     func fetchBalances(context _: SyncContext) async throws -> [PositionDTO] {
         balances
+    }
+}
+
+private actor GatedScopedSyncStubProvider: PortfolioDataProvider {
+    nonisolated var capabilities: ProviderCapabilities {
+        ProviderCapabilities()
+    }
+
+    let balances: [PositionDTO]
+    private var didStartFetchBalances = false
+    private var didReleaseFetchBalances = false
+    private var startContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    init(balances: [PositionDTO]) {
+        self.balances = balances
+    }
+
+    func waitUntilFetchBalancesStarted() async {
+        if didStartFetchBalances { return }
+
+        await withCheckedContinuation { continuation in
+            startContinuation = continuation
+        }
+    }
+
+    func releaseFetchBalances() {
+        didReleaseFetchBalances = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    func fetchBalances(context _: SyncContext) async throws -> [PositionDTO] {
+        didStartFetchBalances = true
+        startContinuation?.resume()
+        startContinuation = nil
+
+        if didReleaseFetchBalances == false {
+            await withCheckedContinuation { continuation in
+                releaseContinuation = continuation
+            }
+        }
+
+        return balances
     }
 }

--- a/Tests/PortuTests/SyncEngineScopedTests.swift
+++ b/Tests/PortuTests/SyncEngineScopedTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import PortuCore
 import PortuNetwork
 import SwiftData
+import Synchronization
 import Testing
 
 @MainActor
@@ -19,9 +20,9 @@ struct SyncEngineScopedTests {
                 healthFactor: nil,
                 tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
         ])
-        nonisolated(unsafe) var resolvedSources: [DataSource] = []
+        let resolvedSources = Mutex<[DataSource]>([])
         let factory = ProviderFactory(resolver: { dataSource, _ in
-            resolvedSources.append(dataSource)
+            resolvedSources.withLock { $0.append(dataSource) }
             return provider
         })
         let engine = SyncEngine(modelContext: context, providerFactory: factory)
@@ -33,7 +34,7 @@ struct SyncEngineScopedTests {
 
         let result = try await engine.sync(scope: .zapper)
 
-        #expect(resolvedSources == [.zapper])
+        #expect(resolvedSources.withLock { $0 } == [.zapper])
         #expect(wallet.lastSyncedAt != nil)
         #expect(exchange.lastSyncedAt == nil)
         #expect(result.failedAccounts.isEmpty)
@@ -52,9 +53,9 @@ struct SyncEngineScopedTests {
                 healthFactor: nil,
                 tokens: [makeTokenDTO(symbol: "BTC", name: "Bitcoin", coinGeckoId: "bitcoin")])
         ])
-        nonisolated(unsafe) var resolvedSources: [DataSource] = []
+        let resolvedSources = Mutex<[DataSource]>([])
         let factory = ProviderFactory(resolver: { dataSource, _ in
-            resolvedSources.append(dataSource)
+            resolvedSources.withLock { $0.append(dataSource) }
             return provider
         })
         let engine = SyncEngine(modelContext: context, providerFactory: factory)
@@ -66,7 +67,7 @@ struct SyncEngineScopedTests {
 
         let result = try await engine.sync(scope: .exchange)
 
-        #expect(resolvedSources == [.exchange])
+        #expect(resolvedSources.withLock { $0 } == [.exchange])
         #expect(wallet.lastSyncedAt == nil)
         #expect(exchange.lastSyncedAt != nil)
         #expect(result.failedAccounts.isEmpty)
@@ -85,9 +86,9 @@ struct SyncEngineScopedTests {
                 healthFactor: nil,
                 tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
         ])
-        nonisolated(unsafe) var resolvedAccountIDs: [UUID] = []
+        let resolvedAccountIDs = Mutex<[UUID]>([])
         let factory = ProviderFactory(resolver: { _, context in
-            resolvedAccountIDs.append(context.accountId)
+            resolvedAccountIDs.withLock { $0.append(context.accountId) }
             return provider
         })
         let engine = SyncEngine(modelContext: context, providerFactory: factory)
@@ -101,7 +102,7 @@ struct SyncEngineScopedTests {
 
         let result = try await engine.sync(accountID: selected.id)
 
-        #expect(resolvedAccountIDs == [selected.id])
+        #expect(resolvedAccountIDs.withLock { $0 } == [selected.id])
         #expect(selected.lastSyncedAt != nil)
         #expect(other.lastSyncedAt == nil)
         #expect(result.failedAccounts.isEmpty)

--- a/Tests/PortuTests/SyncEngineScopedTests.swift
+++ b/Tests/PortuTests/SyncEngineScopedTests.swift
@@ -94,8 +94,13 @@ struct SyncEngineScopedTests {
         let engine = SyncEngine(modelContext: context, providerFactory: factory)
         let selected = Account(name: "Selected", kind: .wallet, dataSource: .zapper)
         selected.addresses = [WalletAddress(address: "0xselected", account: selected)]
+        let staleAsset = Asset(symbol: "OLD", name: "Old Token", category: .major)
+        let staleToken = PositionToken(role: .balance, amount: 1, usdValue: 100, asset: staleAsset)
+        let stalePosition = Position(positionType: .idle, chain: .ethereum, netUSDValue: 100, tokens: [staleToken])
         let other = Account(name: "Other", kind: .wallet, dataSource: .zapper)
         other.addresses = [WalletAddress(address: "0xother", account: other)]
+        other.positions = [stalePosition]
+        context.insert(staleAsset)
         context.insert(selected)
         context.insert(other)
         try context.save()
@@ -114,6 +119,50 @@ struct SyncEngineScopedTests {
         #expect(otherSnapshot.isFresh == false)
         let portfolioSnapshot = try #require(try context.fetch(FetchDescriptor<PortfolioSnapshot>()).first)
         #expect(portfolioSnapshot.isPartial == true)
+        let assetSnapshots = try context.fetch(FetchDescriptor<AssetSnapshot>())
+        #expect(assetSnapshots.allSatisfy { $0.accountId == selected.id })
+    }
+
+    @Test func `partial sync asset snapshots skip failed account stale positions`() async throws {
+        let context = try makeModelContext()
+        let provider = ScopedSyncStubProvider(balances: [
+            PositionDTO(
+                positionType: .idle,
+                chain: .ethereum,
+                protocolId: nil,
+                protocolName: nil,
+                protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
+        ])
+        let succeeded = Account(name: "Succeeded", kind: .wallet, dataSource: .zapper)
+        succeeded.addresses = [WalletAddress(address: "0xsucceeded", account: succeeded)]
+        let staleAsset = Asset(symbol: "OLD", name: "Old Token", category: .major)
+        let staleToken = PositionToken(role: .balance, amount: 1, usdValue: 100, asset: staleAsset)
+        let stalePosition = Position(positionType: .idle, chain: .ethereum, netUSDValue: 100, tokens: [staleToken])
+        let failed = Account(name: "Failed", kind: .wallet, dataSource: .zapper)
+        failed.addresses = [WalletAddress(address: "0xfailed", account: failed)]
+        failed.positions = [stalePosition]
+        let failedID = failed.id
+        let factory = ProviderFactory(resolver: { _, context in
+            if context.accountId == failedID {
+                throw SyncEngineScopedTestError.forcedProviderFailure
+            }
+            return provider
+        })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        context.insert(staleAsset)
+        context.insert(succeeded)
+        context.insert(failed)
+        try context.save()
+
+        let result = try await engine.sync()
+
+        #expect(result.failedAccounts == ["Failed"])
+        let assetSnapshots = try context.fetch(FetchDescriptor<AssetSnapshot>())
+        #expect(assetSnapshots.allSatisfy { $0.accountId == succeeded.id })
+        let failedSnapshot = try #require(try context.fetch(FetchDescriptor<AccountSnapshot>()).first { $0.accountId == failed.id })
+        #expect(failedSnapshot.isFresh == false)
     }
 
     @Test func `account scoped sync snapshot is complete when selected account is the only syncable account`() async throws {
@@ -365,4 +414,8 @@ private actor GatedScopedSyncStubProvider: PortfolioDataProvider {
 
         return balances
     }
+}
+
+private enum SyncEngineScopedTestError: Error {
+    case forcedProviderFailure
 }

--- a/Tests/PortuTests/SyncEngineScopedTests.swift
+++ b/Tests/PortuTests/SyncEngineScopedTests.swift
@@ -106,6 +106,35 @@ struct SyncEngineScopedTests {
         #expect(other.lastSyncedAt == nil)
         #expect(result.failedAccounts.isEmpty)
         #expect(try context.fetch(FetchDescriptor<AccountSnapshot>()).count == 2)
+        let portfolioSnapshot = try #require(try context.fetch(FetchDescriptor<PortfolioSnapshot>()).first)
+        #expect(portfolioSnapshot.isPartial == true)
+    }
+
+    @Test func `account scoped sync snapshot is complete when selected account is the only syncable account`() async throws {
+        let context = try makeModelContext()
+        let provider = ScopedSyncStubProvider(balances: [
+            PositionDTO(
+                positionType: .idle,
+                chain: .ethereum,
+                protocolId: nil,
+                protocolName: nil,
+                protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
+        ])
+        let factory = ProviderFactory(resolver: { _, _ in provider })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        let selected = Account(name: "Selected", kind: .wallet, dataSource: .zapper)
+        selected.addresses = [WalletAddress(address: "0xselected", account: selected)]
+        let manual = Account(name: "Manual", kind: .manual, dataSource: .manual)
+        context.insert(selected)
+        context.insert(manual)
+        try context.save()
+
+        _ = try await engine.sync(accountID: selected.id)
+
+        let portfolioSnapshot = try #require(try context.fetch(FetchDescriptor<PortfolioSnapshot>()).first)
+        #expect(portfolioSnapshot.isPartial == false)
     }
 
     @Test func `account scoped sync rejects missing account`() async throws {

--- a/Tests/PortuTests/SyncEngineScopedTests.swift
+++ b/Tests/PortuTests/SyncEngineScopedTests.swift
@@ -73,6 +73,95 @@ struct SyncEngineScopedTests {
         #expect(try context.fetch(FetchDescriptor<AccountSnapshot>()).count == 2)
     }
 
+    @Test func `account scoped sync fetches only selected account`() async throws {
+        let context = try makeModelContext()
+        let provider = ScopedSyncStubProvider(balances: [
+            PositionDTO(
+                positionType: .idle,
+                chain: .ethereum,
+                protocolId: nil,
+                protocolName: nil,
+                protocolLogoURL: nil,
+                healthFactor: nil,
+                tokens: [makeTokenDTO(symbol: "ETH", name: "Ethereum", coinGeckoId: "ethereum")])
+        ])
+        nonisolated(unsafe) var resolvedAccountIDs: [UUID] = []
+        let factory = ProviderFactory(resolver: { _, context in
+            resolvedAccountIDs.append(context.accountId)
+            return provider
+        })
+        let engine = SyncEngine(modelContext: context, providerFactory: factory)
+        let selected = Account(name: "Selected", kind: .wallet, dataSource: .zapper)
+        selected.addresses = [WalletAddress(address: "0xselected", account: selected)]
+        let other = Account(name: "Other", kind: .wallet, dataSource: .zapper)
+        other.addresses = [WalletAddress(address: "0xother", account: other)]
+        context.insert(selected)
+        context.insert(other)
+        try context.save()
+
+        let result = try await engine.sync(accountID: selected.id)
+
+        #expect(resolvedAccountIDs == [selected.id])
+        #expect(selected.lastSyncedAt != nil)
+        #expect(other.lastSyncedAt == nil)
+        #expect(result.failedAccounts.isEmpty)
+        #expect(try context.fetch(FetchDescriptor<AccountSnapshot>()).count == 2)
+    }
+
+    @Test func `account scoped sync rejects missing account`() async throws {
+        let context = try makeModelContext()
+        let engine = SyncEngine(
+            modelContext: context,
+            providerFactory: ProviderFactory(resolver: { _, _ in ScopedSyncStubProvider(balances: []) }))
+
+        do {
+            _ = try await engine.sync(accountID: UUID())
+            Issue.record("Expected missing account sync to throw.")
+        } catch SyncError.accountNotFound {
+            // Expected.
+        } catch {
+            Issue.record("Expected accountNotFound, got \(error).")
+        }
+    }
+
+    @Test func `account scoped sync rejects manual account`() async throws {
+        let context = try makeModelContext()
+        let manual = Account(name: "Manual", kind: .manual, dataSource: .manual)
+        context.insert(manual)
+        try context.save()
+        let engine = SyncEngine(
+            modelContext: context,
+            providerFactory: ProviderFactory(resolver: { _, _ in ScopedSyncStubProvider(balances: []) }))
+
+        do {
+            _ = try await engine.sync(accountID: manual.id)
+            Issue.record("Expected manual account sync to throw.")
+        } catch SyncError.accountNotSyncable {
+            // Expected.
+        } catch {
+            Issue.record("Expected accountNotSyncable, got \(error).")
+        }
+    }
+
+    @Test func `account scoped sync rejects inactive account`() async throws {
+        let context = try makeModelContext()
+        let inactive = Account(name: "Inactive", kind: .wallet, dataSource: .zapper, isActive: false)
+        context.insert(inactive)
+        try context.save()
+        let engine = SyncEngine(
+            modelContext: context,
+            providerFactory: ProviderFactory(resolver: { _, _ in ScopedSyncStubProvider(balances: []) }))
+
+        do {
+            _ = try await engine.sync(accountID: inactive.id)
+            Issue.record("Expected inactive account sync to throw.")
+        } catch SyncError.accountInactive {
+            // Expected.
+        } catch {
+            Issue.record("Expected accountInactive, got \(error).")
+        }
+    }
+
     private func makeModelContext() throws -> ModelContext {
         let schema = Schema([
             Account.self, WalletAddress.self, Position.self,

--- a/Tests/PortuTests/ViewRenderSmokeTests.swift
+++ b/Tests/PortuTests/ViewRenderSmokeTests.swift
@@ -147,6 +147,23 @@ struct ViewRenderSmokeTests {
         render(view)
     }
 
+    @Test func `edit account sheet renders without crashing`() throws {
+        let container = try makeContainer()
+        let account = try #require(try container.mainContext.fetch(FetchDescriptor<Account>()).first)
+
+        let view = AddAccountSheet(
+            mode: .edit(account.id),
+            account: account,
+            isSyncing: false,
+            canSync: true,
+            onSync: { _ in })
+            .modelContainer(container)
+            .environment(\.colorScheme, .dark)
+            .frame(width: 920, height: 760)
+
+        render(view)
+    }
+
     private func makeStore(section: SidebarSection) -> StoreOf<AppFeature> {
         makeStore(state: populatedState(section: section))
     }

--- a/openspec/changes/accounts-feature/spec.md
+++ b/openspec/changes/accounts-feature/spec.md
@@ -15,8 +15,10 @@ Migrate `AccountsView` from `@Environment(AppState.self)` + `@State` to TCA.
 
 ### Out of scope
 - `sortOrder` (KeyPathComparator not Equatable — stays as view-local `@State`)
-- Save/delete side effects for account rows (toggle active, delete — mutate SwiftData directly)
-- Context menu actions (toggle active, delete — mutate SwiftData directly)
+- Reducer-owned SwiftData mutations for account row actions; views route toggle/delete
+  through `AccountSheetSaveCoordinator` for save, rollback, and credential cleanup
+- Reducer-owned context menu effects; context menu actions remain view-driven and
+  delegate account persistence to `AccountSheetSaveCoordinator`
 
 ---
 
@@ -44,7 +46,8 @@ Migrate `AccountsView` from `@Environment(AppState.self)` + `@State` to TCA.
   - Maps to `AccountRowData` with name, group, full address, type (kind capitalized),
     balance, dataSource, isActive, lastSyncError
   - Group defaults to em dash "—" when nil
-  - Address: first wallet address, or exchange type capitalized, or "Manual"
+  - Address: wallet first address or em dash when missing; exchange type capitalized
+    or "Exchange" when missing; "Manual" for manual accounts
   - Row is syncable only when active and not manual
 
 ### B6: Account row filtering

--- a/openspec/changes/accounts-feature/spec.md
+++ b/openspec/changes/accounts-feature/spec.md
@@ -3,19 +3,19 @@
 ## Scope
 
 Migrate `AccountsView` from `@Environment(AppState.self)` + `@State` to TCA.
-`AddAccountSheet` keeps its form `@State` (local, resets on dismiss).
+`AddAccountSheet` uses local draft state for add/edit form fields.
 
 ### In scope
 - Child reducer `AccountsFeature` under `AppFeature`
-- Filter/search/presentation state in reducer (replacing `@State`)
+- Filter/search/account sheet presentation state in reducer (replacing `@State`)
 - Pure functions for: account row mapping, filtering, group extraction, form validation
 - Lightweight `AccountInput` struct decoupling from SwiftData models
 - Views read from store, @Query stays in views
+- Account-scoped sync entry point exposed through `AppFeature`
 
 ### Out of scope
 - `sortOrder` (KeyPathComparator not Equatable — stays as view-local `@State`)
-- AddAccountSheet form fields (19 @State properties — purely local form state)
-- Save/delete side effects (SwiftData + Keychain — stay in views for now)
+- Save/delete side effects for account rows (toggle active, delete — mutate SwiftData directly)
 - Context menu actions (toggle active, delete — mutate SwiftData directly)
 
 ---
@@ -34,17 +34,18 @@ Migrate `AccountsView` from `@Environment(AppState.self)` + `@State` to TCA.
 - Toggle sets show/hide inactive accounts
 - State change through reducer action
 
-### B4: Show add sheet
-- Button opens add account sheet
-- Dismiss closes it
-- State change through reducer action
+### B4: Show account sheet
+- Add button opens add account sheet mode
+- Edit row/context action opens edit account sheet mode for the selected account id
+- Dismiss clears the sheet mode through reducer action
 
 ### B5: Account row mapping
 - Given a list of `AccountInput` entries:
-  - Maps to `AccountRowData` with name, group, address (truncated to 16 chars + ellipsis),
-    type (kind capitalized), balance, isActive, lastSyncError
+  - Maps to `AccountRowData` with name, group, full address, type (kind capitalized),
+    balance, dataSource, isActive, lastSyncError
   - Group defaults to em dash "—" when nil
   - Address: first wallet address, or exchange type capitalized, or "Manual"
+  - Row is syncable only when active and not manual
 
 ### B6: Account row filtering
 - Given rows + filter criteria:
@@ -60,3 +61,15 @@ Migrate `AccountsView` from `@Environment(AppState.self)` + `@State` to TCA.
 - Tab 0 (Chain): requires non-empty name AND address
 - Tab 1 (Manual): requires non-empty name
 - Tab 2 (Exchange): requires non-empty name AND API key AND API secret
+
+### B9: Edit account sheet
+- Edit mode pre-fills current account data
+- Edit mode locks the account type instead of allowing tab switching
+- Wallet edit updates name, group, notes, first address, and chain/EVM selection
+- Manual edit updates name, group, and notes
+- Exchange edit pre-fills and saves credentials for the same account id
+
+### B10: Account-scoped sync
+- Account row Sync and edit sheet Sync call the app-level account sync action
+- Sync is disabled for manual accounts, inactive accounts, and while another sync is running
+- Account-scoped sync updates the same global `SyncStatus` as full/provider sync


### PR DESCRIPTION
## Summary
- Adds add/edit account sheet modes with prefilled edit drafts, credential handling, and existing-account mutation.
- Adds row and sheet account-scoped sync actions with per-account loading state so only the selected row shows progress.
- Shows full selectable wallet addresses in the Accounts table and documents the behavior in the accounts feature spec.
- Adds Zapper chain support for Celo (`42220`) and opBNB (`204`), fixing the live sync failures seen after the API key was updated.

## Validation
- `xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test` passed: 542 tests in 71 suites.
- Focused final check after commit/lint cleanup passed: `xcodebuild -project Portu.xcodeproj -scheme Portu -configuration Debug -derivedDataPath .build/DerivedData -skipMacroValidation test -only-testing:PortuTests/AppFeatureAccountSyncTests -only-testing:PortuTests/AccountsFeatureTests -only-testing:PortuTests/AccountSheetDraftTests -only-testing:PortuTests/SyncEngineScopedTests` passed: 23 tests in 4 suites.
- Commit hook passed SwiftFormat lint mode and SwiftLint.
- Live debug sync for `0x348117728a7eddf4a7cb688bb1afb7cdc3fb260e` completed without a persisted account error and stored Celo positions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Celo and opBNB support to chain identifiers and Zapper balance decoding.
  * Enabled account-scoped syncing directly from account rows and the add/edit account sheet, with per-account progress and completion states.
* **Improvements**
  * Sync eligibility is now enforced consistently for active, non-manual accounts, including clearer handling of overlapping sync taps.
  * Editing accounts now reliably clears stale sync data, and account save/delete flows gained stronger error handling, credential loading safeguards, and validation.
* **Tests**
  * Expanded coverage for new chains, account-scoped sync, and account sheet behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->