### PR TITLE
docs: add app readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+![Portu banner](docs/assets/portu-readme-banner.svg)
+
+# Portu
+
+Portu is a native macOS crypto portfolio dashboard for tracking wallets, exchanges, and manual holdings from one local app.
+
+[Download latest release](https://github.com/Chalet-Labs/portu/releases/latest) | [All releases](https://github.com/Chalet-Labs/portu/releases) | [Report an issue](https://github.com/Chalet-Labs/portu/issues)
+
+Portu is local-first. Portfolio data stays on your Mac, provider credentials are stored in Keychain, and the app has no backend and no telemetry.
+
+## Features
+
+- Unified overview with total portfolio value, 24h movement, allocation breakdowns, top assets, and a price watchlist.
+- Wallet and DeFi position sync through Zapper.
+- Exchange accounts for Kraken, Coinbase, and Binance.
+- Manual accounts for assets or positions that are not available from a provider.
+- Exposure, performance, all-assets, all-positions, account, and asset-detail views.
+- Live and historical pricing through CoinGecko, with Zapper fallback for onchain tokens that CoinGecko cannot price.
+- Historical price backfill for local performance charts.
+- Token settings for CoinGecko ID overrides, pricing overrides, hidden dust, and unpriced assets.
+- Custom RPC settings and configurable provider sync intervals.
+
+## Downloads
+
+The easiest way to try Portu is from GitHub Releases:
+
+- [Latest release](https://github.com/Chalet-Labs/portu/releases/latest)
+- [All releases](https://github.com/Chalet-Labs/portu/releases)
+
+Release builds publish a `Portu-<version>.dmg` plus a SHA-256 checksum. The release workflow is driven by semantic-release from the `master` and `alpha` branches.
+
+## API Keys
+
+Users currently need a Zapper API key for wallet and DeFi sync. Create one at [build.zapper.xyz](https://build.zapper.xyz/), then add it in Portu under `Settings > API Keys > Zapper`.
+
+Optional credentials:
+
+- CoinGecko API key: raises price API rate limits.
+- Exchange API keys: required only for Kraken, Coinbase, or Binance exchange accounts.
+
+Use read-only exchange API credentials where the exchange supports them. Portu stores provider secrets locally in macOS Keychain.
+
+## Getting Started
+
+1. Download the latest DMG from [Releases](https://github.com/Chalet-Labs/portu/releases/latest).
+2. Open Portu and go to `Settings > API Keys`.
+3. Add your Zapper API key from [build.zapper.xyz](https://build.zapper.xyz/).
+4. Add a wallet, exchange, or manual account from the Accounts view.
+5. Sync the account and use Overview, Exposure, Performance, All Assets, and All Positions to inspect the portfolio.
+
+## Build From Source
+
+Requirements:
+
+- macOS 15 or newer
+- Xcode with Swift 6.2 support
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+- [just](https://github.com/casey/just)
+
+Common commands:
+
+```bash
+just generate
+just build
+just test-packages
+just test
+```
+
+For a full local build, launch, and process verification:
+
+```bash
+./script/build_and_run.sh --verify
+```
+
+## Architecture
+
+Portu is generated from `project.yml` and split into three SwiftPM packages:
+
+- `PortuCore`: models, DTOs, Keychain access, local storage protocols, and shared domain types.
+- `PortuNetwork`: Zapper, CoinGecko, Kraken, Coinbase, and Binance provider clients.
+- `PortuUI`: shared SwiftUI theme and reusable UI components.
+
+The macOS app target in `Sources/Portu` owns app state, feature views, settings, and sync orchestration.

--- a/docs/assets/portu-readme-banner.svg
+++ b/docs/assets/portu-readme-banner.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="520" viewBox="0 0 1600 520" role="img" aria-labelledby="title desc">
+  <title id="title">Portu macOS crypto portfolio dashboard</title>
+  <desc id="desc">A dark macOS-style portfolio dashboard banner with charts, account cards, and Portu branding.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0A1110"/>
+      <stop offset="0.52" stop-color="#121412"/>
+      <stop offset="1" stop-color="#211C12"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#F3E3A6"/>
+      <stop offset="1" stop-color="#C99B42"/>
+    </linearGradient>
+    <linearGradient id="green" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8AE6B9"/>
+      <stop offset="1" stop-color="#39A977"/>
+    </linearGradient>
+    <linearGradient id="red" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FF9D8C"/>
+      <stop offset="1" stop-color="#E35454"/>
+    </linearGradient>
+    <filter id="soft-shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="24" stdDeviation="28" flood-color="#000000" flood-opacity="0.38"/>
+    </filter>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="28" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0.90 0 0 0 0.90 0 0.76 0 0 0.64 0 0 0.46 0 0 0 0 0.38 0"/>
+      <feBlend in="SourceGraphic" mode="screen"/>
+    </filter>
+    <clipPath id="panel-clip">
+      <rect x="770" y="72" width="682" height="376" rx="28"/>
+    </clipPath>
+  </defs>
+
+  <rect width="1600" height="520" rx="0" fill="url(#bg)"/>
+  <path d="M0 430 C230 350 350 510 590 410 C815 317 900 154 1170 178 C1375 196 1453 92 1600 44 L1600 520 L0 520 Z" fill="#1E2B20" opacity="0.42"/>
+  <path d="M-80 120 C235 12 388 92 611 52 C846 10 1042 -36 1270 82 C1418 158 1528 124 1680 94" fill="none" stroke="#E6C56C" stroke-width="2" opacity="0.18"/>
+  <path d="M-60 393 C214 316 353 383 524 337 C766 272 864 129 1088 145 C1276 159 1402 90 1660 52" fill="none" stroke="#72D0A2" stroke-width="2" opacity="0.16"/>
+
+  <g transform="translate(112 86)">
+    <g>
+      <rect x="0" y="0" width="68" height="68" rx="14" fill="url(#gold)"/>
+      <text x="34" y="47" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="43" font-weight="850" fill="#10120F">P</text>
+    </g>
+    <text x="92" y="29" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="15" font-weight="750" fill="#E9D18A">LOCAL FIRST MACOS PORTFOLIO</text>
+    <text x="92" y="68" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="28" font-weight="760" fill="#F8F3E7">Portu</text>
+
+    <text x="0" y="170" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="62" font-weight="780" fill="#FFF8E7">Crypto portfolio</text>
+    <text x="0" y="238" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="62" font-weight="780" fill="#FFF8E7">tracking for macOS</text>
+    <text x="0" y="302" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="24" font-weight="420" fill="#BFC8BC">Wallets, exchanges, manual holdings, live prices,</text>
+    <text x="0" y="336" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="24" font-weight="420" fill="#BFC8BC">and historical performance in one private desktop app.</text>
+
+    <g transform="translate(0 384)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="18" font-weight="680">
+      <rect x="0" y="0" width="144" height="42" rx="10" fill="#F0D680" opacity="0.16" stroke="#F0D680" stroke-opacity="0.42"/>
+      <text x="72" y="27" text-anchor="middle" fill="#F4DE95">Zapper</text>
+      <rect x="160" y="0" width="168" height="42" rx="10" fill="#72D0A2" opacity="0.13" stroke="#72D0A2" stroke-opacity="0.36"/>
+      <text x="244" y="27" text-anchor="middle" fill="#89E1B5">CoinGecko</text>
+      <rect x="344" y="0" width="154" height="42" rx="10" fill="#7DBDFF" opacity="0.13" stroke="#7DBDFF" stroke-opacity="0.34"/>
+      <text x="421" y="27" text-anchor="middle" fill="#9FCEFF">Exchanges</text>
+      <rect x="514" y="0" width="128" height="42" rx="10" fill="#FFFFFF" opacity="0.08" stroke="#FFFFFF" stroke-opacity="0.18"/>
+      <text x="578" y="27" text-anchor="middle" fill="#ECE6D5">Keychain</text>
+    </g>
+  </g>
+
+  <g filter="url(#soft-shadow)">
+    <rect x="770" y="72" width="682" height="376" rx="28" fill="#111613" stroke="#E9D18A" stroke-opacity="0.18"/>
+    <g clip-path="url(#panel-clip)">
+      <rect x="770" y="72" width="166" height="376" fill="#0D120F"/>
+      <rect x="936" y="72" width="516" height="376" fill="#151A16"/>
+      <rect x="770" y="72" width="682" height="54" fill="#161B17"/>
+
+      <circle cx="806" cy="100" r="7" fill="#F27676"/>
+      <circle cx="829" cy="100" r="7" fill="#E9C46A"/>
+      <circle cx="852" cy="100" r="7" fill="#72D0A2"/>
+      <text x="896" y="105" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="15" font-weight="680" fill="#EDE5D0">Portu Dashboard</text>
+
+      <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif">
+        <text x="800" y="158" font-size="12" font-weight="780" fill="#777E73">PORTU</text>
+        <rect x="794" y="176" width="112" height="30" rx="8" fill="#E9D18A" opacity="0.16"/>
+        <text x="816" y="196" font-size="14" font-weight="680" fill="#F3E3A6">Overview</text>
+        <text x="816" y="232" font-size="14" font-weight="520" fill="#AAB4A5">Exposure</text>
+        <text x="816" y="266" font-size="14" font-weight="520" fill="#AAB4A5">Performance</text>
+        <text x="800" y="318" font-size="12" font-weight="780" fill="#777E73">PORTFOLIO</text>
+        <text x="816" y="352" font-size="14" font-weight="520" fill="#AAB4A5">All Assets</text>
+        <text x="816" y="386" font-size="14" font-weight="520" fill="#AAB4A5">Accounts</text>
+      </g>
+
+      <g transform="translate(972 154)">
+        <rect x="0" y="0" width="212" height="112" rx="16" fill="#20261F" stroke="#FFFFFF" stroke-opacity="0.08"/>
+        <text x="20" y="34" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="13" font-weight="680" fill="#99A293">Total value</text>
+        <text x="20" y="75" font-family="SFMono-Regular, ui-monospace, Menlo, Consolas, monospace" font-size="32" font-weight="800" fill="#F8F3E7">$184,920</text>
+        <text x="20" y="98" font-family="SFMono-Regular, ui-monospace, Menlo, Consolas, monospace" font-size="14" font-weight="700" fill="#81DDAF">+3.8% 24h</text>
+      </g>
+
+      <g transform="translate(1208 154)">
+        <rect x="0" y="0" width="190" height="112" rx="16" fill="#20261F" stroke="#FFFFFF" stroke-opacity="0.08"/>
+        <text x="20" y="34" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="13" font-weight="680" fill="#99A293">Top allocation</text>
+        <circle cx="54" cy="72" r="28" fill="none" stroke="#2C332C" stroke-width="12"/>
+        <path d="M54 44 A28 28 0 1 1 30 86" fill="none" stroke="#E9D18A" stroke-width="12" stroke-linecap="round"/>
+        <path d="M30 86 A28 28 0 0 1 54 44" fill="none" stroke="#72D0A2" stroke-width="12" stroke-linecap="round"/>
+        <text x="98" y="72" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="18" font-weight="760" fill="#F8F3E7">ETH</text>
+        <text x="98" y="94" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="13" font-weight="620" fill="#BFC8BC">42%</text>
+      </g>
+
+      <g transform="translate(972 286)">
+        <rect x="0" y="0" width="426" height="116" rx="16" fill="#20261F" stroke="#FFFFFF" stroke-opacity="0.08"/>
+        <text x="20" y="32" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="13" font-weight="680" fill="#99A293">Portfolio performance</text>
+        <path d="M22 89 C62 82 68 54 108 61 C149 67 160 45 197 43 C237 41 242 68 280 61 C325 53 333 34 384 30" fill="none" stroke="#F3D982" stroke-width="5" stroke-linecap="round" filter="url(#glow)"/>
+        <path d="M22 89 C62 82 68 54 108 61 C149 67 160 45 197 43 C237 41 242 68 280 61 C325 53 333 34 384 30" fill="none" stroke="#F3D982" stroke-width="3" stroke-linecap="round"/>
+        <circle cx="384" cy="30" r="6" fill="#F7E19A"/>
+      </g>
+
+      <g transform="translate(1188 286)">
+        <rect x="0" y="-132" width="1" height="248" fill="#FFFFFF" opacity="0.05"/>
+      </g>
+
+      <g transform="translate(996 416)">
+        <circle cx="0" cy="0" r="5" fill="#72D0A2"/>
+        <text x="14" y="5" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="13" font-weight="650" fill="#AAB4A5">Wallets synced</text>
+        <circle cx="138" cy="0" r="5" fill="#7DBDFF"/>
+        <text x="152" y="5" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="13" font-weight="650" fill="#AAB4A5">Exchanges linked</text>
+        <circle cx="302" cy="0" r="5" fill="#F27676"/>
+        <text x="316" y="5" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="13" font-weight="650" fill="#AAB4A5">Manual positions</text>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Add a GitHub-facing README for Portu with release links, feature overview, setup guidance, API key notes, and build-from-source commands.
- Add a local SVG banner asset for the top of the README.

## Validation

- `xmllint --noout docs/assets/portu-readme-banner.svg`
- `sips -s format png docs/assets/portu-readme-banner.svg --out /tmp/portu-sips.png` rendered at `1600x520`
- `rg` check for release links, Zapper API key copy, and README sections
- trailing whitespace check for README and SVG

No app tests were run because this change is documentation and a static README asset only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documentation with project overview, features list, and download information
  * Included API key setup guidance and step-by-step getting started instructions
  * Added build requirements and architecture documentation for developers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->